### PR TITLE
Always generate the public key

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -188,7 +188,6 @@ EOF
 }
 
 resource "tls_private_key" "github_deployment_key" {
-  count     = "${local.enabled_addons["ci"]}"
   algorithm = "RSA"
   rsa_bits  = "4096"
 }


### PR DESCRIPTION
It will only actually be pushed if the CI system is enabled—this lets us
work around Terraform awkwardness with trying to output values that
might be undefined.