### PR TITLE
Remove some default values relating to splunk.

### DIFF
--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -159,6 +159,7 @@ module "gsp-cluster" {
   public_subnet_ids             = "${module.gsp-network.public_subnet_ids}"
   egress_ips                    = "${module.gsp-network.egress_ips}"
   ingress_ips                   = "${module.gsp-network.ingress_ips}"
+  splunk_enabled                = "${var.splunk_enabled}"
   splunk_hec_url                = "${var.splunk_hec_url}"
   k8s_splunk_hec_token          = "${var.k8s_splunk_hec_token}"
   k8s_splunk_index              = "${var.k8s_splunk_index}"


### PR DESCRIPTION
Better to fail fast and explicitly than risk a lengthy debugging exercise
further down the pipeline.