### PR TITLE
Add VirtualService testing to the SmokeTest

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -175,3 +175,10 @@ spec:
                 --diff-changes \
                 -f ./manifests/
 
+      - task: ping
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          run:
+            path: /usr/bin/curl
+            args: ["--silent", "--show-error", "--max-time 10", "--fail", "https://canary.((cluster.domain))/metrics"]

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -513,6 +513,22 @@ jobs:
     #  - task: run-conformance-tests
     #    timeout: 15m
     #    config: *run_conformance_tests
+
+- name: test
+  serial: true
+  serial_groups: [cluster-modification]
+  plan:
+  - get: cluster-state
+    passed: ["deploy"]
+    trigger: true
+  - task: ping
+    config:
+      platform: linux
+      image_resource: *task_image_resource
+      run:
+        path: /usr/bin/curl
+        args: ["--silent", "--show-error", "--max-time 10", "--fail", "https://canary.((cluster-domain))/metrics"]
+
 - name: destroy
   serial: true
   serial_groups: [cluster-modification]


### PR DESCRIPTION
## What

After we have deployed either entire cluster or marely the canary
successfully, we should expect it to be accessible from outside world.
This should assure us that we are capable of providing traffic into the
cluster - our ingress works and is wired up correctly with *LB of a sort.

## How to review

- Code review
- Run the docker image `docker run --rm -it govsvc/task-toolbox:1.2.0`
- Run the curl command from inside the container
- Try to change URL to see if it fails properly
