### PR TITLE
Namespace update pipelines

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -201,6 +201,7 @@ metadata:
     "kubernetes.io/service-account.name": cluster-deployer
 type: kubernetes.io/service-account-token
 {{- end }}
+{{- if .repository }}
 ---
 apiVersion: concourse.k8s.io/v1beta1
 kind: Pipeline
@@ -285,4 +286,5 @@ spec:
               kubectl config use-context deployer
               echo "applying manifests from ${SRC_URI} at path ${PATH_TO_MANIFESTS} to ${RELEASE_NAMESPACE}"
               kubectl apply $NS_ARGS -R -f "./src/${PATH_TO_MANIFESTS}"
+{{- end }}
 {{- end }}

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -225,7 +225,7 @@ spec:
       source:
         uri: "https://github.com/{{ .owner }}/{{ .repository }}.git"
         organization: {{ .owner }}
-        branch: master
+        branch: {{ .branch | default "master" | quote }}
         owner: {{ .owner }}
         repository: {{ .repository }}
         github_api_token: ((github.api-token))

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -18,10 +18,15 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- range .resources }}
 ---
-{{ tpl (toYaml .) $ }}
-{{- end }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .name }}
+  labels:
+    namespace: {{ .name }}
+  annotations:
+    iam.amazonaws.com/permitted: {{ .permittedRolesRegex | default "^$" | quote }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -194,4 +199,88 @@ metadata:
   annotations:
     "kubernetes.io/service-account.name": cluster-deployer
 type: kubernetes.io/service-account-token
+---
+apiVersion: concourse.k8s.io/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: configure-namespace
+  namespace: {{ .name }}
+spec:
+  exposed: true
+  pipelineString: |
+    resource_types:
+    - name: github
+      type: registry-image
+      source:
+        repository: "govsvc/concourse-github-resource"
+        tag: "v0.0.2"
+    resoures:
+    - name: src
+      type: github
+      icon: github-circle
+      source:
+        uri: "https://github.com/{{ .owner }}/{{ .repository }}.git"
+        organization: {{ .owner }}
+        branch: master
+        owner: {{ .owner }}
+        repository: {{ .repository }}
+        github_api_token: ((github.api-token))
+        access_token: ((github.api-token))
+        approvers: ((trusted-developers.github-accounts))
+        required_approval_count: {{ .requiredApprovalCount | default 2 }}
+        commit_verification_keys: ((trusted-developers.gpg-keys))
+        paths:
+        - {{ .path | quote }}
+    jobs:
+    - name: apply
+      serial: true
+      plan:
+      - get: src
+        trigger: true
+      - task: apply
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: govsvc/task-toolbox
+              tag: "1.2.0"
+          inputs:
+          - name: src
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: (({{ .scope | default "namespace" }}-deployer))
+            KUBERNETES_TOKEN: (({{ .scope | default "namespace" }}-deployer.token))
+            KUBERNETES_API: kubernetes.default.svc
+            RELEASE_NAMESPACE: (({{ .scope | default "namespace" }}-deployer.namespace))
+            PATH_TO_MANIFESTS: {{ .path | quote }}
+            SRC_URI: {{ .uri }}
+            SCOPE: {{ .scope | default "namespace" }}
+          run:
+            path: /bin/bash
+            args:
+            - -eu
+            - -c
+            - |
+              echo "this job will populate the namespace with kubeyaml found in repository ${SRC_URI} at path ${PATH_TO_MANIFESTS}..."
+              if [[ "${SCOPE}" == "cluster" ]]; then
+                echo "deployer has cluster scope (can deploy anywhere)"
+                NS_ARGS=""
+              elif [[ "${SCOPE}" == "namespace" ]]; then
+                echo "deployer has namespace scope (can only deploy to namespace)"
+                NS_ARGS="-n ${RELEASE_NAMESPACE}"
+              else
+                echo "invalid scope '${SCOPE}' expected 'namespace' or 'cluster'"
+                exit 1
+              fi
+              echo "configuring kubectl..."
+              echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+              kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+              kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+              kubectl config set-context deployer --user deployer --cluster self
+              kubectl config set-context deployer --namespace "${RELEASE_NAMESPACE}"
+              kubectl config use-context deployer
+              echo "applying manifests from ${SRC_URI} at path ${PATH_TO_MANIFESTS} to ${RELEASE_NAMESPACE}"
+              kubectl apply $NS_ARGS -R -f "./src/${PATH_TO_MANIFESTS}"
 {{- end }}

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -171,6 +171,7 @@ metadata:
   annotations:
     "kubernetes.io/service-account.name": namespace-deployer
 type: kubernetes.io/service-account-token
+{{- if (eq .scope "cluster") }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -199,6 +200,7 @@ metadata:
   annotations:
     "kubernetes.io/service-account.name": cluster-deployer
 type: kubernetes.io/service-account-token
+{{- end }}
 ---
 apiVersion: concourse.k8s.io/v1beta1
 kind: Pipeline

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -38,8 +38,14 @@ githubAPIToken: ""
 #   - sandbox-canary-dev
 
 # namespaces:
-# - name: sandbox-example
-#   resources: [{...}, {...}]
+# - name: verify-metadata-controller
+#   owner: alphagov
+#   repository: verify-metadata-controller
+#   branch: master
+#   path: ci
+#   permittedRolesRegex: "^$"
+#   requiredApprovalCount: 2
+#   scope: cluster
 
 kiam:
   nameOverride:

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -113,32 +113,24 @@ generate_namespace_values: &generate_namespace_values
   platform: linux
   image_resource: *task_image_resource
   params:
-    PATH_TO_NAMESPACES: ((config-path))/namespaces/
     CLUSTER_NAME: ((cluster-name))
+    NAMESPACE_JSON: ((namespaces))
   run:
     path: /bin/bash
     args:
-    - -eu
+    - -euo
+    - pipefail
     - -c
     - |
-      echo "creating tmp dirs"
+      echo "creating helm compatible values file from namespace data"
       mkdir -p namespace-values
       namespace_values_file="$(pwd)/namespace-values/values.yaml"
-      mkdir ns-chart
-      cd config/${PATH_TO_NAMESPACES}
-      echo "creating helm compatible values file from namespace data"
       echo "--> ${CLUSTER_NAME}-main"
-      echo 'namespaces:' > $namespace_values_file
+      echo "namespaces:" > $namespace_values_file
       echo "- name: ${CLUSTER_NAME}-main" >> $namespace_values_file
-      echo "  resources: []" >> $namespace_values_file
-      for ns in $(ls | grep -E "^${CLUSTER_NAME}-"); do
-        echo "--> ${ns}"
-        echo "- name: ${ns}" >> $namespace_values_file
-        set_namespace=".metadata.namespace=\"${ns}\""
-        combined_resources="$(yq . ${ns}/*.yaml | jq $set_namespace | jq -s -c .)"
-        echo "  resources: $combined_resources" >> $namespace_values_file
-      done
+      echo "${NAMESPACE_JSON}" | yq --yaml-output . >> $namespace_values_file
       cat $namespace_values_file
+      echo "OK!"
   inputs:
   - name: config
   outputs:

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -114,7 +114,7 @@ generate_namespace_values: &generate_namespace_values
   image_resource: *task_image_resource
   params:
     CLUSTER_NAME: ((cluster-name))
-    NAMESPACE_JSON: ((namespaces))
+    CLUSTER_CONFIG_PATH: ((config-path))
   run:
     path: /bin/bash
     args:
@@ -128,7 +128,7 @@ generate_namespace_values: &generate_namespace_values
       echo "--> ${CLUSTER_NAME}-main"
       echo "namespaces:" > $namespace_values_file
       echo "- name: ${CLUSTER_NAME}-main" >> $namespace_values_file
-      echo "${NAMESPACE_JSON}" | yq --yaml-output . >> $namespace_values_file
+      yq .namespaces --yaml-output < "./config/${CLUSTER_CONFIG_PATH}" >> $namespace_values_file
       cat $namespace_values_file
       echo "OK!"
   inputs:
@@ -406,8 +406,8 @@ jobs:
       CONCOURSE_PIPELINE_PATH: platform/pipelines/deployer/deployer.yaml
       CONCOURSE_PIPELINE_NAME: ((concourse-pipeline-name))
       CLUSTER_NAME: ((cluster-name))
-      CLUSTER_CONFIG_VARS: config/((config-path))/clusters/((cluster-name)).yaml
-      DEFAULT_CONFIG_VARS: platform/pipelines/deployer/deployer.defaults.yaml
+      CLUSTER_CONFIG_PATH: ((config-path))
+      DEFAULT_CONFIG_PATH: pipelines/deployer/deployer.defaults.yaml
       SKIP_UPDATE: ((disable-update))
     config:
       platform: linux
@@ -449,8 +449,8 @@ jobs:
           ./fly --target self \
             validate-pipeline \
             --config "${CONCOURSE_PIPELINE_PATH}" \
-            --load-vars-from "${DEFAULT_CONFIG_VARS}" \
-            --load-vars-from "${CLUSTER_CONFIG_VARS}" \
+            --load-vars-from "platform/${DEFAULT_CONFIG_PATH}" \
+            --load-vars-from "config/${CLUSTER_CONFIG_PATH}" \
             --load-vars-from "approvers.yaml" \
             --load-vars-from "trusted-developer-keys.yaml"
           echo "updating pipeline..."
@@ -459,8 +459,8 @@ jobs:
             --check-creds \
             --pipeline "${CONCOURSE_PIPELINE_NAME}" \
             --config "${CONCOURSE_PIPELINE_PATH}" \
-            --load-vars-from "${DEFAULT_CONFIG_VARS}" \
-            --load-vars-from "${CLUSTER_CONFIG_VARS}" \
+            --load-vars-from "platform/${DEFAULT_CONFIG_PATH}" \
+            --load-vars-from "config/${CLUSTER_CONFIG_PATH}" \
             --load-vars-from "approvers.yaml" \
             --load-vars-from "trusted-developer-keys.yaml" \
             --non-interactive


### PR DESCRIPTION
### What

currently teams have to add any kubeyaml to initialize namespaces to
the "gsp-teams" repo.. these initial resources are usually pipelines and
secrets that kick of other deployments.

we have seen several issues with this centralized approch:

* Teams are used to having their stuff managed in their own repo and
  don't see the benefit of having it centralized
* There is no visibility of deployment by service teams since these
  resources are deployed by the main deployer pipeline which is not easily
  visible to non SREs
* A change to any resource requires a complete platform deployment which
  is a massive overkill
* The current implementation for passing the namespace yaml into the
  gsp-cluster chart by concatanating the files and then running them
  through helm templating is very fragile and error prone (missing "---"
  ends in silently ignoring a bunch of stuff or weird errors if it
  clobbers the next yaml

To resolve this:

* Instead of declaring the resources in gsp-teams, we declare a
  repository and some additional namespace config as part of the
  cluster.yaml
* A pipeline is created for each namespace that reads from the specified
  repository/path and kubectl applies any resource found there into the
  namespace.

This allows some visibility of the process (since concourse will show
the "configure-namespace" pipeline to the team, and avoids the hacky
concat mess.

### ⚠️  Depends on: https://github.com/alphagov/gsp-teams/pull/202 and https://github.com/alphagov/verify-proxy-node/pull/218