### PR TITLE
Enable Cloudwatch Acceptance Tests

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -285,7 +285,8 @@ check_cloudwatch: &check_cloudwatch
   run:
     path: /bin/bash
     args:
-    - -eu
+    - -euo
+    - pipefail
     - -c
     - |
       echo "assuming aws deployer role..."

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -271,6 +271,70 @@ run_conformance_tests: &run_conformance_tests
   - name: namespace-values
   - name: platform
 
+check_cloudwatch: &check_cloudwatch
+  platform: linux
+  image_resource: *task_image_resource
+  params:
+    ACCOUNT_ROLE_ARN: ((account-role-arn))
+    CLUSTER_DOMAIN: ((cluster-domain))
+    AWS_REGION: eu-west-2
+    AWS_DEFAULT_REGION: eu-west-2
+    TEST_FARBACK: 360
+    TEST_RETRIES: 3
+    TEST_DELAY: 30
+  run:
+    path: /bin/bash
+    args:
+    - -eu
+    - -c
+    - |
+      echo "assuming aws deployer role..."
+      AWS_CREDS="$(aws-assume-role $ACCOUNT_ROLE_ARN)"
+      eval "${AWS_CREDS}"
+
+      CURRENT_TIME=$(date '+%s')
+      DELAY="${TEST_DELAY:-30}"
+      RETRIES="${TEST_RETRIES:-3}"
+      FARBACK="${TEST_FARBACK:-300}"
+      LOGS_SINCE=$(($CURRENT_TIME - $FARBACK))
+      LOGGROUP="$CLUSTER_DOMAIN"
+
+      # convert from seconds based epoch to AWS supported milliseconds epoch
+      CURRENT_TIME="${CURRENT_TIME}000"
+      LOGS_SINCE="${LOGS_SINCE}000"
+
+      echo "ClusterDomain: $CLUSTER_DOMAIN"
+      echo "  Retry Delay: $DELAY"
+      echo "      Retries: $RETRIES"
+      echo "         Time: $CURRENT_TIME"
+      echo "   Logs Since: $LOGS_SINCE"
+      echo "    Log Group: $LOGGROUP"
+
+      i=0
+      while [ $i -lt $RETRIES ]; do
+        i=$((i+1))
+        echo "======================================="
+        echo "      Attempt: $i"
+
+        LASTSEENLOG=$(aws logs filter-log-events --log-group-name $LOGGROUP --start-time $LOGS_SINCE --max-items 10 | jq ".events[].timestamp" | grep -v "null" | sort -urn | head -n1)
+
+        echo "   Logs Since: $LOGS_SINCE"
+        echo "    Logs Seen: $LASTSEENLOG"
+        if (( ${LASTSEENLOG} > ${LOGS_SINCE} )); then
+          echo "PASS: Logs have been reached cloudwatch"
+          echo "Logs received at: $LASTSEENLOG in $LOGGROUP"
+          exit 0
+        fi
+        if (( ${i} != ${RETRIES} )); then
+          echo "Retrying in ${DELAY} seconds"
+          sleep ${DELAY}
+        fi
+      done
+
+      echo ""
+      echo "FAIL: No logs have been detected reaching cloudwatch since $LOGS_SINCE"
+      exit 1
+
 drain_cluster_task: &drain_cluster_task
   platform: linux
   image_resource: *task_image_resource
@@ -528,6 +592,9 @@ jobs:
           - |
             echo "pinging https://canary.${CLUSTER_DOMAIN}/metrics to check ingress..."
             curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_DOMAIN}/metrics
+  - task: check-cloudwatch
+    timeout: 10m
+    config: *check_cloudwatch
 
 - name: destroy
   serial: true

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -279,7 +279,7 @@ check_cloudwatch: &check_cloudwatch
     CLUSTER_DOMAIN: ((cluster-domain))
     AWS_REGION: eu-west-2
     AWS_DEFAULT_REGION: eu-west-2
-    TEST_FARBACK: 360
+    TEST_FARBACK: 180
     TEST_RETRIES: 3
     TEST_DELAY: 30
   run:


### PR DESCRIPTION
This enables cloudwatch acceptance tests on a cluster by discovering the latest log received by cloudwatch.

This test run from the central concourse against a cluster after deployment has occured.

Work was done to integrate this functionality within sonobuoy as a plugin, but was deemed unfeasible as the complexity of implementing and maintaining it would cause signicant issues going forward.  Testing so far has also shown sonobuoy to be somewhat flakey.

Reasons why sonobuoy was not chosen as the acceptance test technology:

1. Issues and complexity around passing secrets in to sonobuoy to allow certain tests to be run
1. The wrapping framework of sonobuoy makes it challenging to pass in arguments to direct tests
1. The learning curve of sonobuoy to implement tests is high
1. To build tests within sonobuoy, docker containers need to created and managed, which is a high cost for simple acceptance tests

However, sonobuoy could still be useful in the future for any tests that need to run within cluster and test the internal components.

Initial work explored the used of "aws logs describe-log-streams", however this did not produce reliable results as it requires prior knowledge of what logstreams within a loggroup should be monitored.  The logstreams appear to be buffered and can suffer delays when passing through fluentd which would sometimes incorrectly cause the test to fail.  Using "aws logs filter-log-events" instead avoided this problem.

Solo: @smford