### PR TITLE
Enable validation webhook for Pipeline resources

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator-role.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator-role.yaml
@@ -36,3 +36,40 @@ rules:
   - get
   - update
   - patch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator-svc.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator-svc.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    control-plane: controller-manager
+    control-plane: concourse-operator
     controller-tools.k8s.io: "1.0"
 spec:
   ports:
@@ -15,5 +15,5 @@ spec:
   selector:
     app.kubernetes.io/name: "pipeline-operator"
     app.kubernetes.io/instance: {{ .Release.Name }}
-    control-plane: controller-manager
+    control-plane: concourse-operator
     controller-tools.k8s.io: "1.0"

--- a/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator-webhook-secret.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator-webhook-secret.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-concourse-operator-webhook

--- a/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
@@ -7,14 +7,14 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    control-plane: controller-manager
+    control-plane: concourse-operator
     controller-tools.k8s.io: "1.0"
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: "pipeline-operator"
       app.kubernetes.io/instance: {{ .Release.Name }}
-      control-plane: controller-manager
+      control-plane: concourse-operator
       controller-tools.k8s.io: "1.0"
   serviceName: {{ .Release.Name }}-pipeline-operator
   template:
@@ -22,7 +22,7 @@ spec:
       labels:
         app.kubernetes.io/name: "pipeline-operator"
         app.kubernetes.io/instance: {{ .Release.Name }}
-        control-plane: controller-manager
+        control-plane: concourse-operator
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
@@ -42,5 +42,31 @@ spec:
           value: {{ .Values.pipelineOperator.concoursePassword | quote }}
         - name: CONCOURSE_INSECURE_SKIP_VERIFY
           value: {{ .Values.pipelineOperator.concourseInsecureSkipVerify | quote }}
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SECRET_NAME
+          value: {{ .Release.Name }}-concourse-operator-webhook
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
       serviceAccountName: {{ template "pipelineOperator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ .Release.Name }}-concourse-operator-webhook

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -340,7 +340,7 @@ pipelineOperator:
   serviceAccountName: pipeline-operator-service-account
   image:
     repository: "govsvc/gsp-concourse-pipeline-controller"
-    tag: "1558635529"
+    tag: "1560841304"
   concourseUsername: admin
   concoursePassword: password
   concourseInsecureSkipVerify: "false"


### PR DESCRIPTION
## What

Updates the concourse-operator to a version that includes a validating webhook for pipeline CRDs

This should make it so that invalid pipelines fail at `kubectl apply` time and so surface errors early.

⚠️ depends on https://github.com/alphagov/gsp-concourse-operator/pull/10

## Why

Without validation we often see the operator stuck in a loop of attempting to apply an invalid pipeline config. There is no visibility into this failure other than checking the logs (which is impractical for users without access to platform logs) and no way to delete the invalid Pipeline (since the finalizer cannot run)

