### PR TITLE
DO NOT MERGE: Update to local environment documentation post-user research

### DIFF
--- a/docs/gds-supported-platform/getting-started-gsp-local.md
+++ b/docs/gds-supported-platform/getting-started-gsp-local.md
@@ -14,21 +14,31 @@ These instructions tell you how to set up a local instance of the GDS Supported 
 
 1. Install [Homebrew](https://brew.sh/).
 
-1. Clone the GSP repository:
+1. Run the following to get the latest version of Homebrew.
 
     ```
-    git clone https://github.com/alphagov/gsp.git
+    brew update
     ```
 
-1. Go to the local repository folder and run the following to install the prerequisites:
+1. Go to the local repository folder and run the following to install the prerequisite software:
 
     ```
     brew bundle
     ```
 
-    After installing `docker-machine-driver-hyperkit`, follow the on-screen instructions to grant `driver superuser` privileges to the hypervisor.
+1. Run the following to grant `driver superuser` privileges to the hypervisor:
+
+    ```
+    sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit && sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
+    ```
 
 1. Install [Docker](https://docs.docker.com).
+
+1. Clone the GSP repository:
+
+    ```
+    git clone https://github.com/alphagov/gsp.git
+    ```
 
 ## Create a local GSP instance
 
@@ -79,7 +89,6 @@ These instructions tell you how to set up a local instance of the GDS Supported 
 
     You now have a local GSP instance and can access that instance using kubectl.
 
-    _what is the difference between this and the creation below?_
 
 ## Create a Dockerised app
 
@@ -229,8 +238,6 @@ You run an app in the local GSP instance by creating a [Kubernetes Deployment re
     ```
     kubectl get pods
     ```
-
-    _output?????_
 
 If the pods are running you have created a Kubernetes Deployment resource.
 

--- a/docs/gds-supported-platform/getting-started-gsp-local.md
+++ b/docs/gds-supported-platform/getting-started-gsp-local.md
@@ -2,13 +2,13 @@
 
 These instructions tell you how to set up a local instance of the GDS Supported Platform (GSP) and run the example `govuk-prototype-kit` app on that instance. This process is useful for testing your app before deploying that app to a production environment. You will:
 
-- install prerequisite software
-- create and run an instance of the GSP on your local machine
-- create a Dockerised `govuk-prototype-kit` app
-- create a Helm chart
-- deploy the app on to the local GSP instance
-- connect to the app
-- destroy the local instance
+- [install prerequisite software](#install-prerequisite-software)
+- [create and run a local GSP instance](#create-and-run-a-local-gsp-instance)
+- [create a Dockerised `govuk-prototype-kit` app](#create-a-dockerised-govuk-prototype-kit-app)
+- [create a Helm chart](#create-a-helm-chart)
+- [deploy the app on to the local GSP instance](#deploy-the-app-on-to-the-local-GSP-instance)
+- [connect to the app](#connect-to-the-app)
+- [destroy the local instance](#destroy-the-local-instance)
 
 ## Install prerequisite software
 
@@ -40,7 +40,7 @@ These instructions tell you how to set up a local instance of the GDS Supported 
     git clone https://github.com/alphagov/gsp.git
     ```
 
-## Create a local GSP instance
+## Create and run a local GSP instance
 
 1. Run the following script to create a local GSP instance:
 
@@ -70,7 +70,7 @@ These instructions tell you how to set up a local instance of the GDS Supported 
     To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
     ```
 
-    If this script is still running after 20 minutes, contact the GSP team using the [re-GSP Slack channel](https://gds.slack.com/messages/CDA7YSP0D).
+    If this script is still running after 20 minutes, contact the GSP team using the [#re-gsp Slack channel](https://gds.slack.com/messages/CDA7YSP0D).
 
     Refer to the [GSP Features list](https://github.com/alphagov/gsp#features) for more information.
 
@@ -90,7 +90,7 @@ These instructions tell you how to set up a local instance of the GDS Supported 
     You now have a local GSP instance and can access that instance using kubectl.
 
 
-## Create a Dockerised app
+## Create a Dockerised `govuk-prototype-kit` app
 
 You must build the `govuk-prototype-kit` app into a Docker image before you can add the app into your GSP local instance.
 
@@ -139,15 +139,26 @@ You must build the `govuk-prototype-kit` app into a Docker image before you can 
     docker build . -t prototype-kit:latest
     ```
 
-    You have created a Docker image and built it into your local GSP instance.
+1. Run the following to check that the Docker image has been built:
+
+    ```
+    docker images | head -n 2
+    ```
+
+    if the Docker image has been built, you will see output similar to the following:
+
+    ```
+    REPOSITORY      TAG       IMAGE ID        CREATED               SIZE
+    prototype-kit   latest    53250c797a93    About a minute ago    246MB
+    ```
+
+    You have created a Docker image and built it in your local GSP instance.
 
 ## Create a Helm chart
 
 Kubernetes resources describe the configuration of your running app. You define these resources as `.yaml` files and collect them together in a packaging format called a [Helm chart](https://helm.sh/docs/developing_charts/).
 
-You create Helm charts as files in a directory. These files are then packaged into versioned archives that users can deploy.
-
-The Helm chart directory has the following structure:
+You create Helm charts as files in a directory with the following structure:
 
 ```
 chart/
@@ -233,11 +244,15 @@ You run an app in the local GSP instance by creating a [Kubernetes Deployment re
     kubectl get deployments
     ```
 
+    _example output_
+
 1. [Kubernetes pods](https://kubernetes.io/docs/concepts/workloads/pods/pod/) are the smallest deployable units of computing that you can create and manage in Kubernetes. You must check that the pods are running:
 
     ```
     kubectl get pods
     ```
+
+    _example output_
 
 If the pods are running you have created a Kubernetes Deployment resource.
 
@@ -423,12 +438,26 @@ By default, your app is not accessible outside of the local instance. To connect
 
 You have successfully deployed the `govuk-prototype-kit` app in your local GSP instance.
 
+1.  In your command line, enter `Ctrl-c` to stop port-forwarding.
+
 ## Destroy the local instance
 
 You should destroy your local GSP instance when you have finished testing your app.
 
-Run the following command to destroy the local instance:
+1. Run the following command to destroy the local instance:
 
-```
-./scripts/gsp-local.sh delete
-```
+    ```
+    ./scripts/gsp-local.sh delete
+    ```
+
+1. Remove the installed packages so your system is in the same state as it was before setting up the local instance:
+
+    ```
+    brew uninstall kubernetes-cli
+    brew uninstall kubernetes-helm
+    brew uninstall hyperkit
+    brew uninstall docker-machine-driver-hyperkit
+    brew cask uninstall minikube
+    ```
+
+You have destroyed your local GSP instance.

--- a/docs/gds-supported-platform/getting-started-gsp-local.md
+++ b/docs/gds-supported-platform/getting-started-gsp-local.md
@@ -46,14 +46,14 @@ This process should take no more than 2 hours. Contact the GSP team using the [#
     git clone https://github.com/alphagov/gsp.git
     ```
 
-1. If you already have either a `~/.minkube/machine/minikube` or `~/.minkube/machine/gocd` directory on your local machine,  run the following to ensure that Minikube is not running an existing cluster:
+1. If you already have either a `~/.minkube/machine/minikube` or `~/.minkube/machine/gocd` directory on your local machine,  run the following to ensure that Minikube is not running either of these clusters:
 
     ```
     minikube stop -p CLUSTER
     ```
     where `CLUSTER` can be either `minikube` or `gocd`.
 
-1. If the `kubeconfig` environment variable is assigned, run the following to unset this environment variable:
+1. If the `KUBECONFIG` environment variable is assigned, run the following to unset this environment variable:
 
     ```
     unset KUBECONFIG

--- a/docs/gds-supported-platform/getting-started-gsp-local.md
+++ b/docs/gds-supported-platform/getting-started-gsp-local.md
@@ -1,6 +1,6 @@
 # Set up a local GDS Supported Platform instance
 
-These instructions tell you how to set up a local instance of the GDS Supported Platform (GSP) and run the example `govuk-prototype-kit` app on that instance. This process is useful for testing your app before deploying that app to a production environment. You will:
+These instructions tell you how to set up a local instance of the GDS Supported Platform (GSP) and run the example `govuk-prototype-kit` app on that instance. You can use this process to test your app before deploying that app to a production environment. You will:
 
 - [install prerequisite software](#install-prerequisite-software)
 - [create and run a local GSP instance](#create-and-run-a-local-gsp-instance)
@@ -10,11 +10,13 @@ These instructions tell you how to set up a local instance of the GDS Supported 
 - [connect to the app](#connect-to-the-app)
 - [destroy the local instance](#destroy-the-local-instance)
 
+This process should take no more than 2 hours. Contact the GSP team using the [#re-gsp Slack channel](https://gds.slack.com/messages/CDA7YSP0D) if it takes longer.
+
+<%= warning_text('Whilst setting up or running a local GSP instance is running, do not:<br>- power down your laptop<br>- put your laptop in standby mode<br>- connect or disconnect the Cisco VPN client') %>
+
 ## Install prerequisite software
 
-1. Install [Homebrew](https://brew.sh/).
-
-1. Run the following to get the latest version of Homebrew.
+1. Install [Homebrew](https://brew.sh/) and run the following to make sure you have the latest version of Homebrew.
 
     ```
     brew update
@@ -32,12 +34,29 @@ These instructions tell you how to set up a local instance of the GDS Supported 
     sudo chown root:wheel /usr/local/bin/docker-machine-driver-hyperkit && sudo chmod u+s /usr/local/bin/docker-machine-driver-hyperkit
     ```
 
-1. Install [Docker](https://docs.docker.com).
+1. Install [Docker](https://docs.docker.com) and configure Docker to have the following settings:
+
+    - CPU = 4
+    - Memory = 8 Gb
+    - Swap = 2 Gb
 
 1. Clone the GSP repository:
 
     ```
     git clone https://github.com/alphagov/gsp.git
+    ```
+
+1. If you already have either a `~/.minkube/machine/minikube` or `~/.minkube/machine/gocd` directory on your local machine,  run the following to ensure that Minikube is not running an existing cluster:
+
+    ```
+    minikube stop -p CLUSTER
+    ```
+    where `CLUSTER` can be either `minikube` or `gocd`.
+
+1. If the `kubeconfig` environment variable is assigned, run the following to unset this environment variable:
+
+    ```
+    unset KUBECONFIG
     ```
 
 ## Create and run a local GSP instance
@@ -244,15 +263,11 @@ You run an app in the local GSP instance by creating a [Kubernetes Deployment re
     kubectl get deployments
     ```
 
-    _example output_
-
 1. [Kubernetes pods](https://kubernetes.io/docs/concepts/workloads/pods/pod/) are the smallest deployable units of computing that you can create and manage in Kubernetes. You must check that the pods are running:
 
     ```
     kubectl get pods
     ```
-
-    _example output_
 
 If the pods are running you have created a Kubernetes Deployment resource.
 


### PR DESCRIPTION
What
----

Updated the local environment documentation post-user research to:

- show a conceptual overview up front to frame what users are doing
- set expectations where appropriate about how long each step will take
- give better context of what users are doing at each stage, why, what they’ll expect to see, and how they’ll know it’s done
- ensure content is in line with gov.uk style

Who can review
--------------

Anyone but Jon Glassman
