### PR TITLE
Add AWS Service Operator, for use by DCS

### DIFF
--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -228,5 +228,5 @@ items:
           args:
             - server
             - --cluster-name=gsp
-            - --region={{ .Values.global.serviceOperatorRegion }}
-            - --account-id={{ .Values.global.serviceOperatorAccountId }}
+            - --region=""
+            - --account-id={{ .Values.global.account.id }}

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -1,0 +1,232 @@
+apiVersion: v1
+kind: List
+items:
+- kind: Namespace
+  apiVersion: v1
+  metadata:
+    name: aws-service-operator
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: cloudformationtemplates.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: CloudFormationTemplate
+      listKind: CloudFormationTemplateList
+      plural: cloudformationtemplates
+      shortNames:
+      - cft
+      - cfts
+      - cfn
+      - cfns
+      - cloudformation
+      singular: cloudformationtemplate
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: dynamodbs.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: DynamoDB
+      listKind: DynamoDBList
+      plural: dynamodbs
+      shortNames:
+      - ddb
+      - ddbs
+      - dynamo
+      - dynamotable
+      - dynamotables
+      singular: dynamodb
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: ecrrepositories.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: ECRRepository
+      listKind: ECRRepositoryList
+      plural: ecrrepositories
+      shortNames:
+      - ecr
+      - repository
+      singular: ecrrepository
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: elasticaches.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: ElastiCache
+      listKind: ElastiCacheList
+      plural: elasticaches
+      shortNames:
+      - ec
+      singular: elasticache
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: s3buckets.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: S3Bucket
+      listKind: S3BucketList
+      plural: s3buckets
+      shortNames:
+      - s3
+      - bucket
+      - buckets
+      singular: s3bucket
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: snssubscriptions.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: SNSSubscription
+      listKind: SNSSubscriptionList
+      plural: snssubscriptions
+      shortNames:
+      - subscription
+      singular: snssubscription
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: snstopics.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: SNSTopic
+      listKind: SNSTopicList
+      plural: snstopics
+      shortNames:
+      - sns
+      - topic
+      - topics
+      singular: snstopic
+    scope: Namespaced
+    version: v1alpha1
+
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: sqsqueues.service-operator.aws
+  spec:
+    group: service-operator.aws
+    names:
+      kind: SQSQueue
+      listKind: SQSQueueList
+      plural: sqsqueues
+      shortNames:
+      - sqs
+      - queue
+      - queues
+      singular: sqsqueue
+    scope: Namespaced
+    version: v1alpha1
+
+- kind: ClusterRole
+  apiVersion: rbac.authorization.k8s.io/v1beta1
+  metadata:
+    name: aws-service-operator
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    - pods
+    - configmaps
+    - services
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+  - apiGroups:
+    - service-operator.aws
+    resources:
+    - "*"
+    verbs:
+    - "*"
+
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: aws-service-operator
+    namespace: aws-service-operator
+
+- kind: ClusterRoleBinding
+  apiVersion: rbac.authorization.k8s.io/v1beta1
+  metadata:
+    name: aws-service-operator
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: aws-service-operator
+  subjects:
+  - kind: ServiceAccount
+    name: aws-service-operator
+    namespace: aws-service-operator
+
+- kind: Deployment
+  apiVersion: apps/v1beta1
+  metadata:
+    name: aws-service-operator
+    namespace: aws-service-operator
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        annotations:
+          iam.amazonaws.com/role: aws-service-operator
+        labels:
+          app: aws-service-operator
+      spec:
+        serviceAccountName: aws-service-operator
+        containers:
+        - name: aws-service-operator
+          image: awsserviceoperator/aws-service-operator:v0.0.1-alpha4
+          imagePullPolicy: Always
+          args:
+            - server
+            - --cluster-name=gsp
+            - --region={{ .Values.global.serviceOperatorRegion }}
+            - --account-id={{ .Values.global.serviceOperatorAccountId }}

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -216,7 +216,7 @@ items:
     template:
       metadata:
         annotations:
-          iam.amazonaws.com/role: aws-service-operator
+          iam.amazonaws.com/role: {{ .Values.global.cluster.name }}-aws-service-operator
         labels:
           app: aws-service-operator
       spec:

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -4,6 +4,8 @@ items:
 - kind: Namespace
   apiVersion: v1
   metadata:
+    annotations:
+      iam.amazonaws.com/permitted: ^(aws-service-operator)$
     name: aws-service-operator
 
 - apiVersion: apiextensions.k8s.io/v1beta1

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -230,5 +230,5 @@ items:
           args:
             - server
             - --cluster-name=gsp
-            - --region=
+            - --region=eu-west-2
             - --account-id={{ .Values.global.account.id }}

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -230,5 +230,5 @@ items:
           args:
             - server
             - --cluster-name=gsp
-            - --region=""
+            - --region=
             - --account-id={{ .Values.global.account.id }}

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -1,13 +1,6 @@
 apiVersion: v1
 kind: List
 items:
-- kind: Namespace
-  apiVersion: v1
-  metadata:
-    annotations:
-      iam.amazonaws.com/permitted: ^({{ .Values.global.cluster.name }}-aws-service-operator)$
-    name: aws-service-operator
-
 - apiVersion: apiextensions.k8s.io/v1beta1
   kind: CustomResourceDefinition
   metadata:
@@ -193,7 +186,7 @@ items:
   apiVersion: v1
   metadata:
     name: aws-service-operator
-    namespace: aws-service-operator
+    namespace: {{ .Release.Namespace }}
 
 - kind: ClusterRoleBinding
   apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -206,13 +199,13 @@ items:
   subjects:
   - kind: ServiceAccount
     name: aws-service-operator
-    namespace: aws-service-operator
+    namespace: {{ .Release.Namespace }}
 
 - kind: Deployment
   apiVersion: apps/v1beta1
   metadata:
     name: aws-service-operator
-    namespace: aws-service-operator
+    namespace: {{ .Release.Namespace }}
   spec:
     replicas: 1
     template:

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -5,7 +5,7 @@ items:
   apiVersion: v1
   metadata:
     annotations:
-      iam.amazonaws.com/permitted: ^(aws-service-operator)$
+      iam.amazonaws.com/permitted: ^({{ .Values.global.cluster.name }}-aws-service-operator)$
     name: aws-service-operator
 
 - apiVersion: apiextensions.k8s.io/v1beta1

--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -222,6 +222,6 @@ items:
           imagePullPolicy: Always
           args:
             - server
-            - --cluster-name=gsp
+            - --cluster-name={{ .Values.global.cluster.name }}
             - --region=eu-west-2
             - --account-id={{ .Values.global.account.id }}

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -1,4 +1,6 @@
 global:
+  serviceOperatorRegion: eu-west-2
+  serviceOperatorAccountId: 626298535712
   runningOnAws: false
   cluster:
     name: "my-cluster"

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -1,6 +1,4 @@
 global:
-  serviceOperatorRegion: eu-west-2
-  serviceOperatorAccountId: 626298535712
   runningOnAws: false
   cluster:
     name: "my-cluster"

--- a/modules/gsp-cluster/iam.tf
+++ b/modules/gsp-cluster/iam.tf
@@ -1,0 +1,31 @@
+resource "aws_iam_role" "aws-service-operator" {
+  name               = "${var.cluster_name}-aws-service-operator"
+  description        = "Role the AWS Service Operator assumes"
+  assume_role_policy = "${data.aws_iam_policy_document.trust_kiam_server.json}"
+}
+
+data "aws_iam_policy_document" "aws-service-operator" {
+  statement {
+    actions = [
+      "sqs:*",
+      "sns:*",
+      "cloudformation:*",
+      "ecr:*",
+      "dynamodb:*",
+      "s3:*",
+      "elasticache:*",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "aws-service-operator" {
+  name = "${var.cluster_name}-aws-service-operator"
+  policy = "${data.aws_iam_policy_document.aws-service-operator.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "aws-service-operator" {
+  policy_arn = "${aws_iam_policy.aws-service-operator.arn}"
+  role = "${aws_iam_role.aws-service-operator.name}"
+}

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -9,7 +9,6 @@ module "k8s-cluster" {
   ci_worker_count         = "${var.ci_worker_count}"
   ci_worker_instance_type = "${var.ci_worker_instance_type}"
   eks_version             = "${var.eks_version}"
-  trust_kiam_server       = "${data.aws_iam_policy_document.trust_kiam_server.json}"
 
   apiserver_allowed_cidrs = ["${concat(
       formatlist("%s/32", var.egress_ips),

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -46,7 +46,7 @@ data "template_file" "values" {
       aws_iam_role.harbor.name,
       aws_iam_role.concourse.name,
       aws_iam_role.cloudwatch_log_shipping_role.name,
-      "${var.cluster_name}-aws-service-operator",
+      aws_iam_role.aws-service-operator.name,
     ))})$"
   }
 }

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -46,6 +46,7 @@ data "template_file" "values" {
       aws_iam_role.harbor.name,
       aws_iam_role.concourse.name,
       aws_iam_role.cloudwatch_log_shipping_role.name,
+      "${var.cluster_name}-aws-service-operator",
     ))})$"
   }
 }

--- a/modules/k8s-cluster/iam.tf
+++ b/modules/k8s-cluster/iam.tf
@@ -77,35 +77,3 @@ resource "aws_iam_role_policy_attachment" "ci-nodes-ssm" {
   policy_arn = "${aws_iam_policy.ssm-minimal.arn}"
   role = "${replace(data.aws_arn.ci-nodes-role.resource, "role/", "")}"
 }
-
-resource "aws_iam_role" "aws-service-operator" {
-  name               = "${var.cluster_name}-aws-service-operator"
-  description        = "Role the AWS Service Operator assumes"
-  assume_role_policy = "${var.trust_kiam_server}"
-}
-
-data "aws_iam_policy_document" "aws-service-operator" {
-  statement {
-    actions = [
-      "sqs:*",
-      "sns:*",
-      "cloudformation:*",
-      "ecr:*",
-      "dynamodb:*",
-      "s3:*",
-      "elasticache:*",
-    ]
-
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_policy" "aws-service-operator" {
-  name = "${var.cluster_name}-aws-service-operator"
-  policy = "${data.aws_iam_policy_document.aws-service-operator.json}"
-}
-
-resource "aws_iam_role_policy_attachment" "aws-service-operator" {
-  policy_arn = "${aws_iam_policy.aws-service-operator.arn}"
-  role = "${aws_iam_role.aws-service-operator.name}"
-}

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -41,7 +41,3 @@ variable "ci_worker_count" {
   type    = "string"
   default = "3"
 }
-
-variable "trust_kiam_server" {
-  type = "string"
-}


### PR DESCRIPTION
DCS are likely to be using this to create SQS queues, which will replace RabbitMQ.

This is mostly from AWS, with a fix or two.