### PR TITLE
Enable the ability to Expose CloudHSM to GDS IP Range

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
@@ -1,0 +1,88 @@
+{{ if .Values.global.cluster.cloudHSMExpose }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-haproxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: vmc
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: haproxy
+  template:
+    metadata:
+      labels:
+        app: haproxy
+    spec:
+      containers:
+      - name: haproxy
+        image: haproxy:1.9.8
+        volumeMounts:
+        - name: config-volume
+          mountPath: /usr/local/etc/haproxy/
+        ports:
+          - containerPort: 2225
+        readinessProbe:
+          tcpSocket:
+            port: 2225
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 2225
+          initialDelaySeconds: 15
+          periodSeconds: 20
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ .Release.Name }}-haproxy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-haproxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: vmc
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  haproxy.cfg: |
+    global
+      daemon
+      maxconn 256
+
+    defaults
+      mode tcp
+      timeout connect 5000ms
+      timeout client 50000ms
+      timeout server 50000ms
+      log stdout format raw daemon
+
+    listen tcp-in
+      bind *:2225
+      acl gds_ips src 10.0.0.0/8 213.86.153.212 213.86.153.213 213.86.153.214 213.86.153.235 213.86.153.236 213.86.153.237 85.133.67.244
+      tcp-request connection reject if !gds_ips
+      server cloudhsm 10.101.29.134:2225 check
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-haproxy
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+      app: haproxy
+  ports:
+    - port: 2225
+      targetPort: 2225
+{{ end }}

--- a/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
@@ -1,22 +1,22 @@
-{{ if .Values.global.cluster.cloudHSMExpose }}
+{{ if .Values.cloudHSMExpose }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-haproxy
+  name: {{ .Release.Name }}-hsmproxy
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: vmc
+    app.kubernetes.io/name: hsmproxy
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-      app: haproxy
+      app: hsmproxy
   template:
     metadata:
       labels:
-        app: haproxy
+        app: hsmproxy
     spec:
       containers:
       - name: haproxy
@@ -39,15 +39,15 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: {{ .Release.Name }}-haproxy
+          name: {{ .Release.Name }}-hsmproxy
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-haproxy
+  name: {{ .Release.Name }}-hsmproxy
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: vmc
+    app.kubernetes.io/name: hsmproxy
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -73,7 +73,7 @@ data:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-haproxy
+  name: {{ .Release.Name }}-hsmproxy
   namespace: {{ .Release.Namespace }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
@@ -81,7 +81,7 @@ spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
   selector:
-      app: haproxy
+      app: hsmproxy
   ports:
     - port: 2225
       targetPort: 2225


### PR DESCRIPTION
This allows for CloudHSM to be exposed by HAproxy, and whitelisted to only allow connections from GDS IPs and internal components of the kuberentes cluster.

To enable CloudHSM a cluster needs to be passed: ```cloudHSMExpose: true```

Pair: @samcrang & @smford