### PR TITLE
Prevent accidental destroy

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -25,11 +25,19 @@ resource "aws_eks_cluster" "eks-cluster" {
     "aws_iam_role_policy_attachment.eks-service-policy",
     "aws_cloudwatch_log_group.eks",
   ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_log_group" "eks" {
   name              = "/aws/eks/${var.cluster_name}/cluster"
   retention_in_days = 30
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # As per https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -1,11 +1,3 @@
-terraform {
-  backend "s3" {}
-}
-
-variable "aws_account_role_arn" {
-  type = "string"
-}
-
 variable "account_name" {
   type = "string"
 }
@@ -87,14 +79,6 @@ variable "ci_worker_count" {
 variable "eks_version" {
   description = "EKS platform version (https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html)"
   type        = "string"
-}
-
-provider "aws" {
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "${var.aws_account_role_arn}"
-  }
 }
 
 data "aws_caller_identity" "current" {}

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -615,17 +615,34 @@ jobs:
   - task: generate-user-terraform
     timeout: 10m
     config: *generate_users_terraform
+  - task: empty-config
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: alpine
+      inputs:
+      - name: platform
+      outputs:
+      - name: terraformz
+      run:
+        path: sh
+        args:
+        - -euc
+        - |
+          cp platform/pipelines/deployer/main.tf terraformz/main.tf
   - put: cluster-state
     params:
       env_name: ((account-name))
-      terraform_source: platform/pipelines/deployer
-      action: destroy
+      terraform_source: terraformz
+      action: apply
     get_params:
-      action: destroy
+      action: apply
   - put: user-state
     params:
       env_name: ((account-name))
       terraform_source: users-terraform
-      action: destroy
+      action: apply
     get_params:
-      action: destroy
+      action: apply

--- a/pipelines/deployer/main.tf
+++ b/pipelines/deployer/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  backend "s3" {}
+}
+
+variable "aws_account_role_arn" {
+  type = "string"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "${var.aws_account_role_arn}"
+  }
+}


### PR DESCRIPTION
## What

It is possible, that inappropriate use of terraform by say, resorting or
renaming resources could cause a cluster to be destroyed. We don't want
to do that, whilst running ordinary `terraform apply` with some changes.

Adding the option to prevent_destroy, will help to avoid terrafrom being
all jolly about removing the control plane. This however will break the
`destroy` Concourse pipeline, as it will no longer be capable of
performing its job.

Additionally, we probably do care about the log group from the EKS.

Now that we are not allowing accidental removal of the EKS cluster, the
pipeline is broken.

A way to solve it, is to clear out the config file and performing an
apply action on it against the same account. This should trigger
destroyment, and ignore any `prevent_destroy` settings previously set
up.

## How to review

- Sanity check