### PR TITLE
Disable SNAT of Pod network traffic (VPC CNI)

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
@@ -77,6 +77,8 @@ spec:
           name: metrics
         name: aws-node
         env:
+          - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
+            value: "true"
           - name: AWS_VPC_K8S_CNI_LOGLEVEL
             value: DEBUG
           - name: MY_NODE_NAME


### PR DESCRIPTION
## What

Disables the SNAT feature of the VPC CNI so that Pod traffic communicates directly without traversing nodes.

Before/Current:

![before](https://docs.aws.amazon.com/eks/latest/userguide/images/SNAT-enabled.jpg)

After/Future:

![after](https://docs.aws.amazon.com/eks/latest/userguide/images/SNAT-disabled.jpg)

## Why

We were having trouble adding protective monitoring that made us of the
VPC Flow logs as _sometimes_ traffic was getting routed to external
services also in the private VPC via the primary node interface(s)
instead of what we expected to see as coming directly from the Pod addr.

By default, the Amazon VPC CNI plugin for Kubernetes configures pods
with source network address translation (SNAT) enabled. This sets the
return address for a packet to the primary public IP of the instance and
allows for communication with the internet.

SNAT is only required for nodes that reside in a public subnet but our
nodes reside in private subnet and connect to the internet through a NAT
gateway so we should not need it.

## Notes

* ⚠️ The nodes will require rolling after this update, node bump PR enroute
* ⚠️ This _may_ cause network interruption, but I tested in Verify cluster already and didn't see any issue.