### PR TITLE
limits hsm ingress to only from worker nodes

### DIFF
--- a/modules/gsp-cluster/outputs.tf
+++ b/modules/gsp-cluster/outputs.tf
@@ -2,6 +2,10 @@ output "kubeconfig" {
   value = "${module.k8s-cluster.kubeconfig}"
 }
 
+output "worker_security_group_id" {
+  value = "${module.k8s-cluster.worker_security_group_id}"
+}
+
 output "values" {
   sensitive = true
   value     = "${data.template_file.values.rendered}"

--- a/modules/hsm/main.tf
+++ b/modules/hsm/main.tf
@@ -2,6 +2,10 @@ variable "subnet_cidr_map" {
   type = "map"
 }
 
+variable "source_security_group_id" {
+  type = "string"
+}
+
 variable "cluster_name" {
   type = "string"
 }
@@ -35,12 +39,12 @@ resource "aws_cloudhsm_v2_cluster" "cluster" {
 }
 
 resource "aws_security_group_rule" "hsm-worker-ingress" {
-  security_group_id = "${aws_cloudhsm_v2_cluster.cluster.security_group_id}"
-  type              = "ingress"
-  from_port         = 2223
-  to_port           = 2225
-  protocol          = "tcp"
-  cidr_blocks       = ["${values(var.subnet_cidr_map)}"]
+  security_group_id        = "${aws_cloudhsm_v2_cluster.cluster.security_group_id}"
+  type                     = "ingress"
+  from_port                = 2223
+  to_port                  = 2225
+  protocol                 = "tcp"
+  source_security_group_id = "${var.source_security_group_id}"
 }
 
 # We can only create one HSM in Terraform rather than the multiple we require for high availability as you must create

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -25,3 +25,7 @@ output "eks-log-group-arn" {
 output "eks-log-group-name" {
   value = "${aws_cloudwatch_log_group.eks.name}"
 }
+
+output "worker_security_group_id" {
+  value = "${aws_cloudformation_stack.worker-nodes.outputs["NodeSecurityGroup"]}"
+}

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -100,13 +100,14 @@ module "gsp-network" {
 }
 
 module "hsm" {
-  source           = "../../modules/hsm"
-  subnet_cidr_map  = "${module.gsp-network.private_subnet_cidr_mapping}"
-  cluster_name     = "${var.cluster_name}"
-  splunk           = "${var.splunk_enabled}"
-  splunk_hec_url   = "${var.splunk_hec_url}"
-  splunk_hec_token = "${var.hsm_splunk_hec_token}"
-  splunk_index     = "${var.hsm_splunk_index}"
+  source                   = "../../modules/hsm"
+  subnet_cidr_map          = "${module.gsp-network.private_subnet_cidr_mapping}"
+  source_security_group_id = "${module.gsp-cluster.worker_security_group_id}"
+  cluster_name             = "${var.cluster_name}"
+  splunk                   = "${var.splunk_enabled}"
+  splunk_hec_url           = "${var.splunk_hec_url}"
+  splunk_hec_token         = "${var.hsm_splunk_hec_token}"
+  splunk_index             = "${var.hsm_splunk_index}"
 }
 
 module "gsp-cluster" {
@@ -150,8 +151,8 @@ module "gsp-cluster" {
   vpc_flow_log_splunk_hec_token = "${var.vpc_flow_log_splunk_hec_token}"
   vpc_flow_log_splunk_index     = "${var.vpc_flow_log_splunk_index}"
 
-  github_client_id         = "${var.github_client_id}"
-  github_client_secret     = "${var.github_client_secret}"
+  github_client_id     = "${var.github_client_id}"
+  github_client_secret = "${var.github_client_secret}"
 }
 
 output "kubeconfig" {


### PR DESCRIPTION
## What

we want to limit the scope of what can connect to the hsm to only the worker nodes

## Why

so that protective monitoring around hsm connectively can be more effective

## How to review

* ⚠️  Untested, so should try in sandbox to check doesn't cause HSM to be destroyed! (it shouldn't!)