### PR TITLE
disable assignment of public ip addr to nodes

### DIFF
--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -306,7 +306,7 @@ Resources:
   NodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: true
+      AssociatePublicIpAddress: false
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId: !Ref NodeImageId
       InstanceType: !Ref NodeInstanceType


### PR DESCRIPTION
we don't want our nodes to have public ip addresses assigned, they live
in a private subnet and have a NAT gateway so assigning a public IP is
kind of pointless and maybe even presents a risk of accidental
misconfiguration

⚠️ untested, run through sandbox first