### PR TITLE
Check if Canary has been deployed recently

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -575,6 +575,7 @@ jobs:
     passed: ["deploy"]
     trigger: true
   - task: ping
+    timeout: 20m
     config:
       platform: linux
       image_resource: *task_image_resource
@@ -586,8 +587,18 @@ jobs:
           - -eu
           - -c
           - |
-            echo "pinging https://canary.${CLUSTER_DOMAIN}/metrics to check ingress..."
-            curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_DOMAIN}/metrics
+            now="$(date '+%s')"
+            echo "Current time: ${now}"
+            echo "pinging https://canary.${CLUSTER_DOMAIN}/metrics to check ingress, expecting the deployment to happen soon..."
+            while true; do
+              last_deploy="$(curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_DOMAIN}/metrics | awk '$1 ~ /^canary_build_timestamp/ {print $2 * 2 / 2}')"
+              if [ "${last_deploy}" -ge "${now}" ]; then
+                echo "OK!"
+                exit 0
+              fi
+              echo -n .
+              sleep 5
+            done
   - task: check-cloudwatch
     timeout: 10m
     config: *check_cloudwatch


### PR DESCRIPTION
## What

At the moment, the canary could have been deployed once and then fail
thereafter. Kubernetes will keep it up despite it further attempts to
re-deploy it. This means we cannot rely on the ping only.

The `/metrics` endpoint exposes the timestamp of when the canary has
been deployed.

We can read that entry and attempt to find out if it has been deployed
in the past N minute slot. That will assure us, that it has in fact been
re-deployed.

## How to review

- Run the above command locally pointing to a live canary
- Expect `exit 0`
- Change the command to do `-ge` comparison instead
- Expect `exit 1`