### PR TITLE
BAU: allow customisation of local GSP resource allocation

### DIFF
--- a/scripts/gsp-local.sh
+++ b/scripts/gsp-local.sh
@@ -88,8 +88,8 @@ function apply() {
 
 log "Creating local GSP..."
 minikube start \
-	--memory 8192 \
-	--cpus 4 \
+	--memory ${GSP_MEMORY:-8192} \
+	--cpus ${GSP_CPUS:-4} \
 	--disk-size 30g \
 	--vm-driver hyperkit \
 	--kubernetes-version v1.12.0 \


### PR DESCRIPTION
When running our product in GSP local, we need more CPU and memory. This will allow us to set environment variables to get a bigger GSP cluster.