### PR TITLE
Re-use the secret for different components

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -83,6 +83,10 @@ harbor:
         bucket: ${harbor_bucket_id}
         region: ${harbor_bucket_region}
         regionendpoint: s3.${harbor_bucket_region}.amazonaws.com
+  core:
+    secret: ${harbor_secret_key}
+  jobservice:
+    secret: ${harbor_secret_key}
   registry:
     secret: ${harbor_secret_key}
     podAnnotations:


### PR DESCRIPTION
## What

When we deploy Harbor in our release pipeline on shared concourse, we're
running `helm template`. This causes some of the values to be generated.
The newly templated app is then kube cuttle applied to the system, and
perhaps does not roll all the boxes properly - as a version of a chart
hasn't really changed.

This is potentially causing a problem we are experiencing, where each
run of the release pipeline breaks the Registry. The solution often is
to kick the containers that haven't been restarted thus far and it will
sort itself out.

By hardcoding / re-using the secret, we hope for it to persist through
all deployments, making our lives easier and preventing the need to kick
the containers into good shape.

https://github.com/goharbor/harbor-helm/blob/master/values.yaml#L291-L294
https://github.com/goharbor/harbor-helm/blob/master/values.yaml#L350-L355

## How to review

- Sanity check
- Merge it and see if it worked (one may need to kick registry for one final time?)

I haven't tested it, and cannot honestly say it will fix the issue. It would be sane if it did, and does no harm to the system if used.