### PR TITLE
Fix Service resource

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
@@ -86,9 +86,12 @@ spec:
       app: hsmproxy
   ports:
     - port: 2223
+      name: cloudhsm-2223
       targetPort: 2223
     - port: 2224
+      name: cloudhsm-2224
       targetPort: 2224
     - port: 2225
+      name: cloudhsm-2225
       targetPort: 2225
 {{ end }}


### PR DESCRIPTION
Multi-port services must have names[1]:

```
For some Services, you need to expose more than one port. Kubernetes
lets you configure multiple port definitions on a Service object. When
using multiple ports for a Service, you must give all of your ports
names so that these are unambiguous.
```

[1] https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services