### PR TITLE
Improve CloudWatch access

### DIFF
--- a/modules/gsp-user/iam.tf
+++ b/modules/gsp-user/iam.tf
@@ -27,14 +27,6 @@ data "aws_iam_policy_document" "user-defaults" {
     effect = "Allow"
 
     actions = [
-      "autoscaling:Describe*",
-      "cloudwatch:Describe*",
-      "cloudwatch:Get*",
-      "cloudwatch:List*",
-      "logs:Get*",
-      "logs:Describe*",
-      "sns:Get*",
-      "sns:List*",
       "eks:DescribeCluster*",
     ]
 
@@ -50,6 +42,12 @@ resource "aws_iam_role" "user" {
 resource "aws_iam_policy" "user-defaults" {
   name   = "${var.cluster_name}-${var.user_name}-user-defaults"
   policy = "${data.aws_iam_policy_document.user-defaults.json}"
+}
+
+resource "aws_iam_policy_attachment" "user-defaults-cloudwatch" {
+  name       = "${var.cluster_name}-${var.user_name}-user-defaults-cloudwatch-attachment"
+  roles      = ["${aws_iam_role.user.name}"]
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
 }
 
 resource "aws_iam_policy_attachment" "user-defaults" {

--- a/modules/gsp-user/iam.tf
+++ b/modules/gsp-user/iam.tf
@@ -50,6 +50,12 @@ resource "aws_iam_policy_attachment" "user-defaults-cloudwatch" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
 }
 
+resource "aws_iam_policy_attachment" "user-defaults-view-only" {
+  name       = "${var.cluster_name}-${var.user_name}-user-defaults-view-only-attachment"
+  roles      = ["${aws_iam_role.user.name}"]
+  policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+}
+
 resource "aws_iam_policy_attachment" "user-defaults" {
   name       = "${var.cluster_name}-${var.user_name}-user-defaults-attachment"
   roles      = ["${aws_iam_role.user.name}"]


### PR DESCRIPTION
## What

At the moment, each user is capable of getting onto the AWS account and
dig through the CloudWatch logs. This is however restricted to the CW
itself and does not include CloudWatch Insights.

We can replace manually created actions with a policy that is attached
to the user, that should give everyone readonly access to everything and
is managed by AWS themselves.

There is no reason for people not to have a very limited access to the
resources used on AWS.

New role allows only for Describing and Listing different pieces of
infrastructure and should prevent things like s3:GetObject from
happening accidentally.

This policy is managed by AWS meaning we have to worry less (?).

## How to review

- Sanity check