### PR TITLE
Upgrade control-plane to v1.13.x

### DIFF
--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -1,4 +1,4 @@
-eks-version: "1.12"
+eks-version: "1.13"
 
 config-trigger: true
 config-version: "master"


### PR DESCRIPTION
## What

Upgrade EKS control-plane to kubernetes v1.13

## Why

It is important to stay up to date.

[AWS Container Roadmap](https://github.com/aws/containers-roadmap/projects/1)
- [EKS Support for Kubernetes 1.13](https://github.com/aws/containers-roadmap/projects/1#card-16594285) SHIPPED
- [Kubernetes v1.10 Deprecation (July 22, 2019)](https://github.com/aws/containers-roadmap/projects/1#card-21819192) COMING SOON

## Before merging

Please merge these first:

* https://github.com/alphagov/verify-cluster-config/pull/8
* https://github.com/alphagov/tech-ops-cluster-config/pull/217
