### PR TITLE
removes generate-namespace-values task

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -111,33 +111,6 @@ generate_users_terraform: &generate_users_terraform
   outputs:
   - name: users-terraform
 
-generate_namespace_values: &generate_namespace_values
-  platform: linux
-  image_resource: *task_image_resource
-  params:
-    CLUSTER_NAME: ((cluster-name))
-    CLUSTER_CONFIG_PATH: ((config-path))
-  run:
-    path: /bin/bash
-    args:
-    - -euo
-    - pipefail
-    - -c
-    - |
-      echo "creating helm compatible values file from namespace data"
-      mkdir -p namespace-values
-      namespace_values_file="$(pwd)/namespace-values/values.yaml"
-      echo "--> ${CLUSTER_NAME}-main"
-      echo "namespaces:" > $namespace_values_file
-      echo "- name: ${CLUSTER_NAME}-main" >> $namespace_values_file
-      yq .namespaces --yaml-output < "./config/${CLUSTER_CONFIG_PATH}" >> $namespace_values_file
-      cat $namespace_values_file
-      echo "OK!"
-  inputs:
-  - name: config
-  outputs:
-  - name: namespace-values
-
 apply_cluster_chart: &apply_cluster_chart
   platform: linux
   image_resource: *task_image_resource
@@ -178,7 +151,6 @@ apply_cluster_chart: &apply_cluster_chart
         --namespace "${DEFAULT_NAMESPACE}" \
         --values cluster-values/values.yaml \
         --values user-values/values.yaml \
-        --values namespace-values/values.yaml \
         --values config/${CONFIG_VALUES_PATH} \
         --set githubAPIToken=${GITHUB_API_TOKEN} \
         --set "global.cluster.privateKey=${CLUSTER_PRIVATE_KEY}" \
@@ -210,7 +182,6 @@ apply_cluster_chart: &apply_cluster_chart
   - name: cluster-values
   - name: config
   - name: user-values
-  - name: namespace-values
   - name: platform
 
 check_conformance: &check_conformance
@@ -578,9 +549,6 @@ jobs:
     - task: generate-cluster-values
       timeout: 10m
       config: *generate_cluster_values
-    - task: generate-namespace-values
-      timeout: 10m
-      config: *generate_namespace_values
     - task: generate-user-values
       timeout: 10m
       config: *generate_user_values


### PR DESCRIPTION
## What

we now have a values.yaml in each cluster config repo, so we can now be explicit and not rely on some scripting hackery to put it in the right place.

this does mean that the ${ACCOUNT_NAME}-main team must be explitictly set as part of the values otherwise concourse will be upset (since concourse likes the -main team to exist)

## Why

previously we scripted the extraction of the namespace values from concourse vars (cluster.yaml) added a ${ACCOUNT_NAME}-main team to the list and then passed them along to the helm template

## Related

Please merge these:

* https://github.com/alphagov/verify-cluster-config/pull/8
* https://github.com/alphagov/tech-ops-cluster-config/pull/217
