### PR TITLE
disable exporters for eks managed components

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -94,6 +94,12 @@ prometheus-operator:
     rules:
       general: false # see templates/general.rules.yaml for replacement
       alertmanager: false
+  kubeControllerManager:
+    enabled: false
+  kubeScheduler:
+    enabled: false
+  kubeEtcd:
+    enabled: false
   prometheus:
     prometheusSpec:
       externalLabels:


### PR DESCRIPTION
## What

Disables prometheus exporters/ServiceMonitors for the etcd, controller-manager, and
scheduler components

## Why

EKS manages etcd, controller-manager and scheduler in a way that is not observable via the usual kubernetes means, this results in false alerts from prometheus spamming our channel which is configured to expect to find them in the cluster. 

## Post deploy

⚠️ Manual intervention required

It is very likely that this will leave the old `ServiceMonitor` records laying around in `gsp-system` that will need manually deleting.