### PR TITLE
Fix pipeline validation for concourse v5+ configs

### DIFF
--- a/components/concourse-operator/Dockerfile
+++ b/components/concourse-operator/Dockerfile
@@ -1,10 +1,14 @@
 # Build the manager binary
 FROM golang:1.11 as builder
+RUN wget https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 \
+	&& mv dep-linux-amd64 /bin/dep \
+	&& chmod +x /bin/dep
 WORKDIR /go/src/github.com/alphagov/gsp/components/concourse-operator
 COPY pkg/    pkg/
 COPY cmd/    cmd/
-COPY vendor/ vendor/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/alphagov/gsp/components/concourse-operator/cmd/manager
+COPY Gopkg.lock Gopkg.lock
+COPY Gopkg.toml Gopkg.toml
+RUN dep ensure && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/alphagov/gsp/components/concourse-operator/cmd/manager
 
 # CA certs
 FROM alpine:3.2 as certs

--- a/components/concourse-operator/Gopkg.lock
+++ b/components/concourse-operator/Gopkg.lock
@@ -26,8 +26,7 @@
   revision = "6226ea591a40176dd3ff9cd8eff81ed6ca721a00"
 
 [[projects]]
-  branch = "master"
-  digest = "1:6ef14d8b084f921692bcc2f2684abec1dbe9ab2373c06122febc2631af564abf"
+  digest = "1:79d04affad4b549c7cc6cb5352836b2db6ae74b5463410b12ada57343f15baca"
   name = "github.com/concourse/concourse"
   packages = [
     ".",
@@ -39,19 +38,8 @@
     "go-concourse/concourse/internal",
   ]
   pruneopts = "T"
-  revision = "858e2d6aa0d65fcaf690865da8753787883906fd"
-
-[[projects]]
-  digest = "1:bb109206a2acc2d1544b21086a34b99b8dd23a645b7b6b9ac3555e4db72e4269"
-  name = "github.com/concourse/go-concourse"
-  packages = [
-    "concourse",
-    "concourse/eventstream",
-    "concourse/internal",
-  ]
-  pruneopts = "T"
-  revision = "79a832c54c62c957d666520937ee4a62b1af9efc"
-  version = "v4.2.2"
+  revision = "5ffc88a8d5c7c82a225ab11997ddfc1fde230e18"
+  version = "v5.3.0"
 
 [[projects]]
   digest = "1:9f42202ac457c462ad8bb9642806d275af9ab4850cf0b1960b9c6f083d4a309a"
@@ -538,7 +526,16 @@
   branch = "master"
   digest = "1:d470cb69884835b1800e93ceceb85afcf981ea647e61d99398a76af7a95bad6a"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "internal/chacha20",
+    "internal/subtle",
+    "poly1305",
+    "ssh",
+    "ssh/terminal",
+  ]
   pruneopts = "T"
   revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
@@ -961,6 +958,7 @@
     "pkg/source/internal",
     "pkg/webhook",
     "pkg/webhook/admission",
+    "pkg/webhook/admission/builder",
     "pkg/webhook/admission/types",
     "pkg/webhook/internal/cert",
     "pkg/webhook/internal/cert/generator",
@@ -1010,12 +1008,13 @@
     "github.com/concourse/concourse/atc",
     "github.com/concourse/concourse/go-concourse/concourse",
     "github.com/concourse/concourse/go-concourse/concourse/concoursefakes",
-    "github.com/concourse/go-concourse/concourse",
     "github.com/emicklei/go-restful",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",
+    "gopkg.in/yaml.v2",
+    "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
@@ -1034,10 +1033,15 @@
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/inject",
     "sigs.k8s.io/controller-runtime/pkg/runtime/log",
     "sigs.k8s.io/controller-runtime/pkg/runtime/scheme",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
     "sigs.k8s.io/controller-runtime/pkg/source",
+    "sigs.k8s.io/controller-runtime/pkg/webhook",
+    "sigs.k8s.io/controller-runtime/pkg/webhook/admission",
+    "sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder",
+    "sigs.k8s.io/controller-runtime/pkg/webhook/admission/types",
     "sigs.k8s.io/controller-tools/cmd/controller-gen",
     "sigs.k8s.io/testing_frameworks/integration",
   ]

--- a/components/concourse-operator/Gopkg.toml
+++ b/components/concourse-operator/Gopkg.toml
@@ -16,14 +16,18 @@ required = [
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "github.com/concourse/concourse",
     "github.com/concourse/concourse/atc",
-    ]
+]
+
+ignored = [
+    "github.com/maxbrunsfeld/counterfeiter*",
+]
 
 [prune]
   go-tests = true
 
 [[constraint]]
   name="github.com/concourse/concourse"
-  branch="master"
+  version="v5.3.0"
 
 # STANZAS BELOW ARE GENERATED AND MAY BE WRITTEN - DO NOT MODIFY BELOW THIS LINE.
 

--- a/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
+++ b/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
@@ -1,0 +1,113 @@
+package validating
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type ValidationTestCase struct {
+	Name                      string
+	Pipeline                  string
+	Valid                     bool
+	ValidationMessageContains string
+	HandlerErrorContains      string
+}
+
+var validationCases = []ValidationTestCase{
+	{
+		Name:  "valid-pipeline-task",
+		Valid: true,
+		Pipeline: `
+jobs:
+- name: hello
+  plan:
+  - task: say
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
+      run:
+        path: echo
+        args: [hello world]
+`,
+	},
+
+	{
+		Name:  "using-in_parallel-step",
+		Valid: true,
+		Pipeline: `
+resources:
+- name: thing1
+  type: docker-image
+- name: thing2
+  type: docker-image
+
+jobs:
+- name: job-with-parallel
+  plan:
+  - in_parallel:
+      limit: 2
+      steps:
+      - get: thing1
+      - get: thing2
+`,
+	},
+
+	{
+		Name:                      "non-existant-resource",
+		Valid:                     false,
+		ValidationMessageContains: "non-existant-resource refers to a resource that does not exist",
+		Pipeline: `
+jobs:
+- name: bad-job
+  plan:
+  - get: non-existant-resource
+  - task: say
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: busybox}
+      run:
+        path: echo
+        args: [hello world]
+`,
+	},
+}
+
+func TestPipelineValidation(t *testing.T) {
+	for _, tc := range validationCases {
+		err := testPipelineValidation(tc)
+		if err != nil {
+			t.Fatalf("%v failed: %v", tc, err)
+		}
+	}
+}
+
+func testPipelineValidation(tc ValidationTestCase) error {
+	h := &PipelineCreateUpdateHandler{}
+	valid, validationMessage, handlerError := h.Validate([]byte(tc.Pipeline))
+	if handlerError != nil {
+		if tc.HandlerErrorContains == "" {
+			return fmt.Errorf("did not expect handlerError but got: %v", handlerError)
+		}
+		if !strings.Contains(handlerError.Error(), tc.HandlerErrorContains) {
+			return fmt.Errorf("expected handlerError to contain '%v' but got: %v", tc.HandlerErrorContains, handlerError)
+		}
+		return nil
+	}
+	if validationMessage != "ok" {
+		if tc.ValidationMessageContains == "" {
+			return fmt.Errorf("did not expect validationMessage but got: %v", validationMessage)
+		}
+		if !strings.Contains(validationMessage, tc.ValidationMessageContains) {
+			return fmt.Errorf("expected validationMessage to contain '%v' but got: %v", tc.ValidationMessageContains, validationMessage)
+		}
+	}
+	if tc.Valid != valid {
+		return fmt.Errorf("expected valid=%v got: %v", tc.Valid, valid)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

* updates the dep depenedency constraints to pull in an up to date version of concourse/atc lib
* adds a basic validation test
* fixes Dockerfile for builds without vendor dir

## Why

Because currently you cannot kubectl apply a Pipeline that has any recent concourse 5 features in it like `in_parallel`  (See https://github.com/alphagov/gsp/issues/231)

Fixes #231 