### PR TITLE
Skip only merge commits

### DIFF
--- a/components/concourse-github-resource/assets/in
+++ b/components/concourse-github-resource/assets/in
@@ -61,8 +61,8 @@ function latest_code_change_commit() {
   for commit_sha in ${commits_to_check} ; do
     commit_diff="$(git diff-tree -p "${commit_sha}")"
 
-    if git verify-commit "${commit_sha}" > /dev/null 2>&1 && [ -z "${commit_diff}" ]; then
-      echo "${commit_sha} is an empty signed commit by GitHub" 1>&2
+    if [ "$(git cat-file -p ${commit_sha} | grep parent | wc -l)" -gt "1" ]; then
+      echo "${commit_sha} is an empty signed merge commit by GitHub" 1>&2
       continue
     fi
 


### PR DESCRIPTION
## What

We'd like an empty commit created by the user not to be skipped during
our checks.

AFAIK, the merge commits will always have more than one parent whilst
the ordinary commit should only keep one. This is a safe assumption for
a check and to prevent an exclusion of empty commits by developers.

## How to review

- Sanity check
- Run the command in your CLI against some SHAs

Fixes #217