### PR TITLE
Brewfile: Support Linux use too

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,8 +3,12 @@ tap "homebrew/cask"
 
 brew "kubernetes-cli"
 brew "kubernetes-helm"
-brew "hyperkit"
-brew "docker-machine-driver-hyperkit"
-
-cask "aws-vault"
-cask "minikube"
+if OS.mac?
+  brew "hyperkit"
+  brew "docker-machine-driver-hyperkit"
+  cask "aws-vault"
+  cask "minikube"
+else
+  brew "linuxbrew/extra/aws-vault"
+  brew "linuxbrew/extra/minikube"
+end


### PR DESCRIPTION
- Some people with Linux laptops use Homebrew on Linux as a package
  manager. Now, they can use this Brewfile to `brew bundle` the
  the required dependencies for this project.
- Hyperkit and related formulae only work on MacOS, but there are now
  Linux formulae for aws-vault and minikube.

Note that in order for GSP Local to run on Linux with easy dependency install with `brew bundle`, this will also need VirtualBox or `docker-machine-driver-kvm2` packages (the former is again shipped as a Cask for MacOS), but I don't have the time to add them to Homebrew on Linux right now. This gets us _some_ of the way at least, and the rest of the pre-requisites are left as an exercise for the next person to try this. :-) GSP Local won't work on Linux yet anyway, even with new docs, as `scripts/gsp-local.sh` hardcodes `hyperkit` as the `minikube --vm-driver`, so we can cross that bridge when we come to it (later this firebreak).