### PR TITLE
No longer use terraform to manage the state of the cloudHSMs.

### DIFF
--- a/modules/hsm/main.tf
+++ b/modules/hsm/main.tf
@@ -47,16 +47,6 @@ resource "aws_security_group_rule" "hsm-worker-ingress" {
   source_security_group_id = "${var.source_security_group_id}"
 }
 
-# We can only create one HSM in Terraform rather than the multiple we require for high availability as you must create
-# a single HSM, initialise and activate it (which is done manually) before you can create more as they are clones of the
-# first HSM. The other HSMs will need to be created after the Terraform apply
-# Manual steps to initalise and activate the HSM can be followed from
-# https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html onwards
-resource "aws_cloudhsm_v2_hsm" "cloudhsm_v2_hsm" {
-  subnet_id  = "${aws_cloudhsm_v2_cluster.cluster.subnet_ids[0]}"
-  cluster_id = "${aws_cloudhsm_v2_cluster.cluster.cluster_id}"
-}
-
 module "lambda_splunk_forwarder" {
   source = "../lambda_splunk_forwarder"
 
@@ -68,12 +58,4 @@ module "lambda_splunk_forwarder" {
   splunk_hec_token          = "${var.splunk_hec_token}"
   splunk_hec_url            = "${var.splunk_hec_url}"
   splunk_index              = "${var.splunk_index}"
-}
-
-data "aws_network_interface" "hsm" {
-  id = "${aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm.hsm_eni_id}"
-}
-
-output "hsm_ips" {
-  value = ["${data.aws_network_interface.hsm.private_ips}"]
 }

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -163,7 +163,3 @@ output "values" {
   sensitive = true
   value     = "${module.gsp-cluster.values}"
 }
-
-output "hsm_ips" {
-  value = "${module.hsm.hsm_ips}"
-}


### PR DESCRIPTION
# Why

Due to:
https://github.com/terraform-providers/terraform-provider-aws/issues/8648
and the inability to scale an HSM cluster out from terraform it makes
sense to not manage the cloudHSMs from terraform.

# To apply

For each `-deployer` pipeline:
1. Run `deploy` job and hijack the `cluster-state` container
1. `terraform state rm module.hsm.aws_cloudhsm_v2_hsm.cloudhsm_v2_hsm`

Then:
1. Pause all relevant `-deployer` pipelines on https://cd.gds-reliability.engineering/
1. Merge
1. Un-pause all pipelines