### PR TITLE
Add acceptance test for Prometheus and Grafana port forwarding

### DIFF
--- a/docs/gds-supported-platform/prometheus_alert_manager_grafana.md
+++ b/docs/gds-supported-platform/prometheus_alert_manager_grafana.md
@@ -15,41 +15,40 @@ Neither Prometheus nor Grafana are publicly accessible to everyone through the i
 1. Run the following command to get the name of the services and ports that expose Prometheus and Grafana:
 
     ```
-    aws vault exec <AWS_PROFILE_NAME> -- kubectl -n monitoring-system get services
+    aws vault exec <AWS_PROFILE_NAME> -- kubectl -n gsp-system get services
     ```
 
     where `<AWS_PROFILE_NAME>`is your AWS profile name.
 
     In the following example output from this command:
-    - the `monitoring-system-promethe-prometheus` service that exposes Prometheus is on port `9090`
-    - the `monitoring-system-grafana` service that exposes Grafana is on port `80`
+    - the `gsp-prometheus-operator-prometheus` service that exposes Prometheus is on port `9090`
+    - the `gsp-grafana` service that exposes Grafana is on port `80`
 
     ```
-    NAME                                         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
-    monitoring-system-grafana                    ClusterIP   10.3.0.125   <none>        80/TCP     20h
-    monitoring-system-kube-state-metrics         ClusterIP   10.3.0.209   <none>        8080/TCP   20h
-    monitoring-system-promethe-operator          ClusterIP   None         <none>        8080/TCP   20h
-    monitoring-system-promethe-prometheus        ClusterIP   10.3.0.20    <none>        9090/TCP   20h
-    monitoring-system-prometheus-node-exporter   ClusterIP   10.3.0.152   <none>        9100/TCP   20h
-    prometheus-operated                          ClusterIP   None         <none>        9090/TCP   20h
+    NAME                                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
+    gsp-grafana                          ClusterIP   172.20.51.56     <none>        80/TCP                       48d
+    gsp-prometheus-node-exporter         ClusterIP   172.20.154.251   <none>        9100/TCP                     48d
+    gsp-prometheus-operator-operator     ClusterIP   172.20.174.143   <none>        8080/TCP                     48d
+    gsp-prometheus-operator-prometheus   ClusterIP   172.20.11.107    <none>        9090/TCP                     48d
+    prometheus-operated                  ClusterIP   None             <none>        9090/TCP                     48d
     ```
 
 1. Run the following to connect to the service that exposes either Prometheus or Grafana:
 
     ```
-    aws-vault exec <AWS_PROFILE_NAME> -- kubectl port-forward service/<SERVICE_NAME> -n monitoring-system <PORT_1>:<PORT_2>
+    aws-vault exec <AWS_PROFILE_NAME> -- kubectl -n gsp-system port-forward service/<SERVICE_NAME> <LOCAL_PORT>:<FORWARDED_PORT>
     ```
 
     where:
     - `<SERVICE_NAME>` is the name of the service that exposes either Prometheus or Grafana
-    - `<PORT_1>` is a port available on your local machine
-    - `<PORT_2>` is the port that exposes either Prometheus or Grafana
+    - `<LOCAL_PORT>` is a port available on your local machine
+    - `<FORWARDED_PORT>` is the port that exposes either Prometheus or Grafana
 
-1. Go to `http://127.0.0.1:<PORT_1>` to see the interface.
+1. Go to `http://127.0.0.1:<LOCAL_PORT>` to see the interface.
 
     To access Grafana you must also sign in with:
-    - username: admin
-    - password: password
+    - username: `admin`
+    - password: `password`
 
 ## Set up monitoring for your app
 

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -6,6 +6,7 @@ groups:
   - check-canary
   - check-logging
   - check-conformance
+  - check-health-monitoring
 - name: destroy
   jobs:
   - destroy
@@ -336,6 +337,43 @@ check_cloudwatch: &check_cloudwatch
       echo ""
       echo "FAIL: No logs have been detected reaching cloudwatch since $LOGS_SINCE"
       exit 1
+
+check-health-monitoring: &check-health-monitoring
+  platform: linux
+  image_resource: *task_image_resource
+  params:
+    ACCOUNT_ROLE_ARN: ((account-role-arn))
+    AWS_REGION: eu-west-2
+    AWS_DEFAULT_REGION: eu-west-2
+    CLUSTER_NAME: ((cluster-name))
+  run:
+    path: /bin/bash
+    args:
+    - -euo
+    - pipefail
+    - -c
+    - |
+      echo "Assuming AWS deployer role..."
+      AWS_CREDS="$(aws-assume-role $ACCOUNT_ROLE_ARN)"
+      eval "${AWS_CREDS}"
+      echo "Fetching kubeconfig from aws..."
+      aws eks update-kubeconfig --name "${CLUSTER_NAME}" --kubeconfig ./kubeconfig
+      export KUBECONFIG=$(pwd)/kubeconfig
+      # Check Prometheus
+      echo "Port forwarding Prometheus to localhost:9090..."
+      kubectl -n gsp-system port-forward service/gsp-prometheus-operator-prometheus 9090:9090 &
+      sleep 5
+      echo "Curling forwarded port..."
+      curl --silent --show-error --max-time 5 --fail --location "http://127.0.0.1:9090" | grep "<title>Prometheus"
+      echo "Success!"
+      echo "Stopping port forward"
+      kill $(jobs -p)
+      # Check Grafana
+      echo "Port forwarding Grafana to localhost:8080"
+      kubectl -n gsp-system port-forward service/gsp-grafana 8080:80 &
+      sleep 5
+      curl --silent --show-error --max-time 5 --fail --location "http://127.0.0.1:8080" | grep "<title>Grafana</title>"
+      echo "Success!"
 
 drain_cluster_task: &drain_cluster_task
   platform: linux
@@ -679,6 +717,15 @@ jobs:
   - task: run-conformance-tests
     timeout: 15m
     config: *check_conformance
+
+- name: check-health-monitoring
+  plan:
+  - get: cluster-state
+    passed: ["deploy"]
+    trigger: true
+  - task: check-health-monitoring
+    timeout: 10m
+    config: *check-health-monitoring
 
 - name: destroy
   serial: true


### PR DESCRIPTION
Add acceptance test to check that Prometheus and Grafana port forwarding works, as is asserted in our documentation.

Change 'Set up monitoring and alerting' docs to reflect change from `monitoring-system` to `gsp-system`.

Resolves https://github.com/alphagov/gsp/issues/199