### PR TITLE
Default deny-all NetworkPolicy for user namespaces

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -31,6 +31,16 @@ metadata:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: default-deny
+  namespace: {{ .name }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: default-allow-prometheus
   namespace: {{ .name }}
 spec:

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -28,6 +28,22 @@ metadata:
   annotations:
     iam.amazonaws.com/permitted: {{ .permittedRolesRegex | default "^$" | quote }}
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-prometheus
+  namespace: {{ .name }}
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          namespace: gsp-system
+      podSelector:
+        matchLabels:
+          app: prometheus
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
## What

* Adds a default deny-all ingress NetworkPolicy to user namespaces (gsp-system, kube-system, istio-system should be unaffected)
* Add a default-allow rule for prometheus to talk to pods

## Why

* We should require people to be explicit from the start about whitelisting NetworkPolicy
* We need prometheus to be allowed to scrap all the envoy instances (and potentially user instances) so that we can monitor them correctly

## Notes

* proxy-node currently has it's own default deny that is identical to this, we should remove it
* I considered adding a default "allow from istioingress" rule too ... but this didn't feel quite right... this means everyone will need to whitelist istioingress :/