### PR TITLE
allows ingress from ingressgateway to user namespaces by default

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -41,6 +41,24 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: default-allow-ingressgateway
+  namespace: {{ .name }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          istio: ingressgateway
+      namespaceSelector:
+        matchLabels:
+          namespace: istio-system
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: default-allow-prometheus
   namespace: {{ .name }}
 spec:


### PR DESCRIPTION
## What

Allow layer4 traffic from ingressgateway pod by default

## Why

we expect most things to need ingress from ingressgateway so we allow this.

we recently added a default-deny rule, but this broke all ingress (see failing canary)