### PR TITLE
Pass KIAM trust policy JSON into k8s-cluster

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -9,6 +9,7 @@ module "k8s-cluster" {
   ci_worker_count         = "${var.ci_worker_count}"
   ci_worker_instance_type = "${var.ci_worker_instance_type}"
   eks_version             = "${var.eks_version}"
+  trust_kiam_server       = "${data.aws_iam_policy_document.trust_kiam_server.json}"
 
   apiserver_allowed_cidrs = ["${concat(
       formatlist("%s/32", var.egress_ips),

--- a/modules/k8s-cluster/iam.tf
+++ b/modules/k8s-cluster/iam.tf
@@ -81,7 +81,7 @@ resource "aws_iam_role_policy_attachment" "ci-nodes-ssm" {
 resource "aws_iam_role" "aws-service-operator" {
   name               = "${var.cluster_name}-aws-service-operator"
   description        = "Role the AWS Service Operator assumes"
-  assume_role_policy = "${data.aws_iam_policy_document.trust_kiam_server.json}"
+  assume_role_policy = "${var.trust_kiam_server}"
 }
 
 data "aws_iam_policy_document" "aws-service-operator" {

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -41,3 +41,7 @@ variable "ci_worker_count" {
   type    = "string"
   default = "3"
 }
+
+variable "trust_kiam_server" {
+  type = "string"
+}


### PR DESCRIPTION
Otherwise this happens:
`Error: resource 'aws_iam_role.aws-service-operator' config: unknown resource 'data.aws_iam_policy_document.trust_kiam_server' referenced in variable data.aws_iam_policy_document.trust_kiam_server.json`