### PR TITLE
use fork of github-release resource

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -449,10 +449,15 @@ resource_types:
   source:
     repository: concourse/concourse-pipeline-resource
     tag: "2.2.0"
+- name: github-release-fork
+  type: registry-image
+  source:
+    repository: govsvc/github-release-resource
+    tag: temp-fork-pull-85 # see https://github.com/concourse/github-release-resource/pull/85
 
 resources:
 - name: gsp
-  type: github-release
+  type: github-release-fork
   source:
     owner: ((platform-organization))
     repository: ((platform-repository))
@@ -471,7 +476,7 @@ resources:
     branch: ((config-version))
     commit_verification_keys: ((trusted-developer-keys))
 - name: users
-  type: github-release
+  type: github-release-fork
   source:
     owner: ((users-organization))
     repository: ((users-repository))

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -13,6 +13,12 @@ resource_types:
     repository: concourse/concourse-pipeline-resource
     tag: "2.2.0"
 
+- name: github-release-fork
+  type: registry-image
+  source:
+    repository: govsvc/github-release-resource
+    tag: temp-fork-pull-85 # see https://github.com/concourse/github-release-resource/pull/85
+
 resources:
 
 - name: platform
@@ -28,7 +34,7 @@ resources:
     commit_verification_keys: ((trusted-developer-keys))
 
 - name: users
-  type: github-release
+  type: github-release-fork
   source:
     owner: alphagov
     repository: gds-trusted-developers
@@ -72,7 +78,7 @@ resources:
     repository: govsvc/task-toolbox
 
 - name: release
-  type: github-release
+  type: github-release-fork
   source:
     owner: alphagov
     repository: gsp
@@ -81,7 +87,7 @@ resources:
     pre_release: true
 
 - name: pre-release
-  type: github-release
+  type: github-release-fork
   source:
     owner: alphagov
     repository: gsp


### PR DESCRIPTION
there is a bug in the github-release resource that causes it to only
fetch the first "page" of results from the github release (first 30
files) leading to confusing failures where files are missing.

To workaround 30 file limit in the meantime we use a forked build
that bumps the limit to the max allowed for a single page to 100.

There is a PR open upstream to resolve. Once upstream is fixed we should
stop using this fork.