### PR TITLE
Fix gsp-local error due to empty values in harbor-notary-secret.yaml

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/harbor-notary-secret.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/harbor-notary-secret.yaml
@@ -5,10 +5,23 @@ metadata:
   namespace: gsp-system
 data:
   # docs say the keys should be like this:
-  tls.ca: {{ .Values.harbor.notary.tlsCA | b64enc }}
-  tls.crt: {{ .Values.harbor.notary.tlsCert | b64enc }}
-  tls.key: {{ .Values.harbor.notary.tlsKey | b64enc }}
+  {{ if .Values.harbor.notary.tlsCA }}
+    tls.ca: {{ .Values.harbor.notary.tlsCA | b64enc }}
+  {{ end }}
+  {{ if .Values.harbor.notary.tlsCert }}
+    tls.crt: {{ .Values.harbor.notary.tlsCert | b64enc }}
+  {{ end }}
+  {{ if .Values.harbor.notary.tlsKey }}
+    tls.key: {{ .Values.harbor.notary.tlsKey | b64enc }}
+  {{ end }}
+
   # ...but in v1.1.1 of the chart it really expects the keys like this:
-  ca: {{ .Values.harbor.notary.tlsCA | b64enc }}
-  crt: {{ .Values.harbor.notary.tlsCert | b64enc }}
-  key: {{ .Values.harbor.notary.tlsKey | b64enc }}
+  {{ if .Values.harbor.notary.tlsCA }}
+    ca: {{ .Values.harbor.notary.tlsCA | b64enc }}
+  {{ end }}
+  {{ if .Values.harbor.notary.tlsCert }}
+    crt: {{ .Values.harbor.notary.tlsCert | b64enc }}
+  {{ end }}
+  {{ if .Values.harbor.notary.tlsKey }}
+    key: {{ .Values.harbor.notary.tlsKey | b64enc }}
+  {{ end }}


### PR DESCRIPTION
- GSP Local users were getting the following error message due to these
  values being empty:
  ```
  error: error validating "/var/folders/jr/lv1mpg4s6cgby621kx99vjfm0000gr/T/tmp.oZlkGF5l/gsp-cluster/templates/02-gsp-system/harbor-notary-secret.yaml": error validating data: [unknown object type "nil" in Secret.data.ca, unknown object type "nil" in Secret.data.crt, unknown object type "nil" in Secret.data.key, unknown object type "nil" in Secret.data.tls.ca, unknown object type "nil" in Secret.data.tls.crt, unknown object type "nil" in Secret.data.tls.key]
  ```
- The problem is b64enc requires a non-empty string, and it's getting
  just that from charts/gsp-cluster/values.yaml.
- Outside of GSP Local, these values are loaded from Terraform. But
  within GSP Local, Terraform doesn't run.

- Fixes #272.

Co-authored-by: Joakim Kakaei <joakim.kakaei@digital.cabinet-office.gov.uk>