### PR TITLE
Allow non-admin users to get services/proxy

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -61,6 +61,10 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    verbs:
+    - get
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -61,6 +61,10 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    verbs:
+    - get
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Appears to be required to seal secrets.

Might fix #271, should at least give us a different error message.