### PR TITLE
gsp-local: Use VM_DRIVER envvar for non-macOS users to set

### DIFF
--- a/scripts/gsp-local.sh
+++ b/scripts/gsp-local.sh
@@ -99,7 +99,7 @@ minikube start \
 	--memory ${GSP_MEMORY:-8192} \
 	--cpus ${GSP_CPUS:-4} \
 	--disk-size 30g \
-	--vm-driver hyperkit \
+	--vm-driver ${VM_DRIVER:-hyperkit} \
 	--kubernetes-version v1.12.0 \
 	--insecure-registry "registry.local.govsandbox.uk:80" \
 	--profile ${cluster_name}


### PR DESCRIPTION
- Hyperkit is a macOS-only thing. Users on Linux need to use a different
  `--vm-driver` setting for Minikube, either `virtualbox` or `kvm2`.
- I didn't find a good place to put this in the gsp-local docs, so Linux
  users can make do with reading the code when they get the "unsupported
  driver" error by default. ;-)