### PR TITLE
Add parameters to be able to clone private repos over HTTPS

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -255,6 +255,8 @@ spec:
         branch: {{ .branch | default "master" | quote }}
         owner: {{ .owner }}
         repository: {{ .repository }}
+        username: "re-autom8-ci"
+        password: ((github.api-token))
         github_api_token: ((github.api-token))
         access_token: ((github.api-token))
         approvers: ((trusted-developers.github-accounts))


### PR DESCRIPTION
- These need `username` and `password` keys (the password being the
  GitHub API token because 2FA).

Co-authored-by: Philip Potter <philip.potter@digital.cabinet-office.gov.uk>