### PR TITLE
Facilitate basic private docker repos in harbor registry.

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -112,6 +112,15 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: registry-creds
+  namespace: {{ .name }}
+data:
+  .dockerconfigjson: {{ include "dockerconfig.json" $ | b64enc }}
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: cluster
   namespace: {{ .name }}
 data:

--- a/charts/gsp-cluster/templates/_helpers.tpl
+++ b/charts/gsp-cluster/templates/_helpers.tpl
@@ -48,3 +48,17 @@ a way to grab the templated values out.
 {{- define "concourse.namespace.prefix" -}}
 {{- printf "%s-" .Release.Name -}}
 {{- end -}}
+
+{{- define "dockerconfig.creds" -}}
+{{- printf "admin:%s" .Values.harbor.harborAdminPassword | b64enc -}}
+{{- end -}}
+
+{{- define "dockerconfig.json" -}}
+{
+    "auths": {
+        "https://registry.{{ .Values.global.cluster.domain }}/": {
+            "auth": "{{ include "dockerconfig.creds" . }}"
+        }
+    }
+}
+{{- end -}}

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -361,6 +361,7 @@ pipelineOperator:
   concourseInsecureSkipVerify: "false"
 
 harbor:
+  harborAdminPassword: ""
   chartmuseum:
     enabled: false
   logLevel: warn


### PR DESCRIPTION
## Security implications

This only makes them private in the sense that anonymous users are unable
to pull images from that repository; but it does potentially open up a
security hole around the harbor registry's admin credentials, which are
used to deliver this.

If we trust the 2-eyes process, then this shouldn't be a problem.

## To use

* Set `public: false` in the harbor resource type in the build pipelines that build the image you want to release privately
* include an `imagePullSecrets` to the pod template as per [k8s docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) with the secret name of `registry-creds`
