### PR TITLE
Configure canary ServiceMonitor to scrape canary over mTLS

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -117,6 +117,7 @@ prometheus-operator:
       retention: "60d"
       ruleSelectorNilUsesHelmValues: false
       ruleSelector: {}
+      secrets: [ istio.gsp-prometheus-operator-prometheus ]
       serviceMonitorSelectorNilUsesHelmValues: false
       serviceMonitorSelector: {}
       additionalScrapeConfigs:

--- a/components/canary/chart/templates/service-monitor.yaml
+++ b/components/canary/chart/templates/service-monitor.yaml
@@ -11,4 +11,10 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
   - port: {{ .Values.service.port_name }}
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/secrets/istio.gsp-prometheus-operator-prometheus/root-cert.pem
+      certFile: /etc/prometheus/secrets/istio.gsp-prometheus-operator-prometheus/cert-chain.pem
+      keyFile: /etc/prometheus/secrets/istio.gsp-prometheus-operator-prometheus/key.pem
+      insecureSkipVerify: true  # prometheus does not support secure naming.
 {{- end }}


### PR DESCRIPTION
We have meshified the canary, which means that Prometheus has stopped
being able to scrape it.

This fixes that.  The idea seems to be that istio autogenerates a
Secret for prometheus to use for communicating over mTLS, which we can
mount into the prometheus pod in order for it to scrape targets which
are in the service mesh and therefore require mTLS to access.

I cobbled together the ideas from istio/installer; in particular, its [Prometheus](https://github.com/istio/installer/blob/b465c3f0407f45662447292530d5635c22cd8c92/istio-telemetry/prometheus-operator/templates/prometheus.yaml#L19)
shows how to mount the Secret, and [kubernetes-pods-secure-monitor][]
shows how to use the Secret.

(These upstream examples also show how to configure a ServiceMonitor
that will scrape any pod in any namespace with appropriate
annotations; in particular, we could set things up so that, rather
than developers having to set up a ServiceMonitor for their service,
they could instead just annotate their pods with
`prometheus.io/scrape: true`.)

(For a different point of view, though, see
https://github.com/prometheus/prometheus/pull/4131 )

[Prometheus]: https://github.com/istio/installer/blob/b465c3f0407f45662447292530d5635c22cd8c92/istio-telemetry/prometheus-operator/templates/prometheus.yaml#L19
[kubernetes-pods-secure-monitor]: https://github.com/istio/installer/blob/b465c3f0407f45662447292530d5635c22cd8c92/istio-telemetry/prometheus-operator/templates/servicemonitors.yaml#L119-L139