### PR TITLE
Don't run AWS service operator unless it's in AWS

### DIFF
--- a/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-service-operator.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.runningOnAws }}
 apiVersion: v1
 kind: List
 items:
@@ -225,3 +226,4 @@ items:
             - --cluster-name={{ .Values.global.cluster.name }}
             - --region=eu-west-2
             - --account-id={{ .Values.global.account.id }}
+{{ end }}


### PR DESCRIPTION
If we're running locally we don't want to (and can't) run the AWS
service operator.