### PR TITLE
Add timeout for canary deploy

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -144,6 +144,7 @@ spec:
                 ./src/components/canary/chart
 
       - task: deploy-manifests
+        timeout: 2m
         config:
           platform: linux
           image_resource: *task_toolbox


### PR DESCRIPTION
The canary deploy job got stuck for 6 days in sandbox, when normally
it takes ~1m.  This adds a timeout so that it will abort if it doesn't
complete in a timely manner.