### PR TITLE
Make the canary Harbor images private via the pipeline

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -61,6 +61,8 @@ spec:
       source:
         <<: *harbor_source
         repository: registry.((cluster.domain))/gsp/canary
+        harbor:
+          public: "false"
 
     jobs:
     - name: build

--- a/components/canary/chart/templates/deployment.yaml
+++ b/components/canary/chart/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
+      imagePullSecrets:
+      - name: registry-creds
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.canary.image.repository }}:{{ .Values.canary.image.tag }}"


### PR DESCRIPTION
- For testing whether the private thing works.

Co-authored-by: Daniel Blair <daniel.blair@digital.cabinet-office.gov.uk>