### PR TITLE
Put `public: "false"` in the YAML anchor itself

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -16,6 +16,7 @@ spec:
       harbor:
         url: ((harbor.harbor_url))
         prevent_vul: "false"
+        public: "false"
       notary:
         url: ((harbor.notary_url))
         root_key: ((harbor.root_key))
@@ -61,8 +62,6 @@ spec:
       source:
         <<: *harbor_source
         repository: registry.((cluster.domain))/gsp/canary
-        harbor:
-          public: "false"
 
     jobs:
     - name: build


### PR DESCRIPTION
- Then hopefully it gets passed correctly?