### PR TITLE
Create draft releases until everything is signed.

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -91,6 +91,17 @@ resources:
     pre_release: true
     tag_filter: ((github-release-tag-prefix))v([^v].*)
 
+- name: draft-release
+  type: github-release
+  source:
+    owner: alphagov
+    repository: gsp
+    access_token: ((github-api-token))
+    release: false
+    pre_release: false
+    drafts: true
+    tag_filter: ((github-release-tag-prefix))v([^v].*)
+
 jobs:
 
 - name: selfupdate
@@ -379,7 +390,7 @@ jobs:
           echo overrides.yaml
           echo "merging with default values..."
           spruce merge ./platform/pipelines/deployer/deployer.defaults.yaml ./overrides.yaml | tee -a ./deployer-package/deployer.defaults.yaml
-  - put: pre-release
+  - put: draft-release
     params:
       name: version/name
       tag: version/tag
@@ -395,7 +406,7 @@ jobs:
     config:
       platform: linux
       inputs:
-      - name: pre-release
+      - name: draft-release
       outputs:
       - name: signed-release
       params:
@@ -411,7 +422,7 @@ jobs:
           echo "${CLUSTER_PRIVATE_KEY}" > key
           gpg --import key
           echo "signing release tarball..."
-          for file in pre-release/*; do
+          for file in draft-release/*; do
             gpg --armor --detach-sign "$file"
             cp ${file}* signed-release/
           done


### PR DESCRIPTION
# What

Create a draft release until all the files have been signed and are ready for uploading & publishing to avoid the race condition currently inherent in the gsp release pipeline.

# Assumptions

* The `put` for a release (or `pre-release`, or whatever) is "atomic" in the sense that the release isn't published (in a way that another `github-release` resource would `check` it) until all the files are uploaded
* github releases & tags follow the same logic as the resource; specifically: `draft XOR (pre-release OR release)` such that if a `pre-release` is `put` that matches a `draft` release with the same tag the draft disappears

# Known limitations

* If a publish fails (or if some of the builds fail but others succeed) we'll fall foul of concourse's odd caching. Specifically, the version is bumped based on the previous `pre-release` or `release` which would mean duplicate image tags if a release failed somewhere in the pipeline, which would stop downstream triggers. If we need to change it so the version is bumped based on `MAX[latest(draft), latest(pre-release), latest(release)]` we might need to write some magic for that.


Relates to https://trello.com/c/YU171IXr/36-race-condition-in-gsp-release-pipeline