### PR TITLE
Add a CODEOWNERS file to automatically request reviews from teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# See https://help.github.com/en/articles/about-code-owners
+* @alphagov/re-autom8 @alphagov/re-gsp


### PR DESCRIPTION
- Right now, we have nothing apart from the GitHub bot for Slack posting
  in the #re-gsp channel. This way, we can disable that integration and
  get less "immediate-attention" Slack spam.
- These review requests will appear in team members' Review Requested
  list (https://github.com/pulls/review-requested), and they'll get
  email about them.
- As with some other repos that use this pattern, the repo requires two
  reviews so reviewers do have to do a manual step of "re-requesting a
  review from the teams(s)", but that's a two second thing.