### PR TITLE
make bash clearer

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -26,9 +26,9 @@ unpack_release: &unpack_release
       echo "preparing keyring to verify release..."
       echo "${CLUSTER_PUBLIC_KEY}" > key
       gpg --import key
-      gpg --verify gsp/*.tar.gz.asc
+      gpg --verify gsp/source.tar.gz.asc
       echo "unpacking src tarball..."
-      tar -xvf gsp/*.tar.gz -C platform --strip-components=1
+      tar -xvf gsp/source.tar.gz -C platform --strip-components=1
   inputs:
   - name: gsp
   outputs:


### PR DESCRIPTION
it's an oxymoron i know

I got confused by these lines - the release only has one file which
fits each of these wildcards - `source.tar.gz.asc` and `source.tar.gz`
respectively.  I found it confusing that these were wildcards because
it looks like it's trying to validate many signatures and unpack many
tarballs (and there are other tarballs in the release, only with `tgz`
in the name instead of `tar.gz`).

I think it's much clearer to use the literal filenames instead of a
wildcard.