### PR TITLE
Brewfile: Remove aws-vault and the `if OS.mac?` conditional for Casks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,13 +3,11 @@ tap "homebrew/cask"
 
 brew "kubernetes-cli"
 brew "kubernetes-helm"
+brew "linuxbrew/extra/minikube" if OS.linux?
 
 if OS.mac?
   brew "hyperkit"
   brew "docker-machine-driver-hyperkit"
-  cask "aws-vault"
-  cask "minikube"
-else
-  brew "linuxbrew/extra/aws-vault"
-  brew "linuxbrew/extra/minikube"
 end
+
+cask "minikube"


### PR DESCRIPTION
- aws-vault was supposed to have been removed in
  c7c6a00513dd37110e0dd7b8cfc4b19c5a76c96b.
- Casks are now automatically skipped on Linux, so we don't need this
  ugly `if OS.mac?` stuff for them.