### PR TITLE
Remove hardcoded approvers (just farms) and 0 required approvals from config deployment

### DIFF
--- a/hack/set-deployer-pipeline.sh
+++ b/hack/set-deployer-pipeline.sh
@@ -17,7 +17,7 @@ $FLY_BIN -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
 	--config "pipelines/deployer/deployer.yaml" \
 	--load-vars-from "pipelines/deployer/deployer.defaults.yaml" \
 	--load-vars-from "${CLUSTER_CONFIG}" \
-	--yaml-var 'github-approvers=[]' \
+	--yaml-var 'config-approvers=[]' \
 	--yaml-var 'trusted-developer-keys=[]' \
 	--check-creds "$@"
 

--- a/hack/set-release-pipeline.sh
+++ b/hack/set-release-pipeline.sh
@@ -17,7 +17,7 @@ fi
 echo "generating initial list of trusted developers for releases..."
 
 approvers="/tmp/gsp-release-approvers.yaml"
-echo -n "github-approvers: " > "${approvers}"
+echo -n "config-approvers: " > "${approvers}"
 yq . ${USER_CONFIGS}/*.yaml \
 	| jq -c -s "[.[].github] | unique | sort" \
 	>> "${approvers}"

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -17,7 +17,7 @@ users-trigger: true
 
 disable-destroy: true
 
-github-approval-count: 2
+config-approval-count: 2
 
 task-toolbox-image: govsvc/task-toolbox
 task-toolbox-tag: latest

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -17,6 +17,7 @@ users-trigger: true
 
 disable-destroy: true
 
+config-approvers: []
 config-approval-count: 2
 
 task-toolbox-image: govsvc/task-toolbox

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -488,8 +488,8 @@ resources:
     organization: ((config-organization))
     repository: ((config-repository))
     github_api_token: ((github-api-token))
-    approvers: ((github-approvers))
-    required_approval_count: ((github-approval-count))
+    approvers: ((config-approvers))
+    required_approval_count: ((config-approval-count))
     branch: ((config-version))
     commit_verification_keys: ((trusted-developer-keys))
 - name: users

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -488,8 +488,8 @@ resources:
     organization: ((config-organization))
     repository: ((config-repository))
     github_api_token: ((github-api-token))
-    approvers: [chrisfarms]
-    required_approval_count: 0
+    approvers: ((github-approvers))
+    required_approval_count: ((github-approval-count))
     branch: ((config-version))
     commit_verification_keys: ((trusted-developer-keys))
 - name: users

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -20,8 +20,8 @@ github-client-secret: "NOTASECRET"
 github-client-id: "NOTID"
 eks-version: "1.12"
 trusted-developer-keys: []
-github-approval-count: 0
-github-approvers: ["chrisfarms"]
+config-approval-count: 0
+config-approvers: ["chrisfarms"]
 disable-destroy: false
 worker-instance-type: t3.medium
 worker-count: 3

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -71,7 +71,7 @@ resources:
     paths:
       - components/concourse-task-toolbox-source
     github_api_token: ((github-api-token))
-    approvers: ((github-approvers))
+    approvers: ((config-approvers))
     required_approval_count: 1
     branch: ((branch))
     commit_verification_keys: ((trusted-developer-keys))

--- a/pipelines/tasks/generate-trusted-contributors.yaml
+++ b/pipelines/tasks/generate-trusted-contributors.yaml
@@ -27,7 +27,7 @@ run:
     echo "generating list of pipeline approvers..."
     trusted_approvers="trusted-contributors/github.vars.yaml"
     trusted_keys="trusted-contributors/keys.vars.yaml"
-    echo -n "github-approvers: " > "${trusted_approvers}"
+    echo -n "config-approvers: " > "${trusted_approvers}"
     yq '.[]' "users/${ACCOUNT_NAME}-trusted-developers.yaml" \
       | jq -c -s "[.[] | .github] | unique | sort" \
       >> "${trusted_approvers}"


### PR DESCRIPTION
I have no idea how this is supposed to work but I'm pretty sure the status quo is wrong.
Not sure how github-approvers is set.