### PR TITLE
Remove dead link to GSP Architecture Local Environment docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,6 @@
 - [GSP Architecture](/docs/architecture/gsp-architecture.md)
 - [GSP Architecture Continuous Deployment](/docs/architecture/gsp-architecture-continuous-deployment.md)
 - [GSP Architecture Cloud Infrastructure](/docs/architecture/gsp-architecture-cloud-infrastructure.md)
-- [GSP Architecture Local Environment](/docs/architecture/gsp-local.md)
 - [GSP Architecture Overview](/docs/architecture/gsp-architecture-overview.md)
 - [GSP Terraform](gds-supported-platform/terraform.md)
 - [Incident Reports](incident-reports)

--- a/docs/architecture/gsp-architecture.md
+++ b/docs/architecture/gsp-architecture.md
@@ -4,6 +4,5 @@ The architecture of the GDS Supported Platform
 
 1. [Overview](gsp-architecture-overview.md)
 1. [GSP Cloud Infrastructure](gsp-architecture-cloud-infrastructure.md)
-1. [GSP Local environment](gsp-local.md)
 1. [Continuous Deployment](gsp-architecture-continuous-deployment.md)
 1. [Architecture Decision Records](adr)


### PR DESCRIPTION
- Closes #305.
- This link is broken.
- The most likely replacement looks to be
  https://github.com/alphagov/gsp/blob/master/docs/architecture/gsp-architecture-local.md,
  but that is blank.
- So, just remove the link at all.