### PR TITLE
Fix name collision for ClusterRoleBinding

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -88,7 +88,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     name: dev
-  name: {{ .Values.global.account.name }}-viewer
+  name: {{ .Values.global.account.name }}-dev-viewer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -88,7 +88,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     name: sre
-  name: {{ .Values.global.account.name }}-viewer
+  name: {{ .Values.global.account.name }}-sre-viewer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Without this change either `dev` or `sre` roles would have `viewer`
access but not both.