### PR TITLE
bump pipeline-operator resource limits

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
@@ -51,10 +51,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 30Mi
         ports:
         - containerPort: 9876
           name: webhook-server


### PR DESCRIPTION
This keeps getting OOMKilled, even though there's plenty of space on
the node.  I've also seen its working set grow above 30Mb in the
metrics.  So I think we should bump the limit upwards.