### PR TITLE
Revert "bump concourse postgres size"

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -349,9 +349,6 @@ concourse:
   persistence:
     worker:
       size: 64Gi
-  postgresql:
-    persistence:
-      size: 64Gi
 
 pipelineOperator:
   service:


### PR DESCRIPTION
Reverts alphagov/gsp#311

This failed with an error that included the text
```
for: "manifests/gsp-cluster/charts/concourse/charts/postgresql/templates/pvc.yaml": persistentvolumeclaims "gsp-postgresql" is forbidden: only dynamically provisioned pvc can be resized and the storageclass that provisions the pvc must support resize
```
😒 

So postgres is still broken but it's not clear how to resize it. Reverting to at least get back to as-broken-as-before.