### PR TITLE
Allow the default storage class to support dynamic scaling of volumes.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: gp2
+parameters:
+  fsType: ext4
+  type: gp2
+provisioner: kubernetes.io/aws-ebs
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true


### PR DESCRIPTION
By default dynamic scaling is not enabled. But in EKS (which is EBS-backed) persistent volumes can be scaled.