### PR TITLE
Revert "Revert "bump concourse postgres size""

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -349,6 +349,9 @@ concourse:
   persistence:
     worker:
       size: 64Gi
+  postgresql:
+    persistence:
+      size: 64Gi
 
 pipelineOperator:
   service:


### PR DESCRIPTION
Reverts alphagov/gsp#312

The storage class has been updated to support dynamic resizing now. This might now work.