### PR TITLE
Allow specifying the location of `fly` as `FLY_BIN` in hack/pipeline scripts

### DIFF
--- a/hack/set-deployer-pipeline.sh
+++ b/hack/set-deployer-pipeline.sh
@@ -4,15 +4,16 @@ set -eu -o pipefail
 
 : "${CLUSTER_CONFIG:?}"
 
+FLY_BIN=${FLY_BIN:-fly}
 CLUSTER_NAME=$(yq -r '.["cluster-name"]' < ${CLUSTER_CONFIG})
 PIPELINE_NAME=$(yq -r '.["concourse-pipeline-name"]' < ${CLUSTER_CONFIG})
 
 echo "generating approvers for ${CLUSTER_NAME}..."
 
 
-fly -t cd-gsp sync
+$FLY_BIN -t cd-gsp sync
 
-fly -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
+$FLY_BIN -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
 	--config "pipelines/deployer/deployer.yaml" \
 	--load-vars-from "pipelines/deployer/deployer.defaults.yaml" \
 	--load-vars-from "${CLUSTER_CONFIG}" \
@@ -20,5 +21,5 @@ fly -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
 	--yaml-var 'trusted-developer-keys=[]' \
 	--check-creds "$@"
 
-fly -t cd-gsp expose-pipeline -p "${PIPELINE_NAME}"
+$FLY_BIN -t cd-gsp expose-pipeline -p "${PIPELINE_NAME}"
 

--- a/hack/set-release-pipeline.sh
+++ b/hack/set-release-pipeline.sh
@@ -4,6 +4,7 @@ set -eu -o pipefail
 
 : "${USER_CONFIGS:?}"
 
+FLY_BIN=${FLY_BIN:-fly}
 PIPELINE_NAME="release"
 
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
@@ -27,9 +28,9 @@ yq . ${USER_CONFIGS}/*.yaml \
 	| jq -c -s '[ .[].pub ] | sort' \
 	>> "${trusted}"
 
-fly -t cd-gsp sync
+$FLY_BIN -t cd-gsp sync
 
-fly -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
+$FLY_BIN -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
 	--config "pipelines/release/release.yaml" \
 	--load-vars-from "${approvers}" \
 	--load-vars-from "${trusted}" \
@@ -38,4 +39,4 @@ fly -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
 	--var "github-release-tag-prefix=gsp-" \
 	--check-creds "$@"
 
-fly -t cd-gsp expose-pipeline -p "${PIPELINE_NAME}"
+$FLY_BIN -t cd-gsp expose-pipeline -p "${PIPELINE_NAME}"


### PR DESCRIPTION
- The multi-tenant Concourse is v4, and the GSP Concourses are v5.
- Fly does not like mismatching major versions.
- I have got around needing to `fly` in both Concourses by downloading
  v4's `fly` and using it as `fly4`, while keeping v5's fly as `fly`.
- If `FLY_BIN` is unset, use `fly`.