### PR TITLE
[prometheus] Remove `deployment: gsp` external label

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -112,7 +112,6 @@ prometheus-operator:
   prometheus:
     prometheusSpec:
       externalLabels:
-        deployment: gsp
         product: local
       retention: "60d"
       ruleSelectorNilUsesHelmValues: false

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -147,7 +147,6 @@ prometheus-operator:
       externalLabels:
         clustername: ${cluster_domain}
         product: ${account_name}
-        deployment: gsp
       additionalAlertManagerConfigs:
       - static_configs:
         - targets:


### PR DESCRIPTION
This was used for routing alerts, but
alphagov/prometheus-aws-configuration-beta#339 changed this to match
on `clustername` instead.

Furthermore, this external label conflicts with metrics generated
relating to Deployment instances, which get given a `deployment` label
identifying the Deployment in question.

It's best to remove this external label entirely.