### PR TITLE
Add permissions to allow SREs to delete higher-order controller resources.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -6,7 +6,24 @@ metadata:
   name: sre
 rules:
   - apiGroups: [""]
-    resources: ["pods"]
+    resources:
+    - configmaps
+    - pods
+    - secrets
+    - services
+    verbs:
+    - delete
+  - apiGroups: ["apps"]
+    resources:
+    - deployments
+    - replicasets
+    - statefulsets
+    verbs:
+    - delete
+  - apiGroups: ["extensions"]
+    resources:
+    - deployments
+    - replicasets
     verbs:
     - delete
   - apiGroups: [""]


### PR DESCRIPTION
Before merging, some thoughts:

* This grants delete permissions in all namespaces. We may want to exclude `kube-system`, `istio-system` and `gsp-system` (which will be a fair amount more complex to achieve - we'd need to create another `ClusterRole` and use `RoleBinding` entries in the `namespace.yaml` magic).
* We can delete `secrets` but not list them. We might want to add `"list"` for `secrets`.
