### PR TITLE
deployer pipeline: destroy user-state in destroy group

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -787,6 +787,6 @@ jobs:
     params:
       env_name: ((account-name))
       terraform_source: users-terraform
-      action: apply
+      action: destroy
     get_params:
-      action: apply
+      action: destroy


### PR DESCRIPTION
Noticed in the review of #302 by @chrisfarms 