### PR TITLE
[canary] don't re-download our docker image after uploading it

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -71,6 +71,7 @@ spec:
         trigger: true
       - get: src
       - put: image
+        get_params: {skip_download: true}
         params:
           build: src/components/canary
           dockerfile: src/components/canary/Dockerfile


### PR DESCRIPTION
Based on something I saw in the verify-proxy-node pipeline.

I don't think this is a big improvement, except insofar as it serves
as a good example to follow