### PR TITLE
set prometheus query timeout to 30s

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -119,6 +119,8 @@ prometheus-operator:
       secrets: [ istio.gsp-prometheus-operator-prometheus ]
       serviceMonitorSelectorNilUsesHelmValues: false
       serviceMonitorSelector: {}
+      query:
+        timeout: 30s
       additionalScrapeConfigs:
       - job_name: 'istio-mesh'
         kubernetes_sd_configs:


### PR DESCRIPTION
I accidentally broke prometheus with an expensive query :(

We previously set a query timeout for Observe in
alphagov/prometheus-aws-configuration-beta@92e81ce7406075584113d739e3fc09a63c6a42ef
and 30 seconds seems to be going well there.