### PR TITLE
Remove path from namespace roles

### DIFF
--- a/components/concourse-task-toolbox/bin/generate-namespace-roles-terraform.py
+++ b/components/concourse-task-toolbox/bin/generate-namespace-roles-terraform.py
@@ -53,8 +53,7 @@ for namespace in in_data.get('namespaces', []):
                         "AWS": genResourceID("arn", "aws", "iam", "", args.account_id, "role/${var.cluster_name}_kiam_server", delimiter=":")
                     }
                 }
-            }),
-            "path": "/gsp/${var.cluster_name}/namespaceroles/"
+            })
         }
         for policy in role['policies']:
             policy_name = genResourceID("${var.cluster_name}", "namespace", namespace['name'], policy)


### PR DESCRIPTION
We found that the path is actually included in the resource ARN.
That's fine until you consider that to call the STS AssumeRole API, you need
to provide that full ARN - and so we'd need to put the path in our kubeyaml
namespace permitted roles regexes as well as pod definitions.

The path doesn't really do anything anyway so let's just get rid of it.