### PR TITLE
Add diskSizeGB as a user-configurable option in the Postgres CRD

### DIFF
--- a/components/service-operator/README.md
+++ b/components/service-operator/README.md
@@ -8,6 +8,7 @@ Given a configuration file of the form:
   kind: Postgres
 spec:
   aws:
+    diskSizeGB: 150
     instanceType: db.m5.large
 ```
 

--- a/components/service-operator/api/v1beta1/postgres_types.go
+++ b/components/service-operator/api/v1beta1/postgres_types.go
@@ -24,6 +24,7 @@ import (
 
 // AWS allows specifying configuration for the Postgres RDS instance
 type AWS struct {
+	DiskSizeGB   int    `json:"diskSizeGB,omitempty"`
 	InstanceType string `json:"instanceType,omitempty"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/alphagov/gsp
 
 go 1.12
+
+require github.com/alphagov/gsp/components/service-operator v0.0.0-20190806142453-a2e2bcbc39d9 // indirect


### PR DESCRIPTION
- This will look something like this, with all `diskSize` values in
  gigabytes:
  ```yaml
  ...
  aws:
    diskSizeGB: 150
    instanceType: db.m5.large
  ```

This comes from @philandstuff on Slack (paraphrased):
> do we need something around storage size? the disk for DCS needs to be large