### PR TITLE
Create an NLB for the worker nodes

### DIFF
--- a/docs/architecture/adr/ADR033-nlb-for-mtls.md
+++ b/docs/architecture/adr/ADR033-nlb-for-mtls.md
@@ -1,0 +1,31 @@
+# ADR033: NLB for mTLS
+
+## Status
+
+Accepted
+
+## Context
+
+Verify's [doc-checking service](https://github.com/alphagov/doc-checking) is
+secured in part using mTLS. Currently, our clusters are fronted by ALBs which
+cannot provide mTLS.
+
+The doc-checking service currently runs an nginx that provides the mTLS
+functionality. In order for GSP to be able to allow something within the
+cluster to perform mTLS we must run a load balancer that forwards unaltered TCP
+packets in addition to, or instead of an ALB.
+
+## Decision
+
+We will optionally create and run an NLB in addition to the current ALB for
+clusters that have a requirement to terminate their own TLS. This NLB will be
+available at `nlb.$CLUSTER_DOMAIN`.
+
+## Consequences
+
+In some of our clusters we will be running two public load balancers. This may
+be confusing or unexpected.
+
+The certificates in use for mTLS will be managed outside of ACM. This means any
+certificates will have to manually rotated unless we decide to start running
+`cert-manager` again.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -34,3 +34,4 @@ We document our decisions using [Architecture Decision Records](https://github.c
 - [ADR #029 - Pull based Continuous delivery tools](ADR029-continuous-delivery-tools.md)
 - [ADR #030 - AWS Service Operator](ADR030-aws-service-operator.md)
 - [ADR #031 - Postgres](ADR031-postgres.md)
+- [ADR #033 - NLB for mTLS](ADR033-nlb-for-mtls.md)

--- a/modules/gsp-cluster/nlb.tf
+++ b/modules/gsp-cluster/nlb.tf
@@ -1,0 +1,47 @@
+resource "aws_lb" "ingress-nlb" {
+  count = "${var.enable_nlb == 1 ? 1 : 0 }"
+
+  name               = "${var.cluster_name}-ingress-nlb"
+  load_balancer_type = "network"
+
+  subnet_mapping {
+    subnet_id = "${var.public_subnet_ids[0]}"
+  }
+
+  subnet_mapping {
+    subnet_id = "${var.public_subnet_ids[1]}"
+  }
+
+  subnet_mapping {
+    subnet_id = "${var.public_subnet_ids[2]}"
+  }
+
+  tags = "${map("Name", "${var.cluster_name}-ingress")}"
+}
+
+resource "aws_lb_listener" "ingress-nlb" {
+  count = "${var.enable_nlb == 1 ? 1 : 0 }"
+
+  load_balancer_arn = "${aws_lb.ingress.arn}"
+  protocol          = "TCP"
+  port              = "443"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = "${module.k8s-cluster.worker_tcp_target_group_arn}"
+  }
+}
+
+resource "aws_route53_record" "ingress-nlb" {
+  count = "${var.enable_nlb == 1 ? 1 : 0 }"
+
+  zone_id = "${var.cluster_domain_id}"
+  name    = "nlb.${var.cluster_domain}."
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.ingress-nlb.dns_name}"
+    zone_id                = "${aws_lb.ingress-nlb.zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -179,3 +179,9 @@ variable "concourse_main_team_github_teams" {
   default     = ["alphagov:re-gsp"]
   description = "the list of github teams authorized to view the concourse 'main' team"
 }
+
+variable "enable_nlb" {
+  default = "0"
+  type = "string"
+  description = "create an NLB for the worker nodes"
+}

--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -280,6 +280,13 @@ Resources:
       Protocol: HTTP
       VpcId: !Ref VpcId
 
+  TCPTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: 31390
+      Protocol: TCP
+      VpcId: !Ref VpcId
+
   NodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
@@ -290,6 +297,7 @@ Resources:
       VPCZoneIdentifier: !Ref Subnets
       TargetGroupARNs:
         - !Ref HTTPTargetGroup
+        - !Ref TCPTargetGroup
       Tags:
         - Key: Name
           Value: !Sub ${ClusterName}-${NodeGroupName}
@@ -341,4 +349,8 @@ Outputs:
 
   HTTPTargetGroup:
     Description: A target group to node port 31380
+    Value: !Ref HTTPTargetGroup
+
+  TCPTargetGroup:
+    Description: A target group to node port 31390
     Value: !Ref HTTPTargetGroup

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -18,6 +18,10 @@ output "worker_http_target_group_arn" {
   value = "${aws_cloudformation_stack.worker-nodes.outputs["HTTPTargetGroup"]}"
 }
 
+output "worker_tcp_target_group_arn" {
+  value = "${aws_cloudformation_stack.worker-nodes.outputs["TCPTargetGroup"]}"
+}
+
 output "eks-log-group-arn" {
   value = "${aws_cloudwatch_log_group.eks.arn}"
 }

--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -42,6 +42,17 @@ resource "aws_security_group_rule" "worker-nodes-from-vpc" {
   cidr_blocks = ["${data.aws_vpc.private.cidr_block}"]
 }
 
+resource "aws_security_group_rule" "worker-nodes-from-public" {
+  security_group_id = "${aws_cloudformation_stack.worker-nodes.outputs["NodeSecurityGroup"]}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 31390
+  to_port   = 31390
+
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group_rule" "kiam-server-from-vpc" {
   security_group_id = "${aws_cloudformation_stack.kiam-server-nodes.outputs["NodeSecurityGroup"]}"
 

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -553,6 +553,7 @@ resources:
       eks_version: ((eks-version))
       worker_instance_type: ((worker-instance-type))
       worker_count: ((worker-count))
+      enable_nlb: ((enable-nlb))
       ci_worker_instance_type: ((ci-worker-instance-type))
       ci_worker_count: ((ci-worker-count))
 - name: user-state


### PR DESCRIPTION
Some clusters run services that need to terminate their own TLS, or more
specifically mTLS. The ALB doesn't support mTLS which is why it has to
be done within the cluster. This change allows services within the
cluster to terminate their own TLS, probably by using Istio.