### PR TITLE
Double the size of the Concourse worker persistent volume

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -347,7 +347,7 @@ concourse:
       enableTeamAuditing: true
   persistence:
     worker:
-      size: 64Gi
+      size: 128Gi
   postgresql:
     persistence:
       size: 64Gi


### PR DESCRIPTION
- This is going from 64G to 128G because we need more space.