### PR TITLE
Remove attempt to segregate tenants SQS access

### DIFF
--- a/modules/gsp-namespace-policies/iam.tf
+++ b/modules/gsp-namespace-policies/iam.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "namespace-sqs" {
       "sqs:DeleteMessage"
     ]
 
-    resources = ["arn:aws:sqs:*:${var.account_id}:${var.cluster_name}-sqsqueue-${var.namespace_name}-*"]
+    resources = ["arn:aws:sqs:*:${var.account_id}:${var.cluster_name}-sqsqueue-*"]
   }
 }
 


### PR DESCRIPTION
This turns out not to work due to how AWS Service Operator names things.

We intend to replace the whole thing with one that better meets our needs.

For now this should do everything needed with the first couple of tenants.