### PR TITLE
Add docs about how to resize volumes in GSP (example: Concourse Workers)

### DIFF
--- a/docs/gds-supported-platform/resizing-persistent-volumes.md
+++ b/docs/gds-supported-platform/resizing-persistent-volumes.md
@@ -1,0 +1,94 @@
+# Resizing persistent volumes
+
+You may need to resize your persistent volumes as your needs change.
+
+As an example, we're going to double the space on the Concourse Worker
+persistent volumes - from 64GiB to 128GiB. Replace
+`gsp-concourse-worker` with the name of the resource you want to
+resize the volume for.
+
+1. Make a change to `charts/gsp-system/values.yml` with your desired
+   sizing, like [in PR 343](https://github.com/alphagov/gsp/pull/343):
+
+```yaml
+...
+persistence:
+  worker:
+    size: 128Gi
+```
+
+1. When merged, the PR will be released to sandbox. Changes must pass
+   through sandbox via the full release process to make sure we haven't
+   broken anything before going to the Verify cluster.
+
+1. Pods in StatefulSets each have a volume. For Kubernetes to be able
+   to resize the volumes, we need to detach them from the pods, by
+   destroying the StatefulSet.
+
+   You should destroy the StatefulSet when the Concourse release pipeline starts to fail. You will see an error message similar to:
+
+    > The StatefulSet “gsp-concourse-worker” is invalid: spec:
+    > Forbidden: updates to statefulset spec for fields other than
+    > ‘replicas’, ‘template’, and ‘updateStrategy’ are forbidden
+
+   To destroy the StatefulSet, run:
+
+   ```sh
+   $ gds sandbox kubectl -n gsp-system delete statefulset --cascade=false gsp-concourse-worker
+   ```
+
+   The `--cascade=false` flag makes sure that you do not delete the pods inside the StatefulSet.
+
+   The `-deployer` pipeline will re-apply the StatefulSet. This will
+   intentionally roll all the associated pods.
+
+1. Once the pods are in a `Running` state, edit the
+   `PersisentVolumeClaim`s manually. Kubernetes currently doesn't support online resizing of the persistent volumes, so we need to work around it manually.
+
+    - Find the name of the claims you want to delete. In this example,
+      we want the three `concourse-worker`s.
+
+      ```sh
+      $ gds sandbox kubectl -n gsp-system get persistentvolumeclaim
+      NAME                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+      concourse-work-dir-gsp-concourse-worker-0   Bound    pvc-a633fb0a-76fe-11e9-bbf3-0ae9bf7a1ac0   64Gi      RWO            gp2            84d
+      concourse-work-dir-gsp-concourse-worker-1   Bound    pvc-a6366add-76fe-11e9-bbf3-0ae9bf7a1ac0   64Gi      RWO            gp2            84d
+      concourse-work-dir-gsp-concourse-worker-2   Bound    pvc-a6386683-76fe-11e9-bbf3-0ae9bf7a1ac0   64Gi      RWO            gp2            84d
+      ```
+
+    - For each claim, run:
+
+      ```sh
+      $ gds sandbox kubectl -n gsp-system edit persistentvolumeclaim concourse-work-dir-gsp-concourse-worker-0
+      $ gds sandbox kubectl -n gsp-system edit persistentvolumeclaim concourse-work-dir-gsp-concourse-worker-1
+      $ gds sandbox kubectl -n gsp-system edit persistentvolumeclaim concourse-work-dir-gsp-concourse-worker-2
+      ```
+
+      This will open `$EDITOR`. Update
+      `.spec.resources.requests.storage` to the desired size, then
+      save.
+
+1. Run `gds sandbox kubectl -n gsp-system get persistentvolumeclaim`
+   to check that your volumes have resized as expected. There should
+   be the same number of volumes as you resized.
+
+1. Finally, delete each pod in turn (it will be recreated by the
+   StatefulSet), allowing the volume resize in AWS to proceed.
+
+   ```sh
+   $ gds sandbox kubectl -n gsp-system get pods
+   NAME                                                READY   STATUS      RESTARTS   AGE
+   gsp-concourse-worker-0                              1/1     Running     0          3m13s
+   gsp-concourse-worker-1                              1/1     Running     0          4m20s
+   gsp-concourse-worker-2                              1/1     Running     0          5m11s
+   ...
+   $ gds sandbox kubectl -n gsp-system get persistentvolumeclaims
+   NAME                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+   concourse-work-dir-gsp-concourse-worker-0   Bound    pvc-a633fb0a-76fe-11e9-bbf3-0ae9bf7a1ac0   128Gi      RWO            gp2            84d
+   concourse-work-dir-gsp-concourse-worker-1   Bound    pvc-a6366add-76fe-11e9-bbf3-0ae9bf7a1ac0   128Gi      RWO            gp2            84d
+   concourse-work-dir-gsp-concourse-worker-2   Bound    pvc-a6386683-76fe-11e9-bbf3-0ae9bf7a1ac0   128Gi      RWO            gp2            84d
+   ```
+
+1. Repeat steps 3-6 for the Verify cluster, with the additional step
+   of making the pre-release a full release in the `alphagov/gsp`
+   GitHub Releases page.


### PR DESCRIPTION
- This was a long and manual process, with lots of waiting for pipelines
  to run. Here are some words to tell people what to do next time a disk
  fills up.