### PR TITLE
Attach listener to the correct load balancer

### DIFF
--- a/modules/gsp-cluster/nlb.tf
+++ b/modules/gsp-cluster/nlb.tf
@@ -22,7 +22,7 @@ resource "aws_lb" "ingress-nlb" {
 resource "aws_lb_listener" "ingress-nlb" {
   count = "${var.enable_nlb == 1 ? 1 : 0 }"
 
-  load_balancer_arn = "${aws_lb.ingress.arn}"
+  load_balancer_arn = "${aws_lb.ingress-nlb.arn}"
   protocol          = "TCP"
   port              = "443"
 


### PR DESCRIPTION
We were accidentally attaching to the ALB rather than the NLB:

```
Error: Error applying plan:

1 error(s) occurred:

* module.gsp-cluster.aws_lb_listener.ingress-nlb: 1 error(s) occurred:

* aws_lb_listener.ingress-nlb: Error creating LB Listener: ValidationError: Listener protocol 'TCP' must be one of 'HTTP, HTTPS'
```