### PR TITLE
Allow Metadata endpoints from KIAM

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -90,6 +90,7 @@ kiam:
       caFileName: ca.pem
     log:
       level: info
+    whiteListRouteRegexp: "^(/latest/meta-data/placement/availability-zone)$"
     tolerations:
     - key: node-role.kubernetes.io/ci
       effect: NoSchedule


### PR DESCRIPTION
## What

A while back, KIAM added a support for `whiteListRouteRegexp` value,
disallowing by default all access to the metadata endpoint. We have not
been affected by this thus yet, as we either had an older version of
KIAM installed or simply didn't need it.

The GSP Service Operator, will require to find out what region is it
located in, and therefore is making a call to the metadata endpoint,
which KIAM is rightfully rejecting.

We've whitelisted the bare minimum we think will be a common
requirement, such as AZs (that includes region) and Public IP.

These are based on the public [AWS documentation][1] and could grow over
time.

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html

## How to review

- Sanity check

I haven't tested this.