### PR TITLE
Remove delete of istio-cni resources.

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -218,7 +218,6 @@ apply_cluster_chart: &apply_cluster_chart
         --values config/${CONFIG_VALUES_PATH} \
         --set global.runningOnAws=true \
         gsp/gsp-istio-*.tgz
-      kubectl delete -R -f manifests/gsp-istio/charts/istio-cni
       rm -rf manifests/gsp-istio/charts/istio-cni
       helm template \
         --name istio \


### PR DESCRIPTION
This was a transient change required during a migration to a new version
of istio. So, once all relevant clusters have been upgraded this can be
rolled out.