### PR TITLE
Add more permissions to Operator's role

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -26,6 +26,16 @@ data "aws_iam_policy_document" "service-operator" {
 
   statement {
     actions = [
+      "ec2:DescribeAccountAttributes",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
       "s3:GetObject",
       "s3:PutObject",
     ]


### PR DESCRIPTION
The way CloudFormation works, is it will run various commands on our
behalf. It requires access to ec2:DescribeAccountAttributes in order to
get RDS quotas...

Sad times.