### PR TITLE
This is to fix a GSP-local installation. 

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.runningOnAws }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -11,3 +12,4 @@ provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
+{{ end }}


### PR DESCRIPTION
A current local installation script never completes due to multiple StorageClasses definied as a default. Follow error(s) presented during install:

Error from server (Forbidden): error when creating "/var/folders/50/gkvw0hn95x30pmghtc5jf_tc001qqh/T/tmp.6Rv20YrN/gsp-cluster/charts/harbor/templates/jobservice/jobservice-pvc.yaml": persistentvolumeclaims "gsp-harbor-jobservice" is forbidden: Internal error occurred: 2 default StorageClasses were found
Error from server (Forbidden): error when creating "/var/folders/50/gkvw0hn95x30pmghtc5jf_tc001qqh/T/tmp.6Rv20YrN/gsp-cluster/charts/harbor/templates/registry/registry-pvc.yaml": persistentvolumeclaims "gsp-harbor-registry" is forbidden: Internal error occurred: 2 default StorageClasses were found

by Sebastian Szypowicz, Paul Dougan