### PR TITLE
Let operator use Describe* permissions

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "service-operator" {
 
   statement {
     actions = [
-      "ec2:DescribeAccountAttributes",
+      "ec2:Describe*",
     ]
 
     resources = [


### PR DESCRIPTION
- This effectively lets the operator have fully read access on the
  ec2:Describe* perms as it checks various weird stuff like security
groups too
- Given we are eventually probably going to end up giving this IAM
  access, read access to ec2 feels like not a huge leap