### PR TITLE
Bump instance sizes for workers from t2.small to t3.medium

### DIFF
--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -57,7 +57,7 @@ variable "worker_count" {
 
 variable "worker_instance_type" {
   type    = "string"
-  default = "t2.small"
+  default = "t3.medium"
 }
 
 variable "ci_worker_count" {
@@ -181,7 +181,7 @@ variable "concourse_main_team_github_teams" {
 }
 
 variable "enable_nlb" {
-  default = "0"
-  type = "string"
+  default     = "0"
+  type        = "string"
   description = "create an NLB for the worker nodes"
 }

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -76,7 +76,7 @@ resource "aws_cloudformation_stack" "kiam-server-nodes" {
     NodeAutoScalingGroupMinSize         = "2"
     NodeAutoScalingGroupDesiredCapacity = "2"
     NodeAutoScalingGroupMaxSize         = "3"
-    NodeInstanceType                    = "t2.small"
+    NodeInstanceType                    = "t3.medium"
     NodeImageId                         = "ami-0bc8d0262346bd65e"
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/cluster-management --register-with-taints=node-role.kubernetes.io/cluster-management=:NoSchedule --event-qps=0\""

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -24,7 +24,7 @@ variable "eks_version" {
 
 variable "worker_instance_type" {
   type    = "string"
-  default = "t2.small"
+  default = "t3.medium"
 }
 
 variable "worker_count" {
@@ -34,7 +34,7 @@ variable "worker_count" {
 
 variable "ci_worker_instance_type" {
   type    = "string"
-  default = "t2.small"
+  default = "t3.medium"
 }
 
 variable "ci_worker_count" {


### PR DESCRIPTION
- Things are very stretched on 1 CPU and 2G RAM. Double the size to 2
  CPUs and 4G RAM, and use the more modern instance class.

https://trello.com/c/xazDafPj/88-increase-our-provisioning-to-help-make-the-platform-more-stable