### PR TITLE
GSP-local: fix Grafana and Promotheus service expose

### DIFF
--- a/scripts/gsp-local.sh
+++ b/scripts/gsp-local.sh
@@ -130,10 +130,10 @@ apply "${manifest_dir}/gsp-cluster/templates/00-aws-auth/"
 apply "${manifest_dir}/gsp-istio/"
 apply "${manifest_dir}/gsp-cluster/"
 
-log "[HACK] Creating Prometheus VirtualService..."
+log "[HACK] Creating Prometheus VirtualService and DestinationRule..."
 apply "${script_dir}/hack/expose-prometheus.yaml"
 
-log "[HACK] Creating Grafana VirtualService..."
+log "[HACK] Creating Grafana VirtualService and DestinationRule..."
 apply "${script_dir}/hack/expose-grafana.yaml"
 
 kubectl cluster-info

--- a/scripts/hack/expose-grafana.yaml
+++ b/scripts/hack/expose-grafana.yaml
@@ -17,3 +17,16 @@ spec:
         host: gsp-grafana
         port:
           number: 80
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: gsp-grafana
+  namespace: gsp-system
+  labels:
+    chart: gsp-cluster
+spec:
+  host: "gsp-grafana.gsp-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/scripts/hack/expose-prometheus.yaml
+++ b/scripts/hack/expose-prometheus.yaml
@@ -17,3 +17,16 @@ spec:
         host: gsp-prometheus-operator-prometheus
         port:
           number: 9090
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: gsp-prometheus
+  namespace: gsp-system
+  labels:
+    chart: gsp-cluster
+spec:
+  host: "gsp-prometheus-operator-prometheus.gsp-system.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE


### PR DESCRIPTION
This is to fix part of a "GSP-local" deployment script which exposes Grafana and Prometheus services.