### PR TITLE
Scrape kubelet metrics with node-role label

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -341,6 +341,29 @@ prometheus-operator:
           regex: true
           target_label: node_role
           replacement: cluster-management
+      - job_name: 'node-exporter'
+        scheme: http
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - source_labels: [__address__]
+          target_label: __address__
+          regex: (.*):.*
+          replacement: $1:9100
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_worker]
+          regex: true
+          target_label: node_role
+          replacement: worker
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_ci]
+          regex: true
+          target_label: node_role
+          replacement: ci
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_cluster_management]
+          regex: true
+          target_label: node_role
+          replacement: cluster-management
   grafana:
     adminPassword: "password"
   kubelet:

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -294,6 +294,51 @@ prometheus-operator:
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: pod_name
+      - job_name: 'kubelet-worker'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true  # prometheus does not support secure naming.
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_worker]
+          action: keep
+        - target_label: node_role
+          replacement: worker
+        - target_label: job
+          replacement: kubelet
+      - job_name: 'kubelet-ci'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true  # prometheus does not support secure naming.
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_ci]
+          action: keep
+        - target_label: node_role
+          replacement: ci
+        - target_label: job
+          replacement: kubelet
+      - job_name: 'kubelet-cluster-management'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true  # prometheus does not support secure naming.
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_cluster_management]
+          action: keep
+        - target_label: node_role
+          replacement: cluster-management
+        - target_label: job
+          replacement: kubelet
   grafana:
     adminPassword: "password"
   kubelet:

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -303,6 +303,8 @@ prometheus-operator:
         kubernetes_sd_configs:
         - role: node
         relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
         - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_worker]
           regex: true
           target_label: node_role

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -294,7 +294,7 @@ prometheus-operator:
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: pod_name
-      - job_name: 'kubelet-worker'
+      - job_name: 'kubelet'
         scheme: https
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -304,41 +304,17 @@ prometheus-operator:
         - role: node
         relabel_configs:
         - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_worker]
-          action: keep
-        - target_label: node_role
+          regex: true
+          target_label: node_role
           replacement: worker
-        - target_label: job
-          replacement: kubelet
-      - job_name: 'kubelet-ci'
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          insecure_skip_verify: true  # prometheus does not support secure naming.
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        kubernetes_sd_configs:
-        - role: node
-        relabel_configs:
         - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_ci]
-          action: keep
-        - target_label: node_role
+          regex: true
+          target_label: node_role
           replacement: ci
-        - target_label: job
-          replacement: kubelet
-      - job_name: 'kubelet-cluster-management'
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          insecure_skip_verify: true  # prometheus does not support secure naming.
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        kubernetes_sd_configs:
-        - role: node
-        relabel_configs:
         - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_cluster_management]
-          action: keep
-        - target_label: node_role
+          regex: true
+          target_label: node_role
           replacement: cluster-management
-        - target_label: job
-          replacement: kubelet
   grafana:
     adminPassword: "password"
   kubelet:

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -298,8 +298,32 @@ prometheus-operator:
         scheme: https
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          insecure_skip_verify: true  # prometheus does not support secure naming.
+          insecure_skip_verify: true
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_worker]
+          regex: true
+          target_label: node_role
+          replacement: worker
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_ci]
+          regex: true
+          target_label: node_role
+          replacement: ci
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_cluster_management]
+          regex: true
+          target_label: node_role
+          replacement: cluster-management
+      - job_name: 'kubelet-cadvisor'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        metrics_path: /metrics/cadvisor
         kubernetes_sd_configs:
         - role: node
         relabel_configs:


### PR DESCRIPTION
I would like us to scrape kubelet metrics in such a way that we can
tell which node has which role.  This is so that, for example, I can
see if a particular node role is running out of resources.  (eg: if
there are no pods available in the worker node group, it's no good
knowing that the CI or cluster-management nodes have plenty of pods
available.)

Currently, this isn't possible for tiresome reasons.

 1. Node roles are set as node labels (node-role.kubernetes.io/<role>)
 2. The labels have an empty value
 3. Prometheus doesn't distinguish between missing labels and labels
    with an empty value

This means that, although it's possible to see node labels via the
`kube_node_labels` metric, the node role labels are not there.

Prometheus 2.9.0 introduced a workaround: you can see if node labels
are present using the `__meta_kubernetes_node_labelpresent_<label>`
meta label in your `kubernetes_sd_configs`.  These labels are only
present if you are doing node-based service discovery (ie using `role:
node`).

Even more tiresomely, the prometheus operator defaults to scraping
kubelet via endpoint-based service discovery, for all sorts of reasons
which need not concern us here.

Therefore, I have decided to re-scrape kubelet via
`additionalScrapeConfigs` that specify `role: node` and include checks
for the specific node-role labels.  This way, we can get a `node_role`
target label on our kubelet metrics, and finally, once and for all,
actually have metrics that can be sliced by node group.

:weary:

By the way, this is untested.  If it works, we should switch off the
old kubelet metrics via the following in gsp-cluster/values.yaml:

    prometheus-operator:
      ...
      # disable service/gsp-prometheus-operator-kubelet in kube-system
      prometheusOperator:
        kubeletService:
          enabled: false
      # disable the kubelet ServiceMonitor that scrapes the above service
      kubelet:
        enabled: false