### PR TITLE
BAU: Add httpEgressSafelist

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/http-egress-safelist.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/http-egress-safelist.yaml
@@ -1,0 +1,71 @@
+{{- range $egressFqdn := .Values.httpEgressSafelist }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-http-egress-safelist-{{ $egressFqdn.name }}
+    helm.sh/chart: {{ include "gsp-cluster.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+spec:
+  hosts:
+  - {{ $egressFqdn.fqdn}}
+  ports:
+  - name: http
+    number: 80
+    protocol: HTTP
+  location: MESH_EXTERNAL
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-http-egress-safelist-{{ $egressFqdn.name }}
+    helm.sh/chart: {{ include "gsp-cluster.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+spec:
+  selector:
+    istio: egressgateway
+  servers:
+  - port:
+      number: 80
+      name: http-egress-safelist-{{ $egressFqdn.name }}
+      protocol: HTTP
+    hosts:
+    - {{ $egressFqdn.fqdn}}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-http-egress-safelist-{{ $egressFqdn.name }}
+    helm.sh/chart: {{ include "gsp-cluster.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+spec:
+  hosts:
+  - {{ $egressFqdn.fqdn}}
+  gateways:
+  - {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
+  tcp:
+  - match:
+    - gateways:
+      - {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
+      port: 80
+    route:
+    - destination:
+        host: {{ $egressFqdn.fqdn}}
+        port:
+          number: 80
+      weight: 100
+---
+{{- end }}

--- a/charts/gsp-cluster/templates/02-gsp-system/http-egress-safelist.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/http-egress-safelist.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
 spec:
   hosts:
-  - {{ $egressFqdn.fqdn}}
+  - {{ $egressFqdn.fqdn }}
   ports:
   - name: http
     number: 80
@@ -36,34 +36,39 @@ spec:
   servers:
   - port:
       number: 80
-      name: http-egress-safelist-{{ $egressFqdn.name }}
-      protocol: HTTP
+      name: https-http-egress-safelist-{{ $egressFqdn.name }}
+      protocol: HTTPS
     hosts:
-    - {{ $egressFqdn.fqdn}}
+    - {{ $egressFqdn.fqdn }}
+    tls:
+      mode: MUTUAL
+      serverCertificate: /etc/certs/cert-chain.pem
+      privateKey: /etc/certs/key.pem
+      caCertificates: /etc/certs/root-cert.pem
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
+  name: {{ $.Release.Name }}-http-egress-safelist-direct-{{ $egressFqdn.name }}-through-egress-gateway
   namespace: {{ $.Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-http-egress-safelist-{{ $egressFqdn.name }}
+    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-http-egress-safelist-direct-{{ $egressFqdn.name }}-through-egress-gateway
     helm.sh/chart: {{ include "gsp-cluster.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
 spec:
   hosts:
-  - {{ $egressFqdn.fqdn}}
+  - {{ $egressFqdn.fqdn }}
   gateways:
   - {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
-  tcp:
+  http:
   - match:
     - gateways:
       - {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
       port: 80
     route:
     - destination:
-        host: {{ $egressFqdn.fqdn}}
+        host: {{ $egressFqdn.fqdn }}
         port:
           number: 80
       weight: 100

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -30,6 +30,7 @@ permittedRolesRegex: ""
 githubAPIToken: ""
 
 httpsEgressSafelist: []
+httpEgressSafelist: []
 
 
 # users:

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -26,6 +26,7 @@ bootstrapRoleARNs: ${bootstrap_role_arns}
 permittedRolesRegex: ${permitted_roles_regex}
 
 httpsEgressSafelist: []
+httpEgressSafelist: []
 
 notary:
   rootPassphrase: ${notary_root_passphrase}


### PR DESCRIPTION
There is an application which wants to talk to another service on the Internet over HTTP. httpsEgressSafelist currently only whitelists services over https. This change adds httpEgressSafelist to allow the application to talk to the service on the Internet over HTTP instead of HTTPS.

Author: @adityapahuja