### PR TITLE
Add a Concourse CI pipeline that checks if PR author == latest commit signature author

### DIFF
--- a/pipelines/ci/check-pr-author-matches-commit-signature.yml
+++ b/pipelines/ci/check-pr-author-matches-commit-signature.yml
@@ -3,7 +3,6 @@ resources:
   type: pull-request
   source:
     access_token: ((pr-build-status))
-    disable_forks: true
     repository: alphagov/gsp
   check_every: 1m
 resource_types:

--- a/pipelines/ci/check-pr-author-matches-commit-signature.yml
+++ b/pipelines/ci/check-pr-author-matches-commit-signature.yml
@@ -1,0 +1,114 @@
+resources:
+- name: gsp-pr
+  type: pull-request
+  source:
+    access_token: ((pr-build-status))
+    disable_forks: true
+    repository: alphagov/gsp
+  check_every: 1m
+resource_types:
+- name: pull-request
+  type: docker-image
+  source:
+    repository: teliaoss/github-pr-resource
+jobs:
+- name: check-pr-author-and-commit-signature-match
+  public: true
+  serial: true
+  plan:
+  - get: gsp-pr
+    trigger: true
+    version: every
+  - put: gsp-pr
+    params:
+      path: gsp-pr
+      status: pending
+  - task: check
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: govsvc/task-toolbox
+      params:
+        GITHUB_TOKEN: ((pr-build-status))
+      run:
+        path: bash
+        args:
+        - -ec
+        - |
+          #!/bin/bash
+
+          function build_query() {
+          {
+            local org=$1
+            local repo=$2
+            local commit_sha=$3
+
+            cat <<EOF
+          query {
+            repository(owner: \"${org}\", name: \"${repo}\") {
+              object(oid: \"${commit_sha}\") {
+                ... on Commit {
+                  oid
+                  associatedPullRequests(first: 1) {
+                    nodes {
+                      author {
+                        login
+                      }
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            signature {
+                              ... on GpgSignature {
+                                signer {
+                                  login
+                                }
+                                keyId
+                                isValid
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          EOF
+          } | tr -d '\n'
+          }
+
+          commit_sha=$(git rev-parse HEAD)
+          api_response=$(curl --header 'Content-Type: application/json' --header "Authorization: bearer ${GITHUB_TOKEN}" --data "{ \"query\": \"$(build_query "alphagov" "gsp" "${commit_sha}")\"}" "https://api.github.com/graphql")
+
+          echo "$(build_query "alphagov" "gsp" "${commit_sha}")"
+          echo $commit_sha
+          echo $api_response
+
+          pr_author=$(echo $api_response | jq ".data.repository.object.associatedPullRequests.nodes[].author.login")
+          commit_signature_author=$(echo $api_response | jq ".data.repository.object.associatedPullRequests.nodes[].commits.nodes[0].commit.signature.signer.login")
+
+          if [ $pr_author == $commit_signature_author ]; then
+            echo "OK: PR author matches commit signature author."
+          else
+            echo "ERROR: PR author ($pr_author) doesn't match commit signature author ($commit_signature_author)."
+            exit 1
+          fi
+        dir: repo
+      inputs:
+      - name: gsp-pr
+        path: repo
+    timeout: 15m
+  on_failure:
+    put: gsp-pr
+    params:
+      path: gsp-pr
+      status: failure
+  on_success:
+    put: gsp-pr
+    params:
+      path: gsp-pr
+      status: success

--- a/pipelines/ci/check-pr-author-matches-commit-signature.yml
+++ b/pipelines/ci/check-pr-author-matches-commit-signature.yml
@@ -2,7 +2,7 @@ resources:
 - name: gsp-pr
   type: pull-request
   source:
-    access_token: ((pr-build-status))
+    access_token: ((re-autom8-ci-pr-build-status-github-token))
     repository: alphagov/gsp
   check_every: 1m
 resource_types:
@@ -30,7 +30,7 @@ jobs:
         source:
           repository: govsvc/task-toolbox
       params:
-        GITHUB_TOKEN: ((pr-build-status))
+        GITHUB_TOKEN: ((re-autom8-ci-pr-build-status-github-token))
       run:
         path: bash
         args:


### PR DESCRIPTION
- This relates to the Concourse GitHub Resource PR (#378), and aims to reduce
  toil for us now we've changed what constitutes a mergeable PR that
  will successfully flow through the pipeline once merged.
- Humans are fallible and won't always remember to manually check that
  the PR author was the person who signed the latest commit.
- This makes it so that on every commit, Concourse will tell us. :muscle: