### PR TITLE
define resource requests for concourse web and worker

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -402,13 +402,20 @@ concourse:
     additionalVolumeMounts:
     - name: ci-web-configuration
       mountPath: /web-configuration
+    resources:
+      requests:
+        cpu: 100m
+        memory: 1Gi
   monitor:
     create: true
   worker:
     nameOverride: concourse-worker
     replicas: 2
     hardAntiAffinity: true
-    resources: {}
+    resources:
+      requests:
+        cpu: 150m
+        memory: 2Gi
     env:
     - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
       value: "false"

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -25,7 +25,7 @@ github-approvers: ["chrisfarms"]
 disable-destroy: false
 worker-instance-type: t3.medium
 worker-count: 3
-ci-worker-instance-type: t3.micro
+ci-worker-instance-type: t3.medium
 ci-worker-count: 3
 config-uri: "https://github.com/alphagov/gsp.git"
 config-organization: "alphagov"


### PR DESCRIPTION
The new concourse grafana dashboard shows that concourse web and
worker are both using way more memory than their default request of
128/512 MiB for web and worker respectively.  This commit bumps the
requests up.

The instance types we use for concourse are:

 - sandbox: t3.large
 - portfolio & verify: m5d.large

both instance types have 8 GiB memory, so these new memory requests
will be satisfiable in all clusters.

The default CPU request is 100m for both web and worker.  This commit
tweaks that slightly but mostly just makes the cpu request explicit.

Resource requests aren't that important for the ci nodes, because
nothing else runs on them, so there can't be contention; but this
hopefully also sets a pattern for being better at defining requests
for other things in future.