### PR TITLE
Fix Principal creation + role policy association

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/crd.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/crd.yaml
@@ -30,9 +30,6 @@ spec:
         status:
           description: PrincipalStatus defines the observed state of Principal
           properties:
-            arn:
-              description: ARN of the IAM Principal
-              type: string
             events:
               description: Events will hold more in-depth details of the current state
                 of the instance.
@@ -58,6 +55,9 @@ spec:
             id:
               description: ID of an instance for a reference.
               type: string
+            name:
+              description: Name of the IAM Principal
+              type: string
             reason:
               description: Reason for the current status of the instance.
               type: string
@@ -65,8 +65,8 @@ spec:
               description: Status of the currently running instance.
               type: string
           required:
-          - arn
           - id
+          - name
           - status
           type: object
       type: object

--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
@@ -23,7 +23,9 @@ rules:
 - apiGroups:
   - database.govsvc.uk
   - queue.govsvc.uk
+  - access.govsvc.uk
   resources:
+  - principals
   - postgres
   - sqs
   verbs:
@@ -37,29 +39,11 @@ rules:
 - apiGroups:
   - database.govsvc.uk
   - queue.govsvc.uk
+  - access.govsvc.uk
   resources:
+  - principals/status
   - postgres/status
   - sqs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - access.govsvc.uk
-  resources:
-  - principal
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - access.govsvc.uk
-  resources:
-  - principal/status
   verbs:
   - get
   - patch

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -14,7 +14,7 @@
   {{- end }}
 {{- end }}
 {{- $defaultedPermittedRolesRegex := .permittedRolesRegex | default "^$" }}
-{{- $permittedRolesRegex := printf "%s|^%s-namespace-%s-.*$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name }}
+{{- $permittedRolesRegex := printf "%s|^%s-namespace-%s-.*$|^svcop-%s-%s-.*$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name $.Values.global.cluster.name .name }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/components/service-operator/apis/access/v1beta1/principal_types.go
+++ b/components/service-operator/apis/access/v1beta1/principal_types.go
@@ -44,8 +44,8 @@ type PrincipalStatus struct {
 	Reason string `json:"reason,omitempty"`
 	// Events will hold more in-depth details of the current state of the instance.
 	Events []Event `json:"events,omitempty"`
-	// ARN of the IAM Principal
-	ARN string `json:"arn"`
+	// Name of the IAM Principal
+	Name string `json:"name"`
 }
 
 // +kubebuilder:object:root=true

--- a/components/service-operator/config/crd/bases/access.govsvc.uk_principals.yaml
+++ b/components/service-operator/config/crd/bases/access.govsvc.uk_principals.yaml
@@ -30,9 +30,6 @@ spec:
         status:
           description: PrincipalStatus defines the observed state of Principal
           properties:
-            arn:
-              description: ARN of the IAM Principal
-              type: string
             events:
               description: Events will hold more in-depth details of the current state
                 of the instance.
@@ -58,6 +55,9 @@ spec:
             id:
               description: ID of an instance for a reference.
               type: string
+            name:
+              description: Name of the IAM Principal
+              type: string
             reason:
               description: Reason for the current status of the instance.
               type: string
@@ -65,8 +65,8 @@ spec:
               description: Status of the currently running instance.
               type: string
           required:
-          - arn
           - id
+          - name
           - status
           type: object
       type: object

--- a/components/service-operator/controllers/postgres_controller.go
+++ b/components/service-operator/controllers/postgres_controller.go
@@ -88,13 +88,19 @@ func (r *PostgresReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		postgres.Status.Status = stackData.Status
 		postgres.Status.Reason = stackData.Reason
 
+		events := []database.Event{}
 		for _, event := range stackData.Events {
-			postgres.Status.Events = append(postgres.Status.Events, database.Event{
+			reason := "-"
+			if event.ResourceStatusReason != nil {
+				reason = *event.ResourceStatusReason
+			}
+			events = append(events, database.Event{
 				Status: *event.ResourceStatus,
-				Reason: *event.ResourceStatusReason,
+				Reason: reason,
 				Time:   &metav1.Time{Time: *event.Timestamp},
 			})
 		}
+		postgres.Status.Events = events
 
 		backoff := ctrl.Result{Requeue: true, RequeueAfter: time.Minute}
 

--- a/components/service-operator/controllers/postgres_controller.go
+++ b/components/service-operator/controllers/postgres_controller.go
@@ -77,7 +77,7 @@ func (r *PostgresReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 2}, err
 		}
 
-		postgresCloudFormationTemplate := internalaws.AuroraPostgres{PostgresConfig: &postgres, IAMRoleARN: roles.Items[0].Status.ARN}
+		postgresCloudFormationTemplate := internalaws.AuroraPostgres{PostgresConfig: &postgres, IAMRoleName: roles.Items[0].Status.Name}
 		action, stackData, err := r.CloudFormationReconciler.Reconcile(ctx, log, req, &postgresCloudFormationTemplate, !postgres.ObjectMeta.DeletionTimestamp.IsZero())
 		if err != nil {
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 2}, err

--- a/components/service-operator/controllers/principal_controller.go
+++ b/components/service-operator/controllers/principal_controller.go
@@ -64,7 +64,7 @@ func (r *PrincipalReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	provisioner := os.Getenv("CLOUD_PROVIDER")
 	switch provisioner {
 	case "aws":
-		roleName := fmt.Sprintf("%s-%s-%s", r.ClusterName, req.Namespace, principal.ObjectMeta.Name)
+		roleName := fmt.Sprintf("svcop-%s-%s-%s", r.ClusterName, req.Namespace, principal.ObjectMeta.Name)
 
 		principalCloudFormationTemplate := internalaws.IAMRole{
 			RoleConfig:          &principal,

--- a/components/service-operator/controllers/principal_controller.go
+++ b/components/service-operator/controllers/principal_controller.go
@@ -48,8 +48,8 @@ const (
 	PrincipalFinalizerName = "stack.principal.access.govsvc.uk"
 )
 
-// +kubebuilder:rbac:groups=access.govsvc.uk,resources=principal,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=access.govsvc.uk,resources=principal/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=access.govsvc.uk,resources=principals,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=access.govsvc.uk,resources=principals/status,verbs=get;update;patch
 
 func (r *PrincipalReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
@@ -94,7 +94,7 @@ func (r *PrincipalReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		switch action {
 		case internal.Create:
 			principal.ObjectMeta.Finalizers = append(principal.ObjectMeta.Finalizers, PrincipalFinalizerName)
-			return backoff, r.Create(ctx, &principal)
+			return backoff, r.Update(ctx, &principal)
 		case internal.Delete:
 			principal.ObjectMeta.Finalizers = internal.RemoveString(principal.ObjectMeta.Finalizers, PrincipalFinalizerName)
 			return backoff, r.Update(ctx, &principal)

--- a/components/service-operator/controllers/principal_controller.go
+++ b/components/service-operator/controllers/principal_controller.go
@@ -79,7 +79,7 @@ func (r *PrincipalReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		principal.Status.ID = stackData.ID
 		principal.Status.Status = stackData.Status
 		principal.Status.Reason = stackData.Reason
-		principal.Status.ARN = string(internalaws.ValueFromOutputs(internalaws.IAMRoleARN, stackData.Outputs))
+		principal.Status.Name = string(internalaws.ValueFromOutputs(internalaws.IAMRoleName, stackData.Outputs))
 
 		for _, event := range stackData.Events {
 			principal.Status.Events = append(principal.Status.Events, access.Event{

--- a/components/service-operator/controllers/principal_controller_test.go
+++ b/components/service-operator/controllers/principal_controller_test.go
@@ -119,8 +119,8 @@ var _ = Describe("PrincipalController", func() {
 					Reason: "because-of-update",
 					Outputs: []*cloudformation.Output{
 						&cloudformation.Output{
-							OutputKey:   aws.String(internalaws.IAMRoleARN),
-							OutputValue: aws.String("arn:aws:iam::123456789012:role/test-cluster-test-test-role"),
+							OutputKey:   aws.String(internalaws.IAMRoleName),
+							OutputValue: aws.String("test-cluster-test-test-role"),
 						},
 					},
 				}
@@ -144,7 +144,7 @@ var _ = Describe("PrincipalController", func() {
 					Name:      roleName,
 				}, &updatedPrincipal)
 				checkPrincipalStatusUpdates(stackData, updatedPrincipal)
-				Expect(updatedPrincipal.Status.ARN).To(Equal("arn:aws:iam::123456789012:role/test-cluster-test-test-role"))
+				Expect(updatedPrincipal.Status.Name).To(Equal("test-cluster-test-test-role"))
 				Expect(updatedPrincipal.ObjectMeta.Finalizers).To(ContainElement(PrincipalFinalizerName))
 				Expect(updatedPrincipal.ObjectMeta.DeletionTimestamp).To(BeNil())
 			})

--- a/components/service-operator/controllers/principal_controller_test.go
+++ b/components/service-operator/controllers/principal_controller_test.go
@@ -45,6 +45,9 @@ var _ = Describe("PrincipalController", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test",
 				Name:      roleName,
+				Labels: map[string]string{
+					access.AccessGroupLabel: "test.access.group",
+				},
 			},
 		}
 		k8sClient.Create(context.TODO(), &principal)
@@ -57,10 +60,6 @@ var _ = Describe("PrincipalController", func() {
 			RolePrincipal:            "arn:aws:iam::123456789012:role/kiam",
 			PermissionsBoundary:      "arn:aws:iam::123456789012:policy/permissions-boundary",
 		}
-	})
-
-	AfterEach(func() {
-		k8sClient.Delete(context.TODO(), &principal)
 	})
 
 	Context("When using an undefined provisioner", func() {
@@ -84,8 +83,6 @@ var _ = Describe("PrincipalController", func() {
 
 		Context("When creating a new resource", func() {
 			It("Should update the kubernetes resource", func() {
-				//FIXME: This test fails for unknown reasons
-				Skip("This test fails as the `resourceVersion should not be set on objects to be created` and I don't know why")
 				stackData := internalaws.StackData{
 					ID:     "test-id",
 					Status: "created",

--- a/components/service-operator/controllers/sqs_controller.go
+++ b/components/service-operator/controllers/sqs_controller.go
@@ -42,6 +42,7 @@ type SQSReconciler struct {
 	client.Client
 	Log                      logr.Logger
 	CloudFormationReconciler internalaws.CloudFormationReconciler
+	ClusterName              string
 	sqs                      queue.SQS
 }
 
@@ -79,7 +80,12 @@ func (r *SQSReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 2}, err
 		}
 
-		sqsCloudFormationTemplate := internalaws.SQS{SQSConfig: &sqs, IAMRoleARN: roles.Items[0].Status.ARN}
+		queueName := fmt.Sprintf("%s-%s-%s", r.ClusterName, req.Namespace, req.Name)
+		sqsCloudFormationTemplate := internalaws.SQS{
+			SQSConfig:   &sqs,
+			QueueName:   queueName,
+			IAMRoleName: roles.Items[0].Status.Name,
+		}
 		action, stackData, err := r.CloudFormationReconciler.Reconcile(ctx, log, req, &sqsCloudFormationTemplate, !sqs.ObjectMeta.DeletionTimestamp.IsZero())
 		if err != nil {
 			return ctrl.Result{Requeue: true, RequeueAfter: time.Minute * 2}, err

--- a/components/service-operator/controllers/sqs_controller.go
+++ b/components/service-operator/controllers/sqs_controller.go
@@ -96,13 +96,19 @@ func (r *SQSReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		sqs.Status.Status = stackData.Status
 		sqs.Status.Reason = stackData.Reason
 
+		events := []queue.Event{}
 		for _, event := range stackData.Events {
-			sqs.Status.Events = append(sqs.Status.Events, queue.Event{
+			reason := "-"
+			if event.ResourceStatusReason != nil {
+				reason = *event.ResourceStatusReason
+			}
+			events = append(events, queue.Event{
 				Status: *event.ResourceStatus,
-				Reason: *event.ResourceStatusReason,
+				Reason: reason,
 				Time:   &metav1.Time{Time: *event.Timestamp},
 			})
 		}
+		sqs.Status.Events = events
 
 		backoff := ctrl.Result{Requeue: true, RequeueAfter: time.Minute}
 

--- a/components/service-operator/internal/aws/aurora_postgres.go
+++ b/components/service-operator/internal/aws/aurora_postgres.go
@@ -40,7 +40,7 @@ const (
 
 type AuroraPostgres struct {
 	PostgresConfig *database.Postgres
-	IAMRoleARN     string
+	IAMRoleName    string
 }
 
 func (p *AuroraPostgres) Template(stackName string, tags []resources.Tag) *cloudformation.Template {
@@ -93,8 +93,8 @@ func (p *AuroraPostgres) Template(stackName string, tags []resources.Tag) *cloud
 
 	template.Resources[PostgresResourceIAMPolicy] = &resources.AWSIAMPolicy{
 		PolicyName:     cloudformation.Join("-", []string{"postgres", "access", cloudformation.Ref(PostgresResourceCluster)}),
-		PolicyDocument: NewRolePolicyDocument(p.IAMRoleARN, []string{cloudformation.Ref(PostgresResourceCluster)}, []string{"rds-data:*"}),
-		Roles:          []string{p.IAMRoleARN},
+		PolicyDocument: NewRolePolicyDocument([]string{cloudformation.Ref(PostgresResourceCluster)}, []string{"rds-data:*"}),
+		Roles:          []string{p.IAMRoleName},
 	}
 
 	template.Outputs[PostgresEndpoint] = map[string]interface{}{

--- a/components/service-operator/internal/aws/iam_role.go
+++ b/components/service-operator/internal/aws/iam_role.go
@@ -11,7 +11,7 @@ import (
 const (
 	IAMRoleResourceName = "IAMRole"
 
-	IAMRoleARN = "IAMRoleARN"
+	IAMRoleName = "IAMRoleName"
 )
 
 type IAMRole struct {
@@ -30,9 +30,9 @@ func (s *IAMRole) Template(stackName string, tags []resources.Tag) *cloudformati
 		PermissionsBoundary:      s.PermissionsBoundary,
 	}
 
-	template.Outputs[IAMRoleARN] = map[string]interface{}{
+	template.Outputs[IAMRoleName] = map[string]interface{}{
 		"Description": "IAMRole ARN to be returned to the user.",
-		"Value":       cloudformation.GetAtt(IAMRoleResourceName, "Arn"),
+		"Value":       cloudformation.Ref(IAMRoleResourceName),
 	}
 
 	return template

--- a/components/service-operator/internal/aws/utils.go
+++ b/components/service-operator/internal/aws/utils.go
@@ -45,10 +45,9 @@ type PolicyDocument struct {
 }
 
 type PolicyStatement struct {
-	Effect    string
-	Principal PolicyPrincipal
-	Action    []string
-	Resources []string
+	Effect   string
+	Action   []string
+	Resource []string
 }
 
 type AssumeRolePolicyDocument struct {
@@ -66,17 +65,14 @@ type PolicyPrincipal struct {
 	AWS []string
 }
 
-func NewRolePolicyDocument(principal string, resources, actions []string) PolicyDocument {
+func NewRolePolicyDocument(resources, actions []string) PolicyDocument {
 	return PolicyDocument{
 		Version: "2012-10-17",
 		Statement: []PolicyStatement{
 			{
-				Effect: "Allow",
-				Principal: PolicyPrincipal{
-					AWS: []string{principal},
-				},
-				Action:    actions,
-				Resources: resources,
+				Effect:   "Allow",
+				Action:   actions,
+				Resource: resources,
 			},
 		},
 	}

--- a/components/service-operator/main.go
+++ b/components/service-operator/main.go
@@ -88,6 +88,7 @@ func main() {
 		Client:                   mgr.GetClient(),
 		Log:                      ctrl.Log.WithName("controllers").WithName("SQS"),
 		CloudFormationReconciler: &cloudFormationController,
+		ClusterName:              clusterName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SQS")
 		os.Exit(1)

--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -49,6 +49,7 @@ data "aws_iam_policy_document" "service-operator" {
   statement {
     actions = [
       "rds:*",
+      "sqs:*",
     ]
 
     resources = [

--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -27,9 +27,6 @@ data "aws_iam_policy_document" "service-operator" {
   statement {
     actions = [
       "ec2:DescribeAccountAttributes",
-
-      # Work around a race condition in Cloudformation where the role exists without the boundary
-      "iam:GetRole",
     ]
 
     resources = [
@@ -65,7 +62,6 @@ data "aws_iam_policy_document" "service-operator" {
       "iam:CreatePolicy",
       "iam:CreateRole",
       "iam:DeletePolicy",
-      "iam:DeleteRole",
       "iam:DeleteRolePolicy",
       "iam:DetachRolePolicy",
       "iam:PutRolePolicy",
@@ -82,6 +78,18 @@ data "aws_iam_policy_document" "service-operator" {
       variable = "iam:PermissionsBoundary"
       values   = ["${aws_iam_policy.service-operator-managed-role-permissions-boundary.arn}"]
     }
+  }
+
+  # No iam:PermissionsBoundary context key set on GetRole, DeleteRole
+  statement {
+    actions = [
+      "iam:GetRole",
+      "iam:DeleteRole",
+    ]
+
+    resources = [
+      "arn:aws:iam::*:role/svcop-${var.cluster_name}-*",
+    ]
   }
 }
 

--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -27,6 +27,9 @@ data "aws_iam_policy_document" "service-operator" {
   statement {
     actions = [
       "ec2:DescribeAccountAttributes",
+
+      # Work around a race condition in Cloudformation where the role exists without the boundary
+      "iam:GetRole",
     ]
 
     resources = [
@@ -63,8 +66,8 @@ data "aws_iam_policy_document" "service-operator" {
       "iam:CreateRole",
       "iam:DeletePolicy",
       "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
       "iam:DetachRolePolicy",
-      "iam:GetRole",
       "iam:PutRolePolicy",
       "iam:TagRole",
       "iam:UntagRole",

--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -88,7 +88,7 @@ data "aws_iam_policy_document" "service-operator" {
     ]
 
     resources = [
-      "arn:aws:iam::*:role/svcop-${var.cluster_name}-*",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/svcop-${var.cluster_name}-*",
     ]
   }
 }


### PR DESCRIPTION
- k8s expects nouns that can be pluralized to be pluralized in
  rolebindings (see events, configmaps, secrets etc.)
- Also only Update the Principal resource as it already exists so we
  can't create it again
- Remove the AfterEach as it was causing cross contamination between
  tests (the update test failed because the Principal ended up having a
deletion timestamp from the Delete in the AfterEach)