### PR TITLE
Bump the tag of the concourse-github-resource in the release pipeline

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -5,7 +5,7 @@ resource_types:
   type: registry-image
   source:
     repository: "govsvc/concourse-github-resource"
-    tag: "v0.0.3"
+    tag: "gsp-v1.0.91"
 
 - name: concourse-pipeline
   type: docker-image


### PR DESCRIPTION
- The changes to the resources are released automatically to the rest of
  the GSP, but the release pipeline itself hardcoded a very old version?