### PR TITLE
Fix flaky CI checks

### DIFF
--- a/pipelines/ci/check-pr-author-matches-commit-signature.yml
+++ b/pipelines/ci/check-pr-author-matches-commit-signature.yml
@@ -18,6 +18,8 @@ jobs:
   - get: gsp-pr
     trigger: true
     version: every
+    params:
+      integration_tool: checkout
   - put: gsp-pr
     params:
       path: gsp-pr


### PR DESCRIPTION
- We were getting intermittent failures of the form:
  ```
  query {  repository(owner: \"alphagov\", name: \"gsp\") {    object(oid: \"3de906b54aff226a54de5e0025b4505f7798a4aa\") {      ... on Commit {        oid        associatedPullRequests(first: 1) {          nodes {            author {              login            }            commits(last: 1) {              nodes {                commit {                  signature {                    ... on GpgSignature {                      signer {                        login                      }                      keyId                      isValid                    }                  }                }              }            }          }        }      }    }  }}
  3de906b54aff226a54de5e0025b4505f7798a4aa
  {"data":{"repository":{"object":null}}}
  jq: error (at <stdin>:1): Cannot iterate over null (null)
  ```
- The code for this came straight from the code inside our
  concourse-github-resource, which uses a different resource for `git`
  which behaves differently. The pull-request Concourse resource
  [performs a merge onto the latest master]() by default, which isn't what
  we expected, and means that `git rev-parse HEAD` may not be the
  correct commit, or have any data that GitHub knows about.
- Hopefully through checking out the PR instead of merging it in the
  resource, we'll get more consistent results.

Co-authored-by: Chris Farmiloe <chris.farmiloe@digital.cabinet-office.gov.uk>