### PR TITLE
Alerting for nodes running out of pods

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/prometheus-rules.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/prometheus-rules.yaml
@@ -23,3 +23,41 @@ spec:
       expr: vector(1)
       labels:
         severity: constant
+    - alert: KubeletTooManyPods
+      expr: |
+        kubelet_running_pod_count
+          > on(node) group_left
+        kube_node_status_allocatable_pods * 0.9
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        message: |
+          Kubelet {{ $labels.instance }} is running {{ $value }} Pods,
+          which is more than 90% of its capacity.
+    - record: az_node_role_resource:allocatable:
+      expr: |
+        sum by(failure_domain_beta_kubernetes_io_zone,node_role,resource) (
+          up{job="kubelet"}
+            * on(node) group_right(failure_domain_beta_kubernetes_io_zone,node_role)
+          kube_node_status_allocatable
+        )
+    - record: az_node_role:kubelet_running_pod_count:
+      expr: |
+        sum by(failure_domain_beta_kubernetes_io_zone,node_role) (
+          kubelet_running_pod_count
+        )
+    - alert: KubeletTooManyPodsByAZNodeRole
+      expr: |
+        az_node_rule:kubelet_running_pod_count:
+          > ignoring(resource) group_right
+        az_node_role_resource:allocatable:{resource="pods"} * 0.9
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        message: |
+          Nodes with role {{ $labels.node_role }} in availability zone
+          {{ $labels.failure_domain_beta_kubernetes_io_zone }} are
+          running {{ $value }} Pods, which is more than 90% of total
+          allocatable capacity.

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -318,6 +318,8 @@ prometheus-operator:
           regex: true
           target_label: node_role
           replacement: cluster-management
+        - source_labels: [instance]
+          target_label: node
       - job_name: 'kubelet-cadvisor'
         scheme: https
         tls_config:
@@ -342,6 +344,8 @@ prometheus-operator:
           regex: true
           target_label: node_role
           replacement: cluster-management
+        - source_labels: [instance]
+          target_label: node
       - job_name: 'node-exporter'
         scheme: http
         kubernetes_sd_configs:
@@ -365,6 +369,8 @@ prometheus-operator:
           regex: true
           target_label: node_role
           replacement: cluster-management
+        - source_labels: [instance]
+          target_label: node
   grafana:
     adminPassword: "password"
   prometheusOperator:

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -367,9 +367,11 @@ prometheus-operator:
           replacement: cluster-management
   grafana:
     adminPassword: "password"
+  prometheusOperator:
+    kubeletService:
+      enabled: false
   kubelet:
-     serviceMonitor:
-       https: true
+    enabled: false
   alertmanager:
     enabled: false
 


### PR DESCRIPTION
This adds some alerting rules for running out of pods.  There are two
alerts: KubeletTooManyPods, which will alert if a single node is
running too many pods, and KubeletTooManyPodsByAZNodeRole, which will
alert if the total pods for a given node role (eg "worker") in a given
AZ (eg "eu-west-2b") is too high.

The data is a bit fiddly to get - running pods are reported by
`kubelet`, which is simple enough, but allocatable pods are reported
by `kube-state-metrics`.  This means we have to do some awkward
many-to-one joins to combine the data from the two different metrics
sources.  Also, `kubelet` and `kube-state-metrics` expose the failure
domain labels in different ways (as target labels, or via the
`kube_node_labels` metric).  It turns out that the target labels are
easier to work with, hence my slightly odd use of `up{job="kubelet"}`
which is just there to make the
`failure_domain_beta_kubernetes_io_zone` label available on the
metric.

I created recording rules for `az_node_role_resource:allocatable:` and
`az_node_role:kubelet_running_pod_count:` since these felt like useful
metrics to keep around and possibly to put into grafana dashboards.