### PR TITLE
Allow more nodes during worker instance scaling

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -60,7 +60,7 @@ resource "aws_cloudformation_stack" "worker-nodes" {
     NodeGroupName                       = "worker"
     NodeAutoScalingGroupMinSize         = "${var.worker_count}"
     NodeAutoScalingGroupDesiredCapacity = "${var.worker_count}"
-    NodeAutoScalingGroupMaxSize         = "${var.worker_count + 1}"
+    NodeAutoScalingGroupMaxSize         = "${var.worker_count + 2}"
     NodeInstanceType                    = "${var.worker_instance_type}"
     NodeImageId                         = "${data.aws_ami.node_ami.image_id}"
     NodeVolumeSize                      = "40"


### PR DESCRIPTION
We've found that having to replace all instances in sandbox takes about 40
minutes and will take about 60 minutes in verify. This is because it does one
node at a time. We should be able to do twice as many node replacements at any
one time.