### PR TITLE
Reduce the name in the Virtual Service to under 63 characters

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/http-egress-safelist.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/http-egress-safelist.yaml
@@ -49,10 +49,10 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ $.Release.Name }}-http-egress-safelist-direct-{{ $egressFqdn.name }}-through-egress-gateway
+  name: {{ $.Release.Name }}-http-egress-safelist-{{ $egressFqdn.name }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-http-egress-safelist-direct-{{ $egressFqdn.name }}-through-egress-gateway
+    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-http-egress-safelist-{{ $egressFqdn.name }}
     helm.sh/chart: {{ include "gsp-cluster.chart" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}


### PR DESCRIPTION
This change addresses the following error message taken from apply job.

```
The VirtualService "..." is invalid: metadata.labels: Invalid value: "...": must be no more than 63 characters
```

Author: @adityapahuja