### PR TITLE
Service Operator: Attempt to fix DB policy creation

### DIFF
--- a/components/service-operator/internal/aws/aurora_postgres.go
+++ b/components/service-operator/internal/aws/aurora_postgres.go
@@ -91,7 +91,23 @@ func (p *AuroraPostgres) Template(stackName string, tags []resources.Tag) *cloud
 
 	template.Resources[PostgresResourceIAMPolicy] = &resources.AWSIAMPolicy{
 		PolicyName:     cloudformation.Join("-", []string{"postgres", "access", cloudformation.Ref(PostgresResourceCluster)}),
-		PolicyDocument: NewRolePolicyDocument([]string{cloudformation.Ref(PostgresResourceCluster)}, []string{"rds-data:*"}),
+		PolicyDocument: NewRolePolicyDocument(
+			[]string{
+				cloudformation.Join(
+					":",
+					[]string{
+						"arn",
+						"aws",
+						"rds",
+						cloudformation.Ref("AWS::Region"),
+						cloudformation.Ref("AWS::AccountId"),
+						"cluster",
+						cloudformation.Ref(PostgresResourceCluster),
+					},
+				),
+			},
+			[]string{"rds-data:*"},
+		),
 		Roles:          []string{p.IAMRoleName},
 	}
 


### PR DESCRIPTION
IAM Policy Resources are supposed to be ARNs, but this was a name.
Normally we would GetAtt ARN this, but it doesn't look like the RDS::DBCluster
resource has an ARN attribute.

This attempts to build an ARN instead, based on the format at https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Tagging.ARN.html