### PR TITLE
Attempt to fix commit signing check

### DIFF
--- a/pipelines/ci/check-pr-author-matches-commit-signature.yml
+++ b/pipelines/ci/check-pr-author-matches-commit-signature.yml
@@ -24,6 +24,8 @@ jobs:
     params:
       path: gsp-pr
       status: pending
+    get_params:
+      integration_tool: checkout
   - task: check
     config:
       platform: linux


### PR DESCRIPTION
We tell the PR resource to use checkout during the initial get, but then we put
pending status. When you put, it does an implicit get, which defaults to merge.
Then in our code we see the merged copy, which will not be a commit in the
upstream GitHub repo, so the check fails.