### PR TITLE
reduces length of name/labels in serviceentries

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/egress-safelist.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/egress-safelist.yaml
@@ -3,13 +3,8 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: {{ $.Release.Name }}-egress-safelist-{{ $egress.name }}
+  name: {{ $.Release.Name }}-{{ $egress.name }}
   namespace: {{ $.Release.Namespace }}
-  labels:
-    app.kubernetes.io/name: {{ include "gsp-cluster.name" $ }}-egress-safelist-{{ $egress.name }}
-    helm.sh/chart: {{ include "gsp-cluster.chart" $ }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
 spec:
 {{- $egress.service | toYaml | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
avoid character limits by simplifying generated names ... labels don't really make sense here and just cause trouble so remove them.