### PR TITLE
Add read access to CRDs used by the Verify Metadata Controller

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/viewer-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/viewer-cluster-role.yaml
@@ -9,3 +9,6 @@ rules:
   verbs: ["list", "get", "watch"]
 - nonResourceURLs: ["*"]
   verbs: ["list", "get"]
+- apiGroups: ["verify.govsvc.uk"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
This means that tenants with only read-only access will at least be able to see instances of the VMC's CRDs in a running cluster.