### PR TITLE
serialize operator builds 

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -205,6 +205,7 @@ jobs:
 
 - name: build-concourse-operator
   serial: true
+  serial_groups: [build-group-1]
   plan:
   - aggregate:
     - get: platform
@@ -225,6 +226,7 @@ jobs:
 
 - name: build-service-operator
   serial: true
+  serial_groups: [build-group-1]
   plan:
   - aggregate:
     - get: platform


### PR DESCRIPTION
# :cry:  

if both operators build at same time, then the node will not be
performant enough to run the tests in a timely mannor and one (usually
concourse-operator) will fail to execute tests.

serializing the build/tests of the two operator images should reduce
this issue and mean humans don't have to kick of flakey jobs again, but
this should be considered a temp solution, and a better one such as more
concourse nodes should be prefured as this will slow down builds