### PR TITLE
Fix SQS examples/docs to not have a queueName property under .spec.aws

### DIFF
--- a/components/service-operator/examples/sqs.yaml
+++ b/components/service-operator/examples/sqs.yaml
@@ -7,4 +7,5 @@ metadata:
     group.access.govsvc.uk: gsp.examples.test
 spec:
   aws:
-    queueName: sqs-sample
+    maximumMessageSize: 1024
+    messageRetentionPeriod: 3600

--- a/docs/gds-supported-platform/gsp-service-operator.md
+++ b/docs/gds-supported-platform/gsp-service-operator.md
@@ -15,7 +15,6 @@ items:
       group.access.govsvc.uk: alexs-test-principal
   spec:
     aws:
-      queueName: alexs-test-queue
       messageRetentionPeriod: 3600
       maximumMessageSize: 1024
     secret: alexs-test-queue-secret


### PR DESCRIPTION
In one of the examples add a couple of other fields as examples.