### PR TITLE
AUT-117: Add Grafana role

### DIFF
--- a/modules/gsp-cluster/grafana.tf
+++ b/modules/gsp-cluster/grafana.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "grafana" {
+  name               = "${var.cluster_name}-grafana"
+  description        = "Role the Grafana process assumes"
+  assume_role_policy = "${data.aws_iam_policy_document.trust_kiam_server.json}"
+}
+
+data "aws_iam_policy_document" "grafana_cloudwatch" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:GetMetricData",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "grafana" {
+  name   = "${var.cluster_name}-grafana"
+  role   = "${aws_iam_role.grafana.id}"
+  policy = "${data.aws_iam_policy_document.grafana_cloudwatch.json}"
+}


### PR DESCRIPTION
Grafana needs a role to get access to metrics in CloudWatch.

Author: @adityapahuja