### PR TITLE
Allow SRE to delete VirtualServices and Gateways

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -64,6 +64,9 @@ rules:
     resources:
     - virtualservices
     - gateways
+    - serviceentries
+    - destinationrules
+    - envoyfilters
     verbs:
     - delete
   - apiGroups: ["authentication.istio.io"]

--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -60,6 +60,12 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["networking.istio.io"]
+    resources:
+    - virtualservices
+    - gateways
+    verbs:
+    - delete
   - apiGroups: ["authentication.istio.io"]
     resources: ["*"]
     verbs:

--- a/docs/architecture/adr/ADR032-sre-permissions.md
+++ b/docs/architecture/adr/ADR032-sre-permissions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted, supplemented by [ADR038](ADR038-sre-permissions-istio.md)
 
 ## Context
 

--- a/docs/architecture/adr/ADR038-sre-permissions-istio.md
+++ b/docs/architecture/adr/ADR038-sre-permissions-istio.md
@@ -1,0 +1,25 @@
+# ADR038: SRE Permissions for Istio
+
+## Status
+
+Accepted
+
+## Context
+
+During [ADR032](ADR032-sre-permissions.md), only core Kubernetes resources were considered. (The context in that ADR is relevant here and should be read first.)
+It was realised after this that other things, such as Istio networking rules, also needed to be deleted sometimes, but could not be.
+These resources should all be ultimately sourced from Git and, if removed in error, should be replaced automatically the next time the deployment pipeline is run.
+
+## Decision
+
+We will add to the SRE permissions map the ability to delete the following Istio networking resources so an escalation to cluster admin is no longer necessary:
+
+* VirtualService
+* Gateway
+* ServiceEntry
+* DestinationRule
+* EnvoyFilter
+
+## Consequences
+
+Deleting one of the above resources may result in downtime, depending on context, and will self-correct when the deployment pipeline for the application is run again.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -40,3 +40,4 @@ We document our decisions using [Architecture Decision Records](https://github.c
 - [ADR #035 - Aurora postgres](ADR035-aurora-postgres.md)
 - [ADR #036 - CloudHSM isolation](ADR036-hsm-isolation-in-detail.md)
 - [ADR #037 - Per namespace istio gateways](ADR037-per-namespace-gateways.md)
+- [ADR #038 - SRE Permissions for Istio](ADR038-sre-permissions-istio.md)


### PR DESCRIPTION
Spoke to Chris about this and we'll probably want to get a few more approvals than is normally required, but should be sound. SREs can already delete Service resources and these should live in git too.