### PR TITLE
AUT-117: Add annotations to allow Grafana pod to assume a role

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -151,6 +151,8 @@ prometheus-operator:
           - "alerts-2.monitoring.gds-reliability.engineering"
           - "alerts-3.monitoring.gds-reliability.engineering"
         scheme: https
+  grafana:
+    podAnnotations: { iam.amazonaws.com/role: ${grafana_iam_role_name} }
 
 serviceOperator:
   kiamServerRoleARN: ${kiam_server_role_arn}

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -22,6 +22,7 @@ data "template_file" "values" {
     github_client_id                 = "${jsonencode(var.github_client_id)}"
     github_client_secret             = "${jsonencode(var.github_client_secret)}"
     github_ca_cert                   = "${jsonencode(var.github_ca_cert)}"
+    grafana_iam_role_name            = "${aws_iam_role.grafana.name}"
     harbor_admin_password            = "${jsonencode(random_string.harbor_password.result)}"
     harbor_secret_key                = "${jsonencode(random_string.harbor_secret_key.result)}"
     harbor_bucket_id                 = "${aws_s3_bucket.ci-system-harbor-registry-storage.id}"
@@ -50,10 +51,11 @@ data "template_file" "values" {
     private_db_subnet_group          = "${aws_db_subnet_group.private.id}"
 
     permitted_roles_regex = "^(${join("|", list(
-      aws_iam_role.harbor.name,
-      aws_iam_role.concourse.name,
       aws_iam_role.cloudwatch_log_shipping_role.name,
+      aws_iam_role.concourse.name,
+      aws_iam_role.grafana.name,
       aws_iam_role.gsp-service-operator.name,
+      aws_iam_role.harbor.name,
     ))})$"
   }
 }


### PR DESCRIPTION
This change adds annotation to Grafana pod to let Kiam know which role should be assumed. It also adds a namespace annotation to allow the pod to assume the role. The role allows Grafana to access CloudWatch's metrics.

Author: @adityapahuja