### PR TITLE
restrict HSM access to specific namespaces

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ .name }}
   labels:
     namespace: {{ .name }}
+{{- if .talksToHsm }}
+    talksToHsm: true
+{{- end }}
   annotations:
     iam.amazonaws.com/permitted: {{ $permittedRolesRegex | quote }}
 {{- end }}

--- a/charts/gsp-cluster/templates/02-gsp-system/egress-networkpolicy.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/egress-networkpolicy.yaml
@@ -18,5 +18,16 @@ spec:
       - 2223
       - 2224
       - 2225
+  - action: Deny
+    protocol: TCP
+    source:
+      namespaceSelector: namespace notin (verify-metadata-controller, verify-proxy-node-build, verify-proxy-node-integration, verify-proxy-node-prod)
+    destination:
+      nets:
+      - {{ .Values.global.cloudHsm.ip }}/32
+      ports:
+      - 2223
+      - 2224
+      - 2225
   - action: Allow
 

--- a/charts/gsp-cluster/templates/02-gsp-system/egress-networkpolicy.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/egress-networkpolicy.yaml
@@ -21,7 +21,7 @@ spec:
   - action: Deny
     protocol: TCP
     source:
-      namespaceSelector: namespace notin (verify-metadata-controller, verify-proxy-node-build, verify-proxy-node-integration, verify-proxy-node-prod)
+      namespaceSelector: talksToHsm != 'true'
     destination:
       nets:
       - {{ .Values.global.cloudHsm.ip }}/32

--- a/docs/architecture/adr/ADR036-hsm-isolation-in-detail.md
+++ b/docs/architecture/adr/ADR036-hsm-isolation-in-detail.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted, amended by [ADR039](ADR039-cloudhsm-namespace-network-policy.md)
 
 ## Context
 

--- a/docs/architecture/adr/ADR039-cloudhsm-namespace-network-policy.md
+++ b/docs/architecture/adr/ADR039-cloudhsm-namespace-network-policy.md
@@ -1,0 +1,54 @@
+# ADR039: Restricting CloudHSM network access to particular namespaces
+
+## Status
+
+Accepted
+
+## Context
+
+[ADR036](ADR036-hsm-isolation-in-detail.md) described the network and
+credential isolation we use to ensure that unauthorised users cannot
+access the CloudHSM.
+
+Recently in 3ea9de2ff, we introduced a GlobalNetworkPolicy object,
+which is a Calico feature that allows a cluster-wide network policy to
+be imposed.  This allows us to control network access to and from
+particular namespaces in a way which cannot be overridden by tenants.
+
+In particular, currently access to the HSM is only allowed from pods
+annotated with a `talksToHsm=true` label.
+
+When working in their own namespace, a developer has full control over
+what labels they put on their pods, so they can still choose to put
+the `talksToHsm=true` label on their pods.  But they do not have
+control over what labels the namespace itself has; to change this
+would require a change to the `gsp` or appropriate `cluster-config`
+repository, which would make such a change visible to many more
+people.
+
+Therefore, if we extend the GlobalNetworkPolicy to require a
+`talksToHsm=true` label on *both* the pod *and* the namespace, we will
+prevent tenants from unilaterally opening up network access to the HSM
+from their namespaces.
+
+## Decision
+
+We will augment the GlobalNetworkPolicy (previously described in ADR036) by:
+
+ - setting a `GlobalNetworkPolicy` that denies access to the
+   CloudHSM's IP address unless the pod carries a label
+   (`talksToHsm=true`) and the namespace also carries a label
+   (`talksToHsm=true`) and allows all other egress traffic
+
+## Consequences
+
+Control of which namespaces get the `talksToHsm=true` label will be
+via the appropriate `-cluster-config` repo.  If a developer wants to
+allow a new namespace to talk to the HSM, they will need to issue a PR
+against that repo.
+
+If we are confident in the GlobalNetworkPolicy's control of HSM
+access, we could consider reducing the technical controls required on
+non-HSM namespaces.  For example, we could consider allowing
+developers to run plain `kubectl apply` in unprivileged namespaces,
+for fast-feedback learning.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -41,3 +41,4 @@ We document our decisions using [Architecture Decision Records](https://github.c
 - [ADR #036 - CloudHSM isolation](ADR036-hsm-isolation-in-detail.md)
 - [ADR #037 - Per namespace istio gateways](ADR037-per-namespace-gateways.md)
 - [ADR #038 - SRE Permissions for Istio](ADR038-sre-permissions-istio.md)
+- [ADR #039 - Restricting CloudHSM network access to particular namespaces](ADR039-cloudhsm-namespace-network-policy.md)


### PR DESCRIPTION
This adds a rule to our GlobalNetworkPolicy that restricts access to
the HSM to specific, named namespaces.

The idea is: currently, it's technically possible for a tenant in a
non-proxy-node-managed namespace to open up access to the HSM for
themselves, by setting up appropriate NetworkPolicies and
ServiceEntries and DestinationRules and what have you, and by setting
the `talksToHsm` label to `true` on a particular pod.  There are a
bunch of controls to stop them doing it - see ADR036 for details - but
it remains a possibility.

If we add a GlobalNetworkPolicy rule that specificially identifies the
namespaces which are allowed to talk to the HSM, that completely shuts
down any possibility for somebody to open a network connection to the
HSM from an unauthorised namespace.  This feels like a win.

This should not be merged without an ADR amending ADR036 with the
updated network control.

A possible future improvement would be to set a `talksToHsm` label on
the appropriate namespaces, rather than having Verify-specific
namespace names in the global gsp repository.  (It would then be up to
namespace.yaml and/or verify-cluster-config to apply this label to the
appropriate namespaces).  Tenants should not be able to set labels on
their own namespaces, so this would provide the same level of security
control, without coupling the Verify-specific config to the global
cluster config.

However, although that would be a nicer design (IMHO), it would be
more work, and simply hardcoding the specific namespaces is better
than nothing.  We could always migrate to that design in future.