### PR TITLE
AUT-117: Add more permissions to Grafana role

### DIFF
--- a/modules/gsp-cluster/grafana.tf
+++ b/modules/gsp-cluster/grafana.tf
@@ -16,6 +16,28 @@ data "aws_iam_policy_document" "grafana_cloudwatch" {
 
     resources = ["*"]
   }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DescribeTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "tag:GetResources",
+    ]
+
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_role_policy" "grafana" {


### PR DESCRIPTION
Grafana role does not have sufficient permissions and Grafana is getting "Access Denied" messages when trying to access metrics from CloudWatch. This change adds missing permissions to Grafana role to match the minimal policy mentioned in https://grafana.com/docs/features/datasources/cloudwatch/. This should resolve the permission issues.

Author: @adityapahuja