### PR TITLE
AUT-117: Add a cloudwatch datasource to Grafana

### DIFF
--- a/charts/gsp-cluster/datasources/cloudwatch.yaml
+++ b/charts/gsp-cluster/datasources/cloudwatch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: 1
+
+datasources:
+  - name: Cloudwatch
+    type: cloudwatch
+    jsonData:
+      authType: credentials
+      defaultRegion: eu-west-2

--- a/charts/gsp-cluster/templates/02-gsp-system/grafana-datasource.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/grafana-datasource.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ .Release.Name }}-grafana-datasource'
+  namespace: {{ .Release.Namespace }}
+  labels:
+    grafana_datasource: "1"
+data:
+  datasource.yaml: |-
+{{ .Files.Get "datasources/cloudwatch.yaml" | indent 4 }}

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -374,6 +374,9 @@ prometheus-operator:
           target_label: node
   grafana:
     adminPassword: "password"
+    sidecar:
+      datasources:
+        enabled: true
   prometheusOperator:
     kubeletService:
       enabled: false

--- a/modules/gsp-cluster/grafana.tf
+++ b/modules/gsp-cluster/grafana.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "grafana_cloudwatch" {
     effect = "Allow"
 
     actions = [
+      "cloudwatch:DescribeAlarmsForMetric",
       "cloudwatch:ListMetrics",
       "cloudwatch:GetMetricStatistics",
       "cloudwatch:GetMetricData",


### PR DESCRIPTION
Grafana can start collecting metrics from the datasource. This change also adds a missing permission "cloudwatch:DescribeAlarmsForMetric" needed for Grafana to avoid permission errors.

Author: @adityapahuja