### PR TITLE
Correctly reference istio-system in resources

### DIFF
--- a/charts/gsp-istio/values.yaml
+++ b/charts/gsp-istio/values.yaml
@@ -1,4 +1,5 @@
 global:
+  istioNamespace: istio-system
   k8sIngressSelector: ingressgateway
   mtls:
     enabled: true


### PR DESCRIPTION
In order for gateways outside of istio-system to correctly reference the
services, the name needs to be provided to the various templates.