### PR TITLE
IAM roles for read-only users: Add CloudFormation and IAM read-only policies

### DIFF
--- a/modules/gsp-user/iam.tf
+++ b/modules/gsp-user/iam.tf
@@ -54,6 +54,16 @@ resource "aws_iam_role_policy_attachment" "user-defaults-cloudwatch" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "user-defaults-cloudformation" {
+  role       = "${aws_iam_role.user.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "user-defaults-iam" {
+  role       = "${aws_iam_role.user.name}"
+  policy_arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "user-defaults-view-only" {
   role       = "${aws_iam_role.user.name}"
   policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"


### PR DESCRIPTION
These are missing and it makes it difficult to reason about the stacks
CloudFormation doesn't like which were generated by the service operator.

Since this is just read-only stuff I don't think we need a whole ADR etc. for
this?