### PR TITLE
AUT-117: Fix unmarshall error

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -375,8 +375,8 @@ prometheus-operator:
           target_label: node
   grafana:
     adminPassword: "password"
-    additionalDataSources:
-      {{ .Files.Get "datasources/cloudwatch.yaml" | indent 6 }}
+    additionalDataSources: |-
+{{ .Files.Get "datasources/cloudwatch.yaml" | indent 6 }}
   prometheusOperator:
     kubeletService:
       enabled: false


### PR DESCRIPTION
Helm fails to unmarshall from []byte to yaml. This change removes unnecessary indentations and adds a missing `|-` to additionalDataSources to resolve the error.

Author: @adityapahuja