### PR TITLE
AUT-117: Fix Grafana's datasources list

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -375,16 +375,12 @@ prometheus-operator:
           target_label: node
   grafana:
     adminPassword: "password"
-    additionalDataSources: |-
-      ---
-      apiVersion: 1
-
-      datasources:
-        - name: Cloudwatch
-          type: cloudwatch
-          jsonData:
-            authType: credentials
-            defaultRegion: eu-west-2
+    additionalDataSources:
+      - name: Cloudwatch
+        type: cloudwatch
+        jsonData:
+          authType: credentials
+          defaultRegion: eu-west-2
   prometheusOperator:
     kubeletService:
       enabled: false


### PR DESCRIPTION
`additionalDataSources` already has Prometheus datasource. This change simply adds CloudWatch datasource to the datasources list.

Author: @adityapahuja