### PR TITLE
fix SQS CRD

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/crd/queue.govsvc.uk_sqs.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/crd/queue.govsvc.uk_sqs.yaml
@@ -35,21 +35,21 @@ spec:
               type: object
               properties:
                 contentBasedDeduplication:
-                  type: bool
+                  type: boolean
                 delaySeconds:
-                  type: int
+                  type: integer
                 fifoQueue:
-                  type: bool
+                  type: boolean
                 maximumMessageSize:
-                  type: int
+                  type: integer
                 messageRetentionPeriod:
-                  type: int
+                  type: integer
                 receiveMessageWaitTimeSeconds:
-                  type: int
+                  type: integer
                 redrivePolicy:
                   type: string
                 visibilityTimeout:
-                  type: int
+                  type: integer
             secret:
               description: Secret name to be used for storing relevant instance secrets
                 for further use.


### PR DESCRIPTION
The data types used here are OpenAPI v3 data types:
https://swagger.io/docs/specification/data-models/data-types/

This fixes the spellings to use the correct names of types.