### PR TITLE
Remove duplicate namespace definition.

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -13,17 +13,6 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- $defaultedPermittedRolesRegex := .permittedRolesRegex | default "^$" }}
-{{- $permittedRolesRegex := printf "%s|^svcop-%s-%s-.*$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .name }}
-  labels:
-    namespace: {{ .name }}
-  annotations:
-    iam.amazonaws.com/permitted: {{ $permittedRolesRegex | quote }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
This was lost somewhere in a rebase and should have been included in https://github.com/alphagov/gsp/pull/390