### PR TITLE
Increase timeout of control-plane initialisation in concourse operator tests

### DIFF
--- a/components/concourse-operator/Dockerfile
+++ b/components/concourse-operator/Dockerfile
@@ -23,6 +23,8 @@ COPY . .
 RUN sh -c 'if [ -e ./vendor ]; then echo skipping dep ensure as found vendor dir 1>&2; else dep ensure -vendor-only; fi'
 
 # run unit tests
+ENV KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=1m
+ENV KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT=1m
 RUN go test -v ./pkg/... ./cmd/...
 
 # build manager


### PR DESCRIPTION
The defaults (20 seconds) come from:

https://github.com/kubernetes-sigs/controller-runtime/blob/ab6131a999ca9e6ff5bf83dba70dc7751751135f/pkg/envtest/server.go#L43-L44
