### PR TITLE
Allow devs and sres to read Metadata and CertificateRequest objects

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -83,6 +83,12 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["verify.gov.uk"]
+    resources: ["certificaterequests", "metadata"]
+    verbs:
+    - get
+    - list
+    - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -115,6 +115,12 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["verify.gov.uk"]
+    resources: ["certificaterequests", "metadata"]
+    verbs:
+    - get
+    - list
+    - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
There shouldn't be anything sensitive in these so it should be safe to
allow read-only access to them.

This would help immensely with debugging verify-metadata-controller
issues.

Would appreciate 👀 from team eIDAS to confirm that there's nothing sensitive here.