### PR TITLE
Fix multi namespace external dns 

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/ingress-gateways.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/ingress-gateways.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/chart: {{ include "gsp-cluster.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    externaldns.k8s.io/namespace: {{ .Release.Namespace }}
 spec:
   selector:
     istio: {{ .Release.Namespace }}-ingressgateway

--- a/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
@@ -16,6 +16,7 @@
 #   iam.amazonaws.com/role: ${external_dns_iam_role_name}
 # istioIngressGateways:
 # - istio-system/ingressgateway
+# annotationFilter: externaldns.k8s.io/namespace=my-namespace
 #
 #
 # The various resources were then updated manually with necessary templating to bring inline with gsp-cluster
@@ -97,6 +98,7 @@ spec:
         - --registry=txt
         - --interval=1m
         - --txt-owner-id=external-dns-{{ $.Values.global.cluster.name }}-{{ .name }}
+        - --annotation-filter=externaldns.k8s.io/namespace={{ .name }}
         - --istio-ingress-gateway={{ .name }}/{{ .name }}-ingressgateway
         - --source=istio-gateway
         # AWS arguments

--- a/components/canary/chart/templates/gateway.yaml
+++ b/components/canary/chart/templates/gateway.yaml
@@ -7,6 +7,8 @@ metadata:
     helm.sh/chart: {{ include "gsp-canary.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    externaldns.k8s.io/namespace: {{ .Release.Namespace }}
 spec:
   selector:
     istio: {{ .Release.Namespace }}-ingressgateway


### PR DESCRIPTION
External-dns was still picking up `Gateway` resources from all namespaces. The mechanism in external-dns to fix this is `annotation filter`. So add one and fix the other resources accordingly.