### PR TITLE
Provision a Principal per-namespace

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -337,4 +337,14 @@ spec:
               echo "applying manifests from ${SRC_URI} at path ${PATH_TO_MANIFESTS} to ${RELEASE_NAMESPACE}"
               kubectl apply $NS_ARGS -R -f "./src/${PATH_TO_MANIFESTS}"
 {{- end }}
+{{- if .principal }}
+---
+apiVersion: v1
+kind: Principal
+apiVersion: access.govsvc.uk/v1beta1
+metadata:
+  name: {{ .name }}-principal
+  labels:
+    group.access.govsvc.uk: {{ .name }}-principal
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Trying to provision a Principal at the same time as any other AWS
resources using the service operator can lead to a race condition where
the IAM role hasn't been created by the time CloudFormation tries to
provision the other resources. At this point the stack creation with
fail and everything ends up in a bad state.

We might as well provision a Principal when setting up the namespace
to allow for trouble-free provisioning of AWS services in the
namespace's own charts.