### PR TITLE
Managed namespace: Try setting talksToHsm as a quoted string

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     namespace: {{ .name }}
 {{- if .talksToHsm }}
-    talksToHsm: true
+    talksToHsm: "true"
 {{- end }}
   annotations:
     iam.amazonaws.com/permitted: {{ $permittedRolesRegex | quote }}


### PR DESCRIPTION
Currently although it looks like a boolean we are getting
for: "manifests/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml": unrecognized type: string
Chris thinks this might work.