### PR TITLE
Allow access to prometheus-operator CRDs

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -61,6 +61,12 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
   - apiGroups: [""]
     resources: ["services/proxy"]
     verbs:

--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -87,6 +87,12 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
   - apiGroups: [""]
     resources: ["services/proxy"]
     verbs:


### PR DESCRIPTION
The prometheus operator chart defines the following CRDs:

 - Alertmanager
 - PodMonitor
 - Prometheus
 - PrometheusRule
 - ServiceMonitor

None of these contain any sensitive information.  We should open these
up to make debugging easier.