### PR TITLE
allow SREs to clean up prometheus config

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -93,6 +93,10 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["podmonitors", "prometheusrules", "servicemonitors"]
+    verbs:
+    - delete
   - apiGroups: ["crd.projectcalico.org"]
     resources: ["*"]
     verbs:


### PR DESCRIPTION
we have some stray `servicemonitors` that we want to clean up.
Specifically, since 583ee5053 we no longer need
servicemonitor/gsp-prometheus-operator-kubelet in gsp-system and we'd
like to delete it.

I think we should be able to delete any of the prometheus config
types, so I've added them all as things that SREs can delete.