### PR TITLE
Use Secret Discovery Service (SDS) in namespace gateways

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/ingress-certificate.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/ingress-certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: ingress-certificate
+  name: {{ .Release.Name }}-ingress-certificate
   namespace: {{ .Release.Namespace }}
 spec:
   secretName: istio-ingressgateway-certs

--- a/charts/gsp-cluster/templates/02-gsp-system/ingress-gateways.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/ingress-gateways.yaml
@@ -29,8 +29,9 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-      privateKey: /etc/istio/ingressgateway-certs/tls.key
+      serverCertificate: sds
+      privateKey: sds
+      credentialName: {{ .Release.Name }}-ingress-certificate
     hosts:
     - "ci.{{ .Values.global.cluster.domain }}"
     - "registry.{{ .Values.global.cluster.domain }}"

--- a/components/canary/chart/templates/gateway.yaml
+++ b/components/canary/chart/templates/gateway.yaml
@@ -27,7 +27,8 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-      privateKey: /etc/istio/ingressgateway-certs/tls.key
+      serverCertificate: sds
+      privateKey: sds
+      credentialName: {{ include "gsp-canary.fullname" . }}-ingress-certificate
     hosts:
     - "canary.{{ .Values.global.cluster.domain }}"

--- a/components/canary/chart/templates/ingress-certificate.yaml
+++ b/components/canary/chart/templates/ingress-certificate.yaml
@@ -1,0 +1,18 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "gsp-canary.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ include "gsp-canary.fullname" . }}-ingress-certificate
+  dnsNames:
+  - "canary.{{ .Values.global.cluster.domain }}"
+  acme:
+    config:
+    - dns01:
+        provider: route53
+      domains:
+      - "canary.{{ .Values.global.cluster.domain }}"
+  issuerRef:
+    name: letsencrypt-r53
+    kind: ClusterIssuer

--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -15,7 +15,7 @@ istio:
       #
       sds:
         # If true, ingress gateway fetches credentials from SDS server to handle TLS connections.
-        enabled: false
+        enabled: true
         # SDS server that watches kubernetes secrets and provisions credentials to ingress gateway.
         # This server runs in the same pod as ingress gateway.
         image: node-agent-k8s


### PR DESCRIPTION
SDS is preferable to file-based volume mounts as it allows a much more sensible split in how certificates are managed across applications.

See also: https://istio.io/docs/tasks/traffic-management/ingress/secure-ingress-sds/