### PR TITLE
Add missing roles and rolebindings for gsp-system.

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/ingress-certificate.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/ingress-certificate.yaml
@@ -1,10 +1,10 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: {{ .Release.Name }}-ingress-certificate
+  name: {{ .Release.Name }}-ingress
   namespace: {{ .Release.Namespace }}
 spec:
-  secretName: istio-ingressgateway-certs
+  secretName: {{ .Release.Name }}-ingress-certificate
   dnsNames:
   - "ci.{{ .Values.global.cluster.domain }}"
   - "registry.{{ .Values.global.cluster.domain }}"

--- a/charts/gsp-cluster/templates/02-gsp-system/ingress-sds-role.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/ingress-sds-role.yaml
@@ -1,0 +1,11 @@
+# Reverse-engineering from istio chart due to some missing logic in istio chart
+# TODO: This Role can be removed when Istio is upgraded to >= 1.2.0
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Namespace }}-ingressgateway-sds
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]

--- a/charts/gsp-cluster/templates/02-gsp-system/ingress-sds-rolebinding.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/ingress-sds-rolebinding.yaml
@@ -1,0 +1,14 @@
+# Reverse-engineering from istio chart due to some missing logic in istio chart
+# TODO: This RoleBinding can be removed when Istio is upgraded to >= 1.2.0
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-ingressgateway-sds
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Namespace }}-ingressgateway-sds
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Namespace }}-ingressgateway-service-account

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -64,6 +64,7 @@ spec:
   - from: []
 ---
 # Reverse-engineering from istio chart due to some missing logic in istio chart
+# TODO: This Role can be removed when Istio is upgraded to >= 1.2.0
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -75,6 +76,7 @@ rules:
   verbs: ["get", "watch", "list"]
 ---
 # Reverse-engineering from istio chart due to some missing logic in istio chart
+# TODO: This RoleBinding can be removed when Istio is upgraded to >= 1.2.0
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
`gsp-system` is not in the list of "managed" namespaces, but from a per-namespace gateway perspective it sort of should be. So this was missed in https://github.com/alphagov/gsp/pull/485.