### PR TITLE
Grant users access to AWS support

### DIFF
--- a/modules/gsp-user/iam.tf
+++ b/modules/gsp-user/iam.tf
@@ -59,6 +59,11 @@ resource "aws_iam_role_policy_attachment" "user-defaults-cloudformation" {
   policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "user-defaults-aws-support" {
+  role       = "${aws_iam_role.user.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSSupportAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "user-defaults-iam" {
   role       = "${aws_iam_role.user.name}"
   policy_arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"


### PR DESCRIPTION
Without this we end up in a situation where RE has to operate as a kind
of proxy between tenants and AWS support. I think we should just let
tenants raise tickets as and when they need them. We're paying AWS to
support us and we may as well let our users take advantage of this.

Also, this is the most finely grained permission available for
`support`[1]:

> Support doesn't let you allow or deny access to individual actions.
> Therefore, the Action element of a policy is always set to support:*.
> Similarly, Support doesn't provide resource-level access, so the
> Resource element is always set to *. An IAM user with Support
> permissions has access to all Support operations and resources.

[1] https://docs.aws.amazon.com/awssupport/latest/user/getting-started.html