### PR TITLE
Allow service operator to set up account for RDS access

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -93,6 +93,22 @@ data "aws_iam_policy_document" "service-operator" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/svcop-${var.cluster_name}-*",
     ]
   }
+
+  statement {
+    actions = [
+      "iam:CreateServiceLinkedRole"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS"
+    ]
+    condition {
+      test = "StringLike"
+      variable = "iam:AWSServiceName"
+      values = [
+        "rds.amazonaws.com"
+      ]
+    }
+  }
 }
 
 resource "aws_iam_policy" "service-operator" {


### PR DESCRIPTION
It turns out RDS requires a special role to be created in an account before it
can be used:
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.ServiceLinkedRoles.html

The sandbox account had this already for some reason, but the verify account is
missing it. CloudFormation will do this for the service operator if we give it
these permissions.