### PR TITLE
Disconnect component builds in release pipeline

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -36,6 +36,8 @@ resources:
     uri: https://github.com/alphagov/gsp.git
     organization: alphagov
     repository: gsp
+    ignore_paths:
+      - components
     github_api_token: ((github-api-token))
     approvers: ((github-approvers))
     required_approval_count: 0
@@ -49,7 +51,7 @@ resources:
     organization: alphagov
     repository: gsp
     paths:
-      - components/concourse-github-resource/*
+      - components/concourse-github-resource
     github_api_token: ((github-api-token))
     approvers: ((github-approvers))
     required_approval_count: 0
@@ -63,7 +65,7 @@ resources:
     organization: alphagov
     repository: gsp
     paths:
-      - components/concourse-harbor-resource/*
+      - components/concourse-harbor-resource
     github_api_token: ((github-api-token))
     approvers: ((github-approvers))
     required_approval_count: 0
@@ -77,7 +79,7 @@ resources:
     organization: alphagov
     repository: gsp
     paths:
-      - components/concourse-operator/*
+      - components/concourse-operator
     github_api_token: ((github-api-token))
     approvers: ((github-approvers))
     required_approval_count: 0
@@ -91,7 +93,7 @@ resources:
     organization: alphagov
     repository: gsp
     paths:
-      - components/service-operator/*
+      - components/service-operator
     github_api_token: ((github-api-token))
     approvers: ((github-approvers))
     required_approval_count: 0
@@ -175,9 +177,11 @@ jobs:
   serial: true
   serial_groups: [release]
   plan:
-  - get: platform
-    trigger: true
-  - get: users
+  - in_parallel:
+    - get: platform
+      trigger: true
+    - get: users
+      trigger: true
   - task: generate-trusted-contributors
     file: platform/pipelines/tasks/generate-trusted-contributors.yaml
     params:
@@ -195,29 +199,24 @@ jobs:
           branch: ((branch))
           pipeline-name: ((pipeline-name))
           github-release-tag-prefix: ((github-release-tag-prefix))
-  - put: semver
-    params:
-      bump: patch
 
 - name: build-concourse-task-toolbox
   serial: true
   serial_groups: [build-concourse-task-toolbox]
   plan:
-  - aggregate:
+  - in_parallel:
     - get: platform
       passed: [selfupdate]
       trigger: true
-    - get: semver
-      passed: [selfupdate]
-  - get: concourse-task-toolbox
-    params:
-      save: true
+    - get: concourse-task-toolbox
+      params:
+        save: true
   - put: concourse-task-toolbox
     params:
       build: platform/components/concourse-task-toolbox
       dockerfile: platform/components/concourse-task-toolbox/Dockerfile
       load_base: concourse-task-toolbox
-      tag_file: semver/version
+      tag_file: platform/.git/short_ref
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
     get_params:
@@ -227,18 +226,13 @@ jobs:
   serial: true
   serial_groups: [build-concourse-github-resource]
   plan:
-  - aggregate:
-    - get: platform
-      passed: [selfupdate]
-    - get: concourse-github-resource-source
-      trigger: true
-    - get: semver
-      passed: [selfupdate]
+  - get: concourse-github-resource-source
+    trigger: true
   - put: concourse-github-resource
     params:
       build: concourse-github-resource-source/components/concourse-github-resource
       dockerfile: concourse-github-resource-source/components/concourse-github-resource/Dockerfile
-      tag_file: semver/version
+      tag_file: concourse-github-resource-source/.git/short_ref
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
     get_params:
@@ -248,18 +242,13 @@ jobs:
   serial: true
   serial_groups: [build-concourse-harbor-resource]
   plan:
-  - aggregate:
-    - get: platform
-      passed: [selfupdate]
-    - get: concourse-harbor-resource-source
-      trigger: true
-    - get: semver
-      passed: [selfupdate]
+  - get: concourse-harbor-resource-source
+    trigger: true
   - put: concourse-harbor-resource
     params:
       build: concourse-harbor-resource-source/components/concourse-harbor-resource
       dockerfile: concourse-harbor-resource-source/components/concourse-harbor-resource/Dockerfile
-      tag_file: semver/version
+      tag_file: concourse-harbor-resource-source/.git/short_ref
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
     get_params:
@@ -269,18 +258,13 @@ jobs:
   serial: true
   serial_groups: [build-concourse-operator]
   plan:
-  - aggregate:
-    - get: platform
-      passed: [selfupdate]
-    - get: concourse-operator-source
-      trigger: true
-    - get: semver
-      passed: [selfupdate]
+  - get: concourse-operator-source
+    trigger: true
   - put: concourse-operator
     params:
       build: concourse-operator-source/components/concourse-operator
       dockerfile: concourse-operator-source/components/concourse-operator/Dockerfile
-      tag_file: semver/version
+      tag_file: concourse-operator-source/.git/short_ref
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
     get_params:
@@ -290,24 +274,19 @@ jobs:
   serial: true
   serial_groups: [build-service-operator]
   plan:
-  - aggregate:
-    - get: platform
-      passed: [selfupdate]
-    - get: service-operator-source
-      trigger: true
-    - get: semver
-      passed: [selfupdate]
+  - get: service-operator-source
+    trigger: true
   - put: service-operator
     params:
       build: service-operator-source/components/service-operator
       dockerfile: service-operator-source/components/service-operator/Dockerfile
-      tag_file: semver/version
+      tag_file: service-operator-source/.git/short_ref
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
     get_params:
       skip_download: true
 
-- name: package
+- name: bump-version
   serial: true
   serial_groups:
     - release
@@ -317,7 +296,7 @@ jobs:
     - build-concourse-operator
     - build-service-operator
   plan:
-  - aggregate:
+  - in_parallel:
     - get: platform
       passed: [build-concourse-task-toolbox]
       trigger: true
@@ -325,14 +304,41 @@ jobs:
       passed: [build-concourse-task-toolbox]
     - get: concourse-github-resource
       passed: [build-concourse-github-resource]
+      trigger: true
     - get: concourse-harbor-resource
       passed: [build-concourse-harbor-resource]
+      trigger: true
     - get: concourse-operator
       passed: [build-concourse-operator]
+      trigger: true
     - get: service-operator
       passed: [build-service-operator]
+      trigger: true
+  - put: semver
+    params:
+      bump: patch
+
+- name: package
+  serial: true
+  serial_groups:
+    - release
+  plan:
+  - in_parallel:
     - get: semver
-      passed: [build-concourse-task-toolbox]
+      passed: [bump-version]
+      trigger: true
+    - get: platform
+      passed: [bump-version]
+    - get: concourse-task-toolbox
+      passed: [bump-version]
+    - get: concourse-github-resource
+      passed: [bump-version]
+    - get: concourse-harbor-resource
+      passed: [bump-version]
+    - get: concourse-operator
+      passed: [bump-version]
+    - get: service-operator
+      passed: [bump-version]
   - task: generate-gsp-cluster-values
     image: concourse-task-toolbox
     config:

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -201,6 +201,7 @@ jobs:
 
 - name: build-concourse-task-toolbox
   serial: true
+  serial_groups: [build-concourse-task-toolbox]
   plan:
   - aggregate:
     - get: platform
@@ -222,6 +223,7 @@ jobs:
 
 - name: build-concourse-github-resource
   serial: true
+  serial_groups: [build-concourse-github-resource]
   plan:
   - aggregate:
     - get: platform
@@ -244,6 +246,7 @@ jobs:
 
 - name: build-concourse-harbor-resource
   serial: true
+  serial_groups: [build-concourse-harbor-resource]
   plan:
   - aggregate:
     - get: platform
@@ -266,7 +269,7 @@ jobs:
 
 - name: build-concourse-operator
   serial: true
-  serial_groups: [build-group-1]
+  serial_groups: [build-concourse-operator]
   plan:
   - aggregate:
     - get: platform
@@ -289,7 +292,7 @@ jobs:
 
 - name: build-service-operator
   serial: true
-  serial_groups: [build-group-1]
+  serial_groups: [build-service-operator]
   plan:
   - aggregate:
     - get: platform
@@ -312,17 +315,18 @@ jobs:
 
 - name: package
   serial: true
-  serial_groups: [release]
+  serial_groups:
+    - release
+    - build-concourse-task-toolbox
+    - build-concourse-github-resource
+    - build-concourse-harbor-resource
+    - build-concourse-operator
+    - build-service-operator
   plan:
   - aggregate:
     - get: platform
+      passed: [build-concourse-task-toolbox]
       trigger: true
-      passed:
-      - build-concourse-task-toolbox
-      - build-concourse-github-resource
-      - build-concourse-harbor-resource
-      - build-concourse-operator
-      - build-service-operator
     - get: concourse-task-toolbox
       passed: [build-concourse-task-toolbox]
     - get: concourse-github-resource
@@ -334,12 +338,7 @@ jobs:
     - get: service-operator
       passed: [build-service-operator]
     - get: semver
-      passed:
-      - build-concourse-task-toolbox
-      - build-concourse-github-resource
-      - build-concourse-harbor-resource
-      - build-concourse-operator
-      - build-service-operator
+      passed: [build-concourse-task-toolbox]
   - task: generate-gsp-cluster-values
     image: concourse-task-toolbox
     config:

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -209,15 +209,17 @@ jobs:
       trigger: true
     - get: semver
       passed: [selfupdate]
+  - get: concourse-task-toolbox
+    params:
+      save: true
   - put: concourse-task-toolbox
     params:
       build: platform/components/concourse-task-toolbox
       dockerfile: platform/components/concourse-task-toolbox/Dockerfile
+      load_base: concourse-task-toolbox
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
-      cache: true
-      cache_tag: latest
     get_params:
       skip_download: true
 
@@ -239,8 +241,6 @@ jobs:
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
-      cache: true
-      cache_tag: latest
     get_params:
       skip_download: true
 
@@ -262,8 +262,6 @@ jobs:
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
-      cache: true
-      cache_tag: latest
     get_params:
       skip_download: true
 
@@ -285,8 +283,6 @@ jobs:
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
-      cache: true
-      cache_tag: latest
     get_params:
       skip_download: true
 
@@ -308,8 +304,6 @@ jobs:
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
-      cache: true
-      cache_tag: latest
     get_params:
       skip_download: true
 

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -42,6 +42,62 @@ resources:
     branch: ((branch))
     commit_verification_keys: ((trusted-developer-keys))
 
+- name: concourse-github-resource-source
+  type: github
+  source:
+    uri: https://github.com/alphagov/gsp.git
+    organization: alphagov
+    repository: gsp
+    paths:
+      - components/concourse-github-resource/*
+    github_api_token: ((github-api-token))
+    approvers: ((github-approvers))
+    required_approval_count: 0
+    branch: ((branch))
+    commit_verification_keys: ((trusted-developer-keys))
+
+- name: concourse-harbor-resource-source
+  type: github
+  source:
+    uri: https://github.com/alphagov/gsp.git
+    organization: alphagov
+    repository: gsp
+    paths:
+      - components/concourse-harbor-resource/*
+    github_api_token: ((github-api-token))
+    approvers: ((github-approvers))
+    required_approval_count: 0
+    branch: ((branch))
+    commit_verification_keys: ((trusted-developer-keys))
+
+- name: concourse-operator-source
+  type: github
+  source:
+    uri: https://github.com/alphagov/gsp.git
+    organization: alphagov
+    repository: gsp
+    paths:
+      - components/concourse-operator/*
+    github_api_token: ((github-api-token))
+    approvers: ((github-approvers))
+    required_approval_count: 0
+    branch: ((branch))
+    commit_verification_keys: ((trusted-developer-keys))
+
+- name: service-operator-source
+  type: github
+  source:
+    uri: https://github.com/alphagov/gsp.git
+    organization: alphagov
+    repository: gsp
+    paths:
+      - components/service-operator/*
+    github_api_token: ((github-api-token))
+    approvers: ((github-approvers))
+    required_approval_count: 0
+    branch: ((branch))
+    commit_verification_keys: ((trusted-developer-keys))
+
 - name: users
   type: github-release
   source:
@@ -170,13 +226,14 @@ jobs:
   - aggregate:
     - get: platform
       passed: [selfupdate]
+    - get: concourse-github-resource-source
       trigger: true
     - get: semver
       passed: [selfupdate]
   - put: concourse-github-resource
     params:
-      build: platform/components/concourse-github-resource
-      dockerfile: platform/components/concourse-github-resource/Dockerfile
+      build: concourse-github-resource-source/components/concourse-github-resource
+      dockerfile: concourse-github-resource-source/components/concourse-github-resource/Dockerfile
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
@@ -191,13 +248,14 @@ jobs:
   - aggregate:
     - get: platform
       passed: [selfupdate]
+    - get: concourse-harbor-resource-source
       trigger: true
     - get: semver
       passed: [selfupdate]
   - put: concourse-harbor-resource
     params:
-      build: platform/components/concourse-harbor-resource
-      dockerfile: platform/components/concourse-harbor-resource/Dockerfile
+      build: concourse-harbor-resource-source/components/concourse-harbor-resource
+      dockerfile: concourse-harbor-resource-source/components/concourse-harbor-resource/Dockerfile
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
@@ -213,13 +271,14 @@ jobs:
   - aggregate:
     - get: platform
       passed: [selfupdate]
+    - get: concourse-operator-source
       trigger: true
     - get: semver
       passed: [selfupdate]
   - put: concourse-operator
     params:
-      build: platform/components/concourse-operator
-      dockerfile: platform/components/concourse-operator/Dockerfile
+      build: concourse-operator-source/components/concourse-operator
+      dockerfile: concourse-operator-source/components/concourse-operator/Dockerfile
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true
@@ -235,13 +294,14 @@ jobs:
   - aggregate:
     - get: platform
       passed: [selfupdate]
+    - get: service-operator-source
       trigger: true
     - get: semver
       passed: [selfupdate]
   - put: service-operator
     params:
-      build: platform/components/service-operator
-      dockerfile: platform/components/service-operator/Dockerfile
+      build: service-operator-source/components/service-operator
+      dockerfile: service-operator-source/components/service-operator/Dockerfile
       tag_file: semver/version
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true


### PR DESCRIPTION
## What

seperate triggering of component container builds (operators, concourse-resources etc) from the main gsp package build.

![screenshot](https://user-images.githubusercontent.com/45921/64713583-08019000-d4b5-11e9-992e-9568e13c553f.png)

## Why

So we don't have to wait for slow container builds to complete when we haven't made any changes to them.