### PR TITLE
Attempt to fix service operator RDS support

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -131,6 +131,7 @@ data "aws_iam_policy_document" "service-operator-managed-role-permissions-bounda
       "sqs:ReceiveMessage",
       "sqs:DeleteMessage",
       "sqs:GetQueueAttributes",
+      "rds:*",
     ]
 
     resources = [


### PR DESCRIPTION
This is broken in Verify at the moment possibly relating to a service-linked
role problem. AWS think it relates to this permissions boundary and that this
might fix things.