### PR TITLE
relax concourse github PR approval rules

### DIFF
--- a/components/concourse-github-resource/assets/in
+++ b/components/concourse-github-resource/assets/in
@@ -104,16 +104,10 @@ api_response=$( \
 )
 
 pr_author=$(echo $api_response | jq ".data.repository.object.associatedPullRequests.nodes[].author.login")
-commit_signature_author=$(echo $api_response | jq ".data.repository.object.associatedPullRequests.nodes[].commits.nodes[0].commit.signature.signer.login")
+commit_signature_author=$(echo $api_response | jq --raw-output ".data.repository.object.associatedPullRequests.nodes[].commits.nodes[0].commit.signature.signer.login")
 
-if [ $pr_author == $commit_signature_author ]; then
-  echo "OK: PR author matches commit signature author."
-else
-  echo "ERROR: PR author ($pr_author) doesn't match commit signature author ($commit_signature_author)."
-  exit 1
-fi
+approvals=$(echo "${api_response}" | jq --raw-output .data.repository.object.associatedPullRequests.nodes[].reviews.nodes[].author.login | grep -v "${commit_signature_author}" | sort -d)
 
-approvals=$(echo "${api_response}" | jq --raw-output .data.repository.object.associatedPullRequests.nodes[].reviews.nodes[].author.login | sort -d)
 
 valid_approval_count=$(\
   comm -12 \
@@ -131,6 +125,7 @@ if [[ "${valid_approval_count}" -lt "${required_approval_count}" ]]; then
   comm -23 \
     <(echo "${approvers}") \
     <(echo "${approvals}") \
+  | grep -v "${commit_signature_author}" \
   | grep -v "${pr_author}" \
   | xargs -I {} echo "[FAILURE]   - {}"
 


### PR DESCRIPTION
Currently, our concourse-github-resource requires that the author of a
PR is the same person as the signer of the last commit in the PR.
This is annoying when someone opens a PR and then goes on leave or is
ill or something and somebody else wants to finish off the work.

This changes the behaviour so that we simply discount the commit
signer from being able to approve their own work.  If you sign a
commit and push to a PR (regardless of who originally opened the PR),
we ignore your approval and you need to get someone else to approve
it.

This is more permissive than the previous version, but it still
enforces that nobody can approve their own code.

I tested this by running locally against two PRs:

 - #495 - opened by @samcrang, re-signed by me, approved by
   @blairboy362 and @Krenair; this was approved (but would be rejected
   by the current resource)
 - #496 - opened by @samcrang, re-signed by me and approved by me;
   this was rejected (because I shouldn't be able to approve my own
   commit)

@samcrang saw me run these manual tests.