### PR TITLE
create deployer.defaults.yaml fresh, don't append

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -523,7 +523,7 @@ jobs:
           EOF
           cat overrides.yaml
           echo "merging with default values..."
-          spruce merge ./platform/pipelines/deployer/deployer.defaults.yaml ./overrides.yaml | tee -a ./deployer-package/deployer.defaults.yaml
+          spruce merge ./platform/pipelines/deployer/deployer.defaults.yaml ./overrides.yaml | tee ./deployer-package/deployer.defaults.yaml
   - put: candidate-release
     params:
       name: semver/version


### PR DESCRIPTION
The file we were creating had a bunch of duplicate fields.  What seems
to be happening is that deployer.defaults.yaml exists already in the
target location, and we append to it, with a bunch of duplicate keys.

We should just create the whole file from scratch here i think?