### PR TITLE
fixes ability to manually set deployer pipeline

### DIFF
--- a/hack/set-deployer-pipeline.sh
+++ b/hack/set-deployer-pipeline.sh
@@ -17,7 +17,8 @@ $FLY_BIN -t cd-gsp set-pipeline -p "${PIPELINE_NAME}" \
 	--config "pipelines/deployer/deployer.yaml" \
 	--load-vars-from "pipelines/deployer/deployer.defaults.yaml" \
 	--load-vars-from "${CLUSTER_CONFIG}" \
-	--yaml-var 'config-approvers=[]' \
+	--yaml-var 'config-approvers=[alphagov]' \
+	--yaml-var 'config-approval-count=0' \
 	--yaml-var 'trusted-developer-keys=[]' \
 	--check-creds "$@"
 


### PR DESCRIPTION
the github resource requires at least one approver in the list and we
need to set approvers to zero for initial kick off of the pipeline
(which should selfupdate itself with correct approver values after it
runs).