### PR TITLE
[concourse-github-resource] require github-verified signatures

### DIFF
--- a/components/concourse-github-resource/assets/in
+++ b/components/concourse-github-resource/assets/in
@@ -105,6 +105,16 @@ api_response=$( \
 
 pr_author=$(echo $api_response | jq ".data.repository.object.associatedPullRequests.nodes[].author.login")
 commit_signature_author=$(echo $api_response | jq --raw-output ".data.repository.object.associatedPullRequests.nodes[].commits.nodes[0].commit.signature.signer.login")
+commit_signature_valid_string=$(echo $api_response | jq --raw-output ".data.repository.object.associatedPullRequests.nodes[].commits.nodes[0].commit.signature.isValid")
+
+if [ "${commit_signature_valid_string}" != "true" ] ; then
+  keyId=$(echo $api_response | jq --raw-output ".data.repository.object.associatedPullRequests.nodes[].commits.nodes[0].commit.signature.keyId")
+  echo "ERROR: GitHub reports that the git signature was not valid.  This can happen for a number of reasons, but you can check:"
+  echo "- has the GPG key ${keyId} been added to ${commit_signature_author}'s GitHub account?"
+  echo "- has the GPG key ${keyId} expired?"
+  echo "You can read more about checking commit verification status here: https://help.github.com/en/articles/checking-your-commit-and-tag-signature-verification-status"
+  exit 1
+fi
 
 approvals=$(echo "${api_response}" | jq --raw-output .data.repository.object.associatedPullRequests.nodes[].reviews.nodes[].author.login | grep -v "${commit_signature_author}" | sort -d)
 


### PR DESCRIPTION
We were fetching `isValid` in the graphql query but not using it for
anything.  I think it's probably useful to require that github has
verified the signature, because that means that we can be confident
that github thinks the signing key actually belongs to the specified
user account.

Without this, I can vaguely imagine an attack where:

 - I add a new key for myself to gds-trusted-developers
 - I *don't* add the key to my github account
 - (I *also* ensure I don't use an email address for a key userid that
   matches any of my github email addresses)
 - the signature is approved because the key is in gds-trusted-developers
 - github can't match the signature to my github user, so the graphql
   query doesn't know that I am the signer
 - I am therefore allowed to approve my commit because github doesn't
   realise it's mine
 - i have skipped the two-eyes process

With this check, the attack won't work because we refuse to allow a
signed commit where github can't match the signature to a user.

This is a pretty academic attack (it leaves an awful lot of paper
trail behind) but I think it's enough to make this check worth doing.