### PR TITLE
Add `.coverprofile` files to this project's .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ hack/*log
 
 # generated files
 output/
+*.coverprofile


### PR DESCRIPTION
- Whatever plugin for Go I'm using generated these when I ran tests. I
  don't think we care about them, so `.gitignore` them to reduce noise.