### PR TITLE
Expand svc-op provisioned SQS queue policy

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -107,16 +107,19 @@ data "aws_iam_policy_document" "service-operator" {
 
   statement {
     actions = [
-      "iam:CreateServiceLinkedRole"
+      "iam:CreateServiceLinkedRole",
     ]
+
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS",
     ]
+
     condition {
-      test = "StringLike"
+      test     = "StringLike"
       variable = "iam:AWSServiceName"
+
       values = [
-        "rds.amazonaws.com"
+        "rds.amazonaws.com",
       ]
     }
   }
@@ -138,10 +141,7 @@ data "aws_iam_policy_document" "service-operator-managed-role-permissions-bounda
   statement {
     actions = [
       "rds-data:*",
-      "sqs:SendMessage",
-      "sqs:ReceiveMessage",
-      "sqs:DeleteMessage",
-      "sqs:GetQueueAttributes",
+      "sqs:*",
       "rds:*",
     ]
 


### PR DESCRIPTION
## What

Consumers of SQS queues need more permissions than were previously
granted. This expands the roles to allow all the queue-scopeable actions
that may be required and do not conflict with actions the operator will
take on the stack (ie SetQueueAttributes would conflict with
cloudformation config so is disallowed).

We have seen issues where `ListQueues` is required to fetch some queue
information. This is unfortunately not a "queue-scopable" action and as a
result this permission will give access to view ALL existing queues.
This is far from ideal, but the data that leaked is the
queue name, and attributes which would be viewable within the cluster anyway not access to the queue itself.

expanding the policy, means expanding the boundary too.

## Why

So that we are able to consume from provisioned queues. 