### PR TITLE
remove sqs:ListQueues permission from sqs policy

### DIFF
--- a/components/service-operator/apis/queue/v1beta1/sqs_types.go
+++ b/components/service-operator/apis/queue/v1beta1/sqs_types.go
@@ -155,37 +155,9 @@ func (s *SQS) GetStackTemplate() *cloudformation.Template {
 					"sqs:PurgeQueue",
 					"sqs:ReceiveMessage",
 					"sqs:SendMessage",
-					// "sqs:SetQueueAttributes",
-					// "sqs:AddPermission",
-					// "sqs:CreateQueue",
-					// "sqs:DeleteQueue",
-					// "sqs:RemovePermission",
-					// "sqs:TagQueue",
-					// "sqs:UntagQueue",
 				},
 				Resource: []string{
 					cloudformation.GetAtt(SQSResourceName, "Arn"),
-				},
-			},
-			{
-				// NOTE: this is potentially over scoped.  It's
-				// not possible to scope this to the
-				// queue-level, so everyone can "see" the other
-				// queues :/ but we have experienced issues
-				// (potentially with older versions of the java
-				// sdk) that refused to work unless this was
-				// present
-				Effect: "Allow",
-				Action: []string{
-					"sqs:ListQueues",
-				},
-				Resource: []string{
-					cloudformation.Join(":", []string{
-						"arn:aws:sqs",
-						cloudformation.Ref("AWS::Region"),
-						cloudformation.Ref("AWS::AccountId"),
-						"*",
-					}),
 				},
 			},
 		},


### PR DESCRIPTION
## What

after upgrading java libs the requirement for ListQueues has gone away. This permission was too
broad and leaked data about provisioned queue names between tenants and
so should be removed.

## Why

we should not be giving policy that leaks information outside of a provisioned resource