### PR TITLE
Temporarily remove grafana secure cookies requirement

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -395,8 +395,8 @@ prometheus-operator:
       GF_AUTH_GOOGLE_ENABLED: "true"
       GF_AUTH_GOOGLE_ALLOW_SIGN_UP: "true"
       GF_AUTH_GOOGLE_ALLOWED_DOMAINS: "digital.cabinet-office.gov.uk"
-      GF_SECURITY_COOKIE_SECURE: "true"
-      GF_SESSION_COOKIE_SECURE: "true"
+#      GF_SECURITY_COOKIE_SECURE: "true"
+#      GF_SESSION_COOKIE_SECURE: "true"
     envFromSecret: grafana
 
   prometheusOperator:


### PR DESCRIPTION
This is so Grafana can continue to function so we can log in and get it in a
state where we can open it to the world. We'll want to revert this when
exposing it.