### PR TITLE
Remove hardcoded Grafana admin password

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -377,7 +377,6 @@ prometheus-operator:
         - source_labels: [instance]
           target_label: node
   grafana:
-    adminPassword: "password"
     additionalDataSources:
       - name: Cloudwatch
         type: cloudwatch


### PR DESCRIPTION
Right now Grafana is protected behind the privileged port forwarding
requirement, now that we have Google authentication enabled we should close
admin password authentication, so that we can open Grafana up to the internet.