### PR TITLE
svc-op: register s3 controller with manager

### DIFF
--- a/components/service-operator/examples/s3.yaml
+++ b/components/service-operator/examples/s3.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: storage.govsvc.uk/v1beta1
-kind: S3
+kind: S3Bucket
 metadata:
   name: s3-bucket-sample
   labels:

--- a/components/service-operator/main.go
+++ b/components/service-operator/main.go
@@ -22,6 +22,7 @@ import (
 	accessv1beta1 "github.com/alphagov/gsp/components/service-operator/apis/access/v1beta1"
 	databasev1beta1 "github.com/alphagov/gsp/components/service-operator/apis/database/v1beta1"
 	queuev1beta1 "github.com/alphagov/gsp/components/service-operator/apis/queue/v1beta1"
+	storagev1beta1 "github.com/alphagov/gsp/components/service-operator/apis/storage/v1beta1"
 	"github.com/alphagov/gsp/components/service-operator/controllers"
 	"github.com/alphagov/gsp/components/service-operator/internal/aws/sdk"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,6 +43,7 @@ func init() {
 	_ = databasev1beta1.AddToScheme(scheme)
 	_ = queuev1beta1.AddToScheme(scheme)
 	_ = accessv1beta1.AddToScheme(scheme)
+	_ = storagev1beta1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -69,6 +71,7 @@ func run() error {
 		controllers.PrincipalCloudFormationController(c),
 		controllers.PostgresCloudFormationController(c),
 		controllers.SQSCloudFormationController(c),
+		controllers.S3CloudFormationController(c),
 	}
 
 	for _, c := range controllers {


### PR DESCRIPTION
register the s3 controller with the svc-operator manager on startup so that it
actually reconciles S3Bucket resources.

This was accidently forgotton, as main.go has no tests yet :disappointed: 