### PR TITLE
fix incorrect rbac generation for s3 resources

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
@@ -69,7 +69,7 @@ rules:
 - apiGroups:
   - storage.govsvc.uk
   resources:
-  - s3bucket
+  - s3buckets
   verbs:
   - create
   - delete
@@ -81,7 +81,7 @@ rules:
 - apiGroups:
   - storage.govsvc.uk
   resources:
-  - s3bucket/status
+  - s3buckets/status
   verbs:
   - get
   - patch

--- a/components/service-operator/internal/aws/cloudformation/controller.go
+++ b/components/service-operator/internal/aws/cloudformation/controller.go
@@ -129,8 +129,8 @@ func (r *Controller) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=database.govsvc.uk,resources=postgres/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=access.govsvc.uk,resources=principals,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=access.govsvc.uk,resources=principals/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=storage.govsvc.uk,resources=s3bucket,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=storage.govsvc.uk,resources=s3bucket/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=storage.govsvc.uk,resources=s3buckets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=storage.govsvc.uk,resources=s3buckets/status,verbs=get;update;patch
 
 // Reconcile synchronises state between the resource and a cloudformation stack
 func (r *Controller) Reconcile(req ctrl.Request) (res ctrl.Result, err error) {


### PR DESCRIPTION
the singular version of the resource name is not accecpted for rbac
resource name, use the plural.