### PR TITLE
BAU: Ignore unchanged k8s resources

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -202,9 +202,11 @@ apply_cluster_chart: &apply_cluster_chart
         gsp/gsp-istio-*.tgz
       function apply() {
         echo "applying ${1} from ${CHART_NAME} chart..."
-        until kubectl apply -R -f $1; do
+        kubectl apply -R -f $1 | grep -v "unchanged"
+        until [ "${PIPESTATUS[0]}" == "0" ]; do
           echo "---> ${1} apply failed retrying in 5s..."
           sleep 5
+          kubectl apply -R -f $1 | grep -v "unchanged"
         done
         sleep 5 # FIXME: we should do something smarter than sleep and check for success
         echo "---> ${1} applied OK!"


### PR DESCRIPTION
- We have quite a lot of resources and for non-sandbox clusters it would
  be really useful to know only what has changed
- Use some bash-foo to ignore all the unchanged lines

I tested this with:
```
#!/usr/bin/env bash

if [ "$RANDOM" -gt 20000 ]; then true; else false; fi | grep -v "blah"

until [ "${PIPESTATUS[0]}" == "0" ]; do
  echo "failed"
  sleep 2
  if [ "$RANDOM" -gt 20000 ]; then true; else false; fi | grep -v "blah"
done
```