### PR TITLE
allow svcop to manage buckets

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "service-operator" {
     actions = [
       "rds:*",
       "sqs:*",
+      "s3:*",
     ]
 
     resources = [


### PR DESCRIPTION
we tested the operator with more permission than it really gets for realzies and of course
missed some actions.... give the svc-operator full s3 access to all buckets
prefixed with cluster name.