### PR TITLE
Randomise Grafana admin password

### DIFF
--- a/modules/gsp-cluster/grafana.tf
+++ b/modules/gsp-cluster/grafana.tf
@@ -46,3 +46,7 @@ resource "aws_iam_role_policy" "grafana" {
   role   = "${aws_iam_role.grafana.id}"
   policy = "${data.aws_iam_policy_document.grafana_cloudwatch.json}"
 }
+
+resource "random_password" "grafana_default_admin_password" {
+  length = 40
+}

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -49,7 +49,8 @@ data "template_file" "values" {
     service_operator_boundary_arn    = "${aws_iam_policy.service-operator-managed-role-permissions-boundary.arn}"
     rds_from_worker_security_group   = "${aws_security_group.rds-from-worker.id}"
     private_db_subnet_group          = "${aws_db_subnet_group.private.id}"
-    external_dns_iam_role_name      = "${aws_iam_role.external_dns.name}"
+    external_dns_iam_role_name       = "${aws_iam_role.external_dns.name}"
+    grafana_default_admin_password   = "${random_password.grafana_default_admin_password.result}"
 
     permitted_roles_regex = "^(${join("|", list(
       aws_iam_role.cloudwatch_log_shipping_role.name,


### PR DESCRIPTION
If we don't set this, prometheus operator's default value of prom-operator will
apply. The current sandbox and verify GSP clusters are fine because I already
changed their admin passwords before exposing them, they have peristence
enabled, and Grafana only looks at the GF_SECURITY_ADMIN_PASSWORD environment
variable this ends up in on first run. However it would be a risk for new
clusters, or if the PVC was broken somehow and Grafana got reset.