### PR TITLE
Deploy 2 instances of Prometheus

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -105,7 +105,7 @@ kiam:
 prometheus-operator:
   defaultRules:
     rules:
-      general: false # see templates/general.rules.yaml for replacement
+      general: false # see templates/02-gsp-system/prometheus-rules.yaml for replacement
       alertmanager: false
   kubeControllerManager:
     enabled: false

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -113,10 +113,13 @@ prometheus-operator:
     enabled: false
   kubeEtcd:
     enabled: false
+  service:
+    sessionAffinity: "ClientIP"
   prometheus:
     prometheusSpec:
       externalLabels:
         product: local
+      replicas: 2
       retention: "60d"
       ruleSelectorNilUsesHelmValues: false
       ruleSelector: {}

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -126,6 +126,13 @@ prometheus-operator:
       secrets: [ istio.gsp-prometheus-operator-prometheus ]
       serviceMonitorSelectorNilUsesHelmValues: false
       serviceMonitorSelector: {}
+      storageSpec:
+        volumeClaimTemplate:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 50Gi
+          storageClassName: gp2
       query:
         timeout: 30s
       additionalScrapeConfigs:


### PR DESCRIPTION
Prometheus's fault-tolerance is based on it being a really dumb simple
thing to operate.  It doesn't do replication, backups, leadership
elections, distributed locking, or anything like that.  It's just a
single instance with a local disk.

As a result, if we lose the AZ that our single Prometheus is running
in, we'll lose Prometheus.  To guard against that, we should maybe
have 2 of them?

In a multiple Prometheus setup, each Prometheus is completely
independent.  Each Prometheus will scrape each target and maintain a
separate tsdb of time series data.  As a result, it's probably best to
always target the same Prometheus instance where possible so that you
don't get weird jitter in your results where different Prometheis
scraped out of phase with each other.

Therefore, this also sets the Prometheus service session affinity to
`ClientIP` which enforces sticky sessions. See
https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
for more on this.

I considered making this configurable on a per-cluster basis but I
thought that was probably more effort than it was worth.  2 is a
sensible default.