### PR TITLE
Revert "BAU: Ignore unchanged k8s resources"

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -202,11 +202,9 @@ apply_cluster_chart: &apply_cluster_chart
         gsp/gsp-istio-*.tgz
       function apply() {
         echo "applying ${1} from ${CHART_NAME} chart..."
-        kubectl apply -R -f $1 | grep -v "unchanged"
-        until [ "${PIPESTATUS[0]}" == "0" ]; do
+        until kubectl apply -R -f $1; do
           echo "---> ${1} apply failed retrying in 5s..."
           sleep 5
-          kubectl apply -R -f $1 | grep -v "unchanged"
         done
         sleep 5 # FIXME: we should do something smarter than sleep and check for success
         echo "---> ${1} applied OK!"


### PR DESCRIPTION
Reverts alphagov/gsp#519

sandbox-deployer is failing and we're not sure why.