### PR TITLE
Add a build errors panel to the Concourse dashboard in Grafana

### DIFF
--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -835,7 +835,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(concourse_builds_errored_total[60m])",
+          "expr": "irate(concourse_builds_errored_total[60m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Build errors - {{pod}}",

--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -835,7 +835,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "concourse_builds_errored_total",
+          "expr": "increase(concourse_builds_errored_total[60m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Build errors - {{pod}}",

--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -925,3 +925,4 @@
   "uid": "xgwl_AUiz",
   "version": 1
 }
+

--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -805,8 +805,8 @@
       "dashes": false,
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 6,
+        "w": 8,
         "x": 0,
         "y": 14
       },
@@ -835,9 +835,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(concourse_builds_errored_total) without (instance, pod)",
+          "expr": "concourse_builds_errored_total",
           "format": "time_series",
           "intervalFactor": 1,
+          "legendFormat": "Build errors - {{pod}}",
           "refId": "A"
         }
       ],

--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 13,
   "links": [],
   "panels": [
     {
@@ -783,6 +782,90 @@
           "logBase": 1,
           "max": null,
           "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 31,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(concourse_builds_errored_total) without (instance, pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Build errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
           "show": true
         },
         {


### PR DESCRIPTION
This new JSON came out of the Grafana UI, I just gave the expression and the panel title (and the position I guess).