### PR TITLE
Fix prometheus metrics

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -362,6 +362,8 @@ prometheus-operator:
           replacement: cluster-management
         - source_labels: [instance]
           target_label: node
+        - target_label: job
+          replacement: kubelet
       - job_name: 'node-exporter'
         scheme: http
         kubernetes_sd_configs:


### PR DESCRIPTION
It turns out I accidentally broke a bunch of our recording rules
recently in the big kubelet job refactoring of 2019 (see #375, which
introduced the new kubelet scrape job, and #481, which allowed me to
delete the old scrape job).

The issue is that the cadvisor metrics used to have `job="kubelet"`
and now have `job="kubelet-cadvisor"`.  But a bunch of our recording
rules assume that the job label is `job="kubelet"`.

The simplest way to fix it is to just change the job label in a
relabelling rule.  (I thought about changing the `job_name` field but
job names must be unique across all scrape_configs.)

In particular, this will fix the CPU usage metrics on the concourse
grafana dashboard.