### PR TITLE
scrape AWS VPC CNI metrics

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -311,6 +311,35 @@ prometheus-operator:
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: pod_name
+      - job_name: 'amazon-vpc-cni'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_worker]
+          regex: true
+          target_label: node_role
+          replacement: worker
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_ci]
+          regex: true
+          target_label: node_role
+          replacement: ci
+        - source_labels: [__meta_kubernetes_node_labelpresent_node_role_kubernetes_io_cluster_management]
+          regex: true
+          target_label: node_role
+          replacement: cluster-management
+        - source_labels: [instance]
+          target_label: node
+        - source_labels: [__address__]
+          target_label: __address__
+          regex: (.*):.*
+          replacement: $1:61678
       - job_name: 'kubelet'
         scheme: https
         tls_config:


### PR DESCRIPTION
We run the AWS VPC CNI (aka `aws-node` for some reason).  It has a
prometheus metrics endpoint.  We should scrape it. :prometheus: