### PR TITLE
upgrade AWS VPC CNI and calico

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
@@ -1,37 +1,37 @@
 {{ if .Values.global.runningOnAws }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: aws-node
 rules:
-- apiGroups:
-  - crd.k8s.amazonaws.com
-  resources:
-  - "*"
-  - namespaces
-  verbs:
-  - "*"
-- apiGroups: [""]
-  resources:
-  - pods
-  - nodes
-  - namespaces
-  verbs: ["list", "watch", "get"]
-- apiGroups: ["extensions"]
-  resources:
-  - daemonsets
-  verbs: ["list", "watch"]
+  - apiGroups:
+      - crd.k8s.amazonaws.com
+    resources:
+      - "*"
+      - namespaces
+    verbs:
+      - "*"
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+    verbs: ["list", "watch"]
+
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aws-node
   namespace: kube-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: aws-node
@@ -40,13 +40,13 @@ roleRef:
   kind: ClusterRole
   name: aws-node
 subjects:
-- kind: ServiceAccount
-  name: aws-node
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: aws-node
+    namespace: kube-system
+
 ---
 kind: DaemonSet
 apiVersion: apps/v1
-# kubernetes versions before 1.9.0 should use extensions/v1beta1
 metadata:
   name: aws-node
   namespace: kube-system
@@ -62,60 +62,75 @@ spec:
     metadata:
       labels:
         k8s-app: aws-node
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "beta.kubernetes.io/os"
+                    operator: In
+                    values:
+                      - linux
+                  - key: "beta.kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
       serviceAccountName: aws-node
       hostNetwork: true
       tolerations:
-      - operator: Exists
+        - operator: Exists
       containers:
-      - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.3.3
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 61678
-          name: metrics
-        name: aws-node
-        env:
-          - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
-            value: "true"
-          - name: AWS_VPC_K8S_CNI_LOGLEVEL
-            value: DEBUG
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: WATCH_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        resources:
-          requests:
-            cpu: 10m
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          name: cni-bin-dir
-        - mountPath: /host/etc/cni/net.d
-          name: cni-net-dir
-        - mountPath: /host/var/log
-          name: log-dir
-        - mountPath: /var/run/docker.sock
-          name: dockersock
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 61678
+              name: metrics
+          name: aws-node
+          #readinessProbe:
+          #  exec:
+          #    command: ["/app/grpc_health_probe", "-addr=:50051"]
+          #  initialDelaySeconds: 25
+          #livenessProbe:
+          #  exec:
+          #    command: ["/app/grpc_health_probe", "-addr=:50051"]
+          #  initialDelaySeconds: 25
+          env:
+            - name: AWS_VPC_K8S_CNI_LOGLEVEL
+              value: DEBUG
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+            - mountPath: /host/var/log
+              name: log-dir
+            - mountPath: /var/run/docker.sock
+              name: dockersock
       volumes:
-      - name: cni-bin-dir
-        hostPath:
-          path: /opt/cni/bin
-      - name: cni-net-dir
-        hostPath:
-          path: /etc/cni/net.d
-      - name: log-dir
-        hostPath:
-          path: /var/log
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+        - name: log-dir
+          hostPath:
+            path: /var/log
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -124,7 +139,10 @@ metadata:
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
   names:
     plural: eniconfigs
     singular: eniconfig

--- a/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
@@ -97,6 +97,8 @@ spec:
           #    command: ["/app/grpc_health_probe", "-addr=:50051"]
           #  initialDelaySeconds: 25
           env:
+            - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
+              value: "true"
             - name: AWS_VPC_K8S_CNI_LOGLEVEL
               value: DEBUG
             - name: MY_NODE_NAME

--- a/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
@@ -18,8 +18,13 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below,
+        # marks the pod as a critical add-on, ensuring it gets
+        # priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
-      priorityClassName: system-node-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -32,7 +37,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.3.6
+          image: quay.io/calico/node:v3.8.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -157,6 +162,42 @@ spec:
     kind: FelixConfiguration
     plural: felixconfigurations
     singular: felixconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: ipamblocks.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: IPAMBlock
+    plural: ipamblocks
+    singular: ipamblock
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockaffinities.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: BlockAffinity
+    plural: blockaffinities
+    singular: blockaffinity
 
 ---
 
@@ -302,6 +343,24 @@ spec:
 
 ---
 
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networksets.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: NetworkSet
+    plural: networksets
+    singular: networkset
+
+---
+
 # Create the ServiceAccount and roles necessary for Calico.
 
 apiVersion: v1
@@ -330,6 +389,12 @@ rules:
       - pods/status
     verbs:
       - patch
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+      - update
   - apiGroups: [""]
     resources:
       - pods
@@ -376,9 +441,11 @@ rules:
       - globalbgpconfigs
       - bgpconfigurations
       - ippools
+      - ipamblocks
       - globalnetworkpolicies
       - globalnetworksets
       - networkpolicies
+      - networksets
       - clusterinformations
       - hostendpoints
     verbs:
@@ -386,6 +453,22 @@ rules:
       - get
       - list
       - update
+      - watch
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+      - ipamblocks
+      - ipamhandles
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - blockaffinities
+    verbs:
       - watch
 
 ---
@@ -422,9 +505,9 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
-      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
@@ -434,7 +517,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       containers:
-        - image: quay.io/calico/typha:v3.3.6
+        - image: quay.io/calico/typha:v3.8.1
           name: calico-typha
           ports:
             - containerPort: 5473
@@ -467,19 +550,17 @@ spec:
             - name: FELIX_IPTABLESMANGLEALLOWACTION
               value: Return
           livenessProbe:
-            exec:
-              command:
-                - calico-typha
-                - check
-                - liveness
+            httpGet:
+              path: /liveness
+              port: 9098
+              host: localhost
             periodSeconds: 30
             initialDelaySeconds: 30
           readinessProbe:
-            exec:
-              command:
-                - calico-typha
-                - check
-                - readiness
+            httpGet:
+              path: /readiness
+              port: 9098
+              host: localhost
             periodSeconds: 10
 
 ---


### PR DESCRIPTION
This upgrades the AWS VPC CNI and calico CNI to the latest.

I did this by:

 - copypasting the yaml from
   https://github.com/aws/amazon-vpc-cni-k8s/tree/master/config/v1.5
   over the top of our yaml
 - removing the calico-typha-autoscaler again (which we have
   previously removed for being CPU intensive)
 - ignoring the new cni-metrics-helper.yaml, which scrapes lovely
   prometheus metrics (see #533) and pushes them into CloudWatch

In [Amazon's "Upgrading your EKS cluster" guide][1], they recommend
running the latest CNI available regardless of your kubernetes version.

[1]: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html