### PR TITLE
Fix path for concourse-task-toolbox-source resource in release pipeline

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -69,7 +69,7 @@ resources:
     organization: alphagov
     repository: gsp
     paths:
-      - components/concourse-task-toolbox-source
+      - components/concourse-task-toolbox
     github_api_token: ((github-api-token))
     approvers: ((config-approvers))
     required_approval_count: 1


### PR DESCRIPTION
Looks like this got broken in the release pipeline refactor but we haven't
tried modifying it since, so we didn't notice problems. Today we lost the
pipelines in Concourse and found release didn't come back properly.