### PR TITLE
import coredns Deployment yaml

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
@@ -101,3 +101,29 @@ spec:
             path: Corefile
           name: coredns
         name: config-volume
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    eks.amazonaws.com/component: coredns
+    k8s-app: kube-dns
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+          pods insecure
+          upstream
+          fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        proxy . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }

--- a/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
@@ -1,0 +1,103 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    eks.amazonaws.com/component: coredns
+    k8s-app: kube-dns
+    kubernetes.io/name: CoreDNS
+  name: coredns
+  namespace: kube-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      eks.amazonaws.com/component: coredns
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        eks.amazonaws.com/component: coredns
+        k8s-app: kube-dns
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/coredns:v1.2.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: coredns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          procMount: Default
+          readOnlyRootFilesystem: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: config-volume
+          readOnly: true
+      dnsPolicy: Default
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: coredns
+      serviceAccountName: coredns
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: Corefile
+            path: Corefile
+          name: coredns
+        name: config-volume


### PR DESCRIPTION
When we created the EKS cluster, it automagically creates a `coredns`
deployment within the cluster.

When you want to upgrade coredns, the documented way is to run

    kubectl set image --namespace kube-system deployment.apps/coredns \
      coredns=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/coredns:v1.3.1

:face_vomiting:

This commit imports the already-running coredns Deployment into the
cluster chart, so that we can upgrade it in a proper gitops manner
later.

It refers to a ServiceAccount `coredns` - this is also part of the
cluster and we should not import the yaml for that.  It has a
ClusterRole `system:coredns` and a ClusterRoleBinding
`system:coredns`, both of which are labelled
`kubernetes.io/bootstrapping: rbac-defaults` which means that they
belong to the cluster and you shouldn't manage them yourself.  See
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
for details.