### PR TITLE
aws-vpc-cni gets scraped over http not https

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -312,11 +312,7 @@ prometheus-operator:
           action: replace
           target_label: pod_name
       - job_name: 'amazon-vpc-cni'
-        scheme: https
-        tls_config:
-          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          insecure_skip_verify: true
-        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        scheme: http
         kubernetes_sd_configs:
         - role: node
         relabel_configs:


### PR DESCRIPTION
and probably doesn't need bearer token auth either