### PR TITLE
import kube-proxy DaemonSet yaml

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
@@ -1,0 +1,98 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    eks.amazonaws.com/component: kube-proxy
+    k8s-app: kube-proxy
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        k8s-app: kube-proxy
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config
+        image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.12.6
+        imagePullPolicy: IfNotPresent
+        name: kube-proxy
+        resources:
+          requests:
+            cpu: 100m
+        securityContext:
+          privileged: true
+          procMount: Default
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/log
+          name: varlog
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
+        - mountPath: /var/lib/kube-proxy/
+          name: kubeconfig
+        - mountPath: /var/lib/kube-proxy-config/
+          name: config
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: kube-proxy
+      serviceAccountName: kube-proxy
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /var/log
+          type: ""
+        name: varlog
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+      - hostPath:
+          path: /lib/modules
+          type: ""
+        name: lib-modules
+      - configMap:
+          defaultMode: 420
+          name: kube-proxy
+        name: kubeconfig
+      - configMap:
+          defaultMode: 420
+          name: kube-proxy-config
+        name: config
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate


### PR DESCRIPTION
When we created the EKS cluster, it automagically creates a `kube-proxy`
daemonset within the cluster.

When you want to upgrade kube-proxy, the documented way is to run

    kubectl set image daemonset.apps/kube-proxy \
      -n kube-system \
      kube-proxy=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.13.10

:face_vomiting:

This commit imports the already-running kube-proxy DaemonSet into the
cluster chart, so that we can upgrade it in a proper gitops manner
later.

It refers to ConfigMaps `kube-proxy` and `kube-proxy-config`.  The
`kube-proxy` ConfigMap has cluster-specific config (ie the name of an
upstream EKS server to talk to) and so I don't think it's right to
pull this ConfigMap into our chart.  `kube-proxy-config` could go
either way - there's nothing unique to the specific cluster in there -
but I'm tempted to leave it out for consistency.  Opinions on this
welcome :)