### PR TITLE
bump coredns to 1.2.6

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
@@ -36,7 +36,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/coredns:v1.2.2
+        image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/coredns:v1.2.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
as recommended by
https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
with EKS 1.13