### PR TITLE
Allow us to delete jobs

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -101,6 +101,10 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs:
+    - delete
 {{- range $extraPermission := .Values.extraPermissionsDev }}
   -
 {{- $extraPermission | toYaml | nindent 4 }}

--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -137,6 +137,10 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs:
+    - delete
 {{- range $extraPermission := .Values.extraPermissionsSRE }}
   -
 {{- $extraPermission | toYaml | nindent 4 }}


### PR DESCRIPTION
When a k8s Job hits backoffLimit, it will be marked as failed and any running
Pods will be terminated. This impedes our ability to debug it at a later date
as we won't be able to get logs etc.
With this commit we should be able to delete it and have it re-created by the
deployment pipeline.