### PR TITLE
Add setup-kube-deployer script

### DIFF
--- a/components/concourse-task-toolbox/Dockerfile
+++ b/components/concourse-task-toolbox/Dockerfile
@@ -72,7 +72,7 @@ RUN curl -LO https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/d
 	&& chmod +x aws-iam-authenticator_0.4.0-alpha.1_linux_amd64 \
 	&& mv aws-iam-authenticator_0.4.0-alpha.1_linux_amd64 /usr/local/bin/aws-iam-authenticator
 
-COPY bin/aws-assume-role /usr/local/bin/
+COPY bin/aws-assume-role bin/setup-kube-deployer /usr/local/bin/
 
 # --------------------output------------------------
 

--- a/components/concourse-task-toolbox/bin/setup-kube-deployer
+++ b/components/concourse-task-toolbox/bin/setup-kube-deployer
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+echo "configuring kubectl for deployer"
+echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+kubectl config set-context deployer --user deployer --cluster self
+kubectl config use-context deployer


### PR DESCRIPTION
We often have to do things in our GSP clusters as the deployer user and
end up repeating the same lines in our Concourse tasks to set the
Kubernetes config up. I'm adding the `setup-kube-deployer` script to the
task-toolbox image that does all the setup things.