### PR TITLE
add Name and Namespace tags to ingressgateway NLBs

### DIFF
--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -49,6 +49,8 @@ istio:
       externalIPs: []
       serviceAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+        service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: |
+          Environment={{ $namespace.name }},Name={{ $namespace.name }}-ingress
       podAnnotations: {}
       type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
       #externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out


### PR DESCRIPTION
I haven't tested this and I'm not sure if it will work.  But:

 - we don't currently tag our NLBs
 - this makes it hard to work out which NLB does what
 - this also makes billing a little bit harder

The
`service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags`
annotation is documented at
https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/
but it is documented as working with classic ELBs.  I'm hoping that it
will work with NLBs too...?