### PR TITLE
enables viewers_can_edit: true for grafana

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -160,6 +160,8 @@ gsp-monitoring:
       grafana.ini:
         server:
           root_url: https://grafana.${cluster_domain}
+        users:
+          viewers_can_edit: true
 
 serviceOperator:
   kiamServerRoleARN: ${kiam_server_role_arn}


### PR DESCRIPTION
I want to be able to see the explore tab, and mess around in grafana.

Since google auth, I (and everyone else) only have the `viewer` role.

viewers_can_edit:true means that anyone with the viewer role can make
transient changes (not saved) which makes it a bit more useful for
poking around without becoming a stateful nightmare.