### PR TITLE
AUT-103: Add Canary Smoke Test Status to Grafana

### DIFF
--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -882,6 +882,107 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "decimals": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 33,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "UNKNOWN",
+          "to": "null"
+        },
+        {
+          "from": "0",
+          "text": "OK",
+          "to": "0"
+        },
+        {
+          "from": "0.001",
+          "text": "NOT OK",
+          "to": "10"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(increase(concourse_builds_finished{team=\"main\", pipeline=\"cd-smoke-test\", status=\"failed\"}[15m]))",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.001,0.001",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Canary Smoke Test Status",
+      "transparent": true,
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        },
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "max"
     }
   ],
   "refresh": false,
@@ -925,4 +1026,3 @@
   "uid": "xgwl_AUiz",
   "version": 1
 }
-


### PR DESCRIPTION
This change adds Canary Smoke Test Status panel to Grafana. This panel will get support team's attention by displaying a red colour "NOT OK" on it if Canary Smoke Test fails or errors over the last 15 minutes. This will help the team to take action to resolve this issue quickly.

Author: @adityapahuja