### PR TITLE
allow iframes for framesplits.cloudapps.digital

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -161,6 +161,7 @@ concourse:
         logLevel: error
         driver: overlay
     web:
+      xFrameOptions: "allow-from: https://framesplits.cloudapps.digital/"
       logLevel: error
       auth:
         mainTeam:


### PR DESCRIPTION
:innocent: selfish PR is selfish.

Framesplits is an application for slicing a screen up into many iframes
for displaying on a monitor.

Concourse v5 started defaulting to X-Frame-Options: deny, which prevents
embeding the concourse ui in an iframe, and broke my nice views spanning the pipelines we have interest in.

This allows embedding the ui in the GOV.UK PaaS hosted instance of
Framesplits.