### PR TITLE
fix alert templates

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
@@ -9,7 +9,7 @@ spec:
     - alert: KubeNodeNotReady
       annotations:
         message: |
-          {{'{{ $labels.node }} has been unready for more than an hour.'}}
+          {{`{{ $labels.node }} has been unready for more than an hour.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready
       expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}
         == 0
@@ -19,8 +19,8 @@ spec:
     - alert: KubeVersionMismatch
       annotations:
         message: |
-          {{'There are {{ $value }} different semantic versions of Kubernetes
-          components running.'}}
+          {{`There are {{ $value }} different semantic versions of Kubernetes
+          components running.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
       expr: count(count by(major, minor) (kubernetes_build_info))
         > 1
@@ -30,8 +30,8 @@ spec:
     - alert: KubeClientErrors
       annotations:
         message: |
-          {{"Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
-          }}' is experiencing {{ printf "%0.0f" $value }}% errors.'"}}
+          {{`Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
+          }}' is experiencing {{ printf "%0.0f" $value }}% errors.'`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
       expr: |-
         (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job)
@@ -44,8 +44,8 @@ spec:
     - alert: KubeClientErrors
       annotations:
         message: |
-          {{"Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
-          }}' is experiencing {{ printf "%0.0f" $value }} errors / second."}}
+          {{`Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
+          }}' is experiencing {{ printf "%0.0f" $value }} errors / second.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
       expr: sum(rate(ksm_scrape_error_total{job="kube-state-metrics"}[5m])) by (instance,
         job) > 0.1
@@ -55,8 +55,8 @@ spec:
     - alert: KubeletTooManyPods
       annotations:
         message: |
-          {{"Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close
-          to the limit of 110."}}
+          {{`Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close
+          to the limit of 110.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
       expr: kubelet_running_pod_count{job="kubelet"} > 110 * 0.9
       for: 15m
@@ -65,8 +65,8 @@ spec:
     - alert: KubeAPILatencyHigh
       annotations:
         message: |
-          {{"The API server has a 99th percentile latency of {{ $value }} seconds
-          for {{ $labels.verb }} {{ $labels.resource }}."}}
+          {{`The API server has a 99th percentile latency of {{ $value }} seconds
+          for {{ $labels.verb }} {{ $labels.resource }}.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
       expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
         > 1
@@ -76,8 +76,8 @@ spec:
     - alert: KubeAPILatencyHigh
       annotations:
         message: |
-          {{"The API server has a 99th percentile latency of {{ $value }} seconds
-          for {{ $labels.verb }} {{ $labels.resource }}."}}
+          {{`The API server has a 99th percentile latency of {{ $value }} seconds
+          for {{ $labels.verb }} {{ $labels.resource }}.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
       expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
         > 4
@@ -87,7 +87,7 @@ spec:
     - alert: KubeAPIErrorsHigh
       annotations:
         message: |
-          {{"API server is returning errors for {{ $value }}% of requests."}}
+          {{`API server is returning errors for {{ $value }}% of requests.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m]))
@@ -99,7 +99,7 @@ spec:
     - alert: KubeAPIErrorsHigh
       annotations:
         message: |
-          {{"API server is returning errors for {{ $value }}% of requests."}}
+          {{`API server is returning errors for {{ $value }}% of requests.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m]))
@@ -111,8 +111,8 @@ spec:
     - alert: KubeAPIErrorsHigh
       annotations:
         message: |
-          {{"API server is returning errors for {{ $value }}% of requests for
-          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}."}}
+          {{`API server is returning errors for {{ $value }}% of requests for
+          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)
@@ -124,8 +124,8 @@ spec:
     - alert: KubeAPIErrorsHigh
       annotations:
         message: |
-          {{"API server is returning errors for {{ $value }}% of requests for
-          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}."}}
+          {{`API server is returning errors for {{ $value }}% of requests for
+          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)

--- a/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
@@ -8,7 +8,8 @@ spec:
     rules:
     - alert: KubeNodeNotReady
       annotations:
-        message: '{{ $labels.node }} has been unready for more than an hour.'
+        message: |
+          {{'{{ $labels.node }} has been unready for more than an hour.'}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready
       expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}
         == 0
@@ -17,8 +18,9 @@ spec:
         severity: warning
     - alert: KubeVersionMismatch
       annotations:
-        message: There are {{ $value }} different semantic versions of Kubernetes
-          components running.
+        message: |
+          {{'There are {{ $value }} different semantic versions of Kubernetes
+          components running.'}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
       expr: count(count by(major, minor) (kubernetes_build_info))
         > 1
@@ -27,8 +29,9 @@ spec:
         severity: warning
     - alert: KubeClientErrors
       annotations:
-        message: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
-          }}' is experiencing {{ printf "%0.0f" $value }}% errors.'
+        message: |
+          {{"Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
+          }}' is experiencing {{ printf "%0.0f" $value }}% errors.'"}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
       expr: |-
         (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (instance, job)
@@ -40,8 +43,9 @@ spec:
         severity: warning
     - alert: KubeClientErrors
       annotations:
-        message: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
-          }}' is experiencing {{ printf "%0.0f" $value }} errors / second.
+        message: |
+          {{"Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
+          }}' is experiencing {{ printf "%0.0f" $value }} errors / second."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors
       expr: sum(rate(ksm_scrape_error_total{job="kube-state-metrics"}[5m])) by (instance,
         job) > 0.1
@@ -50,8 +54,9 @@ spec:
         severity: warning
     - alert: KubeletTooManyPods
       annotations:
-        message: Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close
-          to the limit of 110.
+        message: |
+          {{"Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close
+          to the limit of 110."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
       expr: kubelet_running_pod_count{job="kubelet"} > 110 * 0.9
       for: 15m
@@ -59,8 +64,9 @@ spec:
         severity: warning
     - alert: KubeAPILatencyHigh
       annotations:
-        message: The API server has a 99th percentile latency of {{ $value }} seconds
-          for {{ $labels.verb }} {{ $labels.resource }}.
+        message: |
+          {{"The API server has a 99th percentile latency of {{ $value }} seconds
+          for {{ $labels.verb }} {{ $labels.resource }}."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
       expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
         > 1
@@ -69,8 +75,9 @@ spec:
         severity: warning
     - alert: KubeAPILatencyHigh
       annotations:
-        message: The API server has a 99th percentile latency of {{ $value }} seconds
-          for {{ $labels.verb }} {{ $labels.resource }}.
+        message: |
+          {{"The API server has a 99th percentile latency of {{ $value }} seconds
+          for {{ $labels.verb }} {{ $labels.resource }}."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
       expr: cluster_quantile:apiserver_request_latencies:histogram_quantile{job="apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"}
         > 4
@@ -79,7 +86,8 @@ spec:
         severity: critical
     - alert: KubeAPIErrorsHigh
       annotations:
-        message: API server is returning errors for {{ $value }}% of requests.
+        message: |
+          {{"API server is returning errors for {{ $value }}% of requests."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m]))
@@ -90,7 +98,8 @@ spec:
         severity: critical
     - alert: KubeAPIErrorsHigh
       annotations:
-        message: API server is returning errors for {{ $value }}% of requests.
+        message: |
+          {{"API server is returning errors for {{ $value }}% of requests."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m]))
@@ -101,8 +110,9 @@ spec:
         severity: warning
     - alert: KubeAPIErrorsHigh
       annotations:
-        message: API server is returning errors for {{ $value }}% of requests for
-          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.
+        message: |
+          {{"API server is returning errors for {{ $value }}% of requests for
+          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)
@@ -113,8 +123,9 @@ spec:
         severity: critical
     - alert: KubeAPIErrorsHigh
       annotations:
-        message: API server is returning errors for {{ $value }}% of requests for
-          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}.
+        message: |
+          {{"API server is returning errors for {{ $value }}% of requests for
+          {{ $labels.verb }} {{ $labels.resource }} {{ $labels.subresource }}."}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh
       expr: |-
         sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[5m])) by (resource,subresource,verb)


### PR DESCRIPTION
Helm is a bunch of go templates.

Prometheus alerts are a bunch of go templates.

Go templates do not nest well :(

I "fixed" this for now by wrapping each alert message that wants to
reference a variable in {{" "}} so that Helm just thinks it's a
literal string, so that the actual template can get through to
Prometheus.