### PR TITLE
Docs for SQS Service Operator: Fix role name

### DIFF
--- a/docs/gds-supported-platform/gsp-service-operator.md
+++ b/docs/gds-supported-platform/gsp-service-operator.md
@@ -65,7 +65,7 @@ kind: Pod
 metadata:
   name: alexs-test-pod
   annotations:
-    iam.amazonaws.com/role: svcop-sandbox-gsp-service-operator-test-alexs-test-princ
+    iam.amazonaws.com/role: svcop-sandbox-sandbox-gsp-service-operator-test-alexs-test-princ
 spec:
   containers:
   - name: myapp-container


### PR DESCRIPTION
Role name includes cluster and namespace name, and the namespace name includes
cluster, so the generated role name will have 'sandbox' in there twice.