### PR TITLE
Make harbor API inaccessible to the public

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/harbor-ip-safelist.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/harbor-ip-safelist.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.global.runningOnAws }}
+---
+apiVersion: config.istio.io/v1alpha2
+kind: handler
+metadata:
+  name: harbor-api-ip-safelist
+spec:
+  compiledAdapter: listchecker
+  params:
+    overrides:
+{{ .Values.global.cluster.egressIpAddresses | toYaml | indent 4 -}}
+    blacklist: false
+    entryType: IP_ADDRESSES
+---
+apiVersion: config.istio.io/v1alpha2
+kind: instance
+metadata:
+  name: harbor-api-ip-safelist-originip
+spec:
+  compiledTemplate: listentry
+  params:
+    value: origin.ip | ip("0.0.0.0")
+---
+apiVersion: config.istio.io/v1alpha2
+kind: rule
+metadata:
+  name: harbor-api-ip-safelist
+spec:
+  match: source.labels["istio"] == "gsp-system-ingressgateway" && destination.service.name == "gsp-harbor-core" && request.path.startsWith("/api")
+  actions:
+  - handler: harbor-ip-safelist
+    instances: [ harbor-ip-safelist-originip ]
+{{ end }}

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -4,6 +4,7 @@ global:
     name: "my-cluster"
     domain: "example.com"
     domain_id: ""
+    egressIpAddresses: ["127.0.0.1"]
   account:
     name: ""
   roles:

--- a/hack/lint-terraform-values-output.sh
+++ b/hack/lint-terraform-values-output.sh
@@ -31,6 +31,7 @@ global:
   cluster:
     domain: fake.com
     name: sandbox
+    egressIpAddresses: ["127.0.0.1", "1.2.3.4"]
     privateKey: BEGIN-PRIVATE
     publicKey: BEGIN-PUBLIC
 egressSafelist:
@@ -110,6 +111,7 @@ helm template \
 		| sed 's/${sre_user_arns}/[]/' \
 		| sed 's/${bootstrap_role_arns}/[]/' \
 		| sed 's/${concourse_teams}/["org:team"]/' \
+		| sed 's/${egress_ip_addresses}/[]/' \
 	) \
 	--values output/values.yaml \
 	--set 'global.cloudHsm.enabled=true' \

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -4,6 +4,7 @@ global:
     name: ${cluster_name}
     domain: ${cluster_domain}
     domain_id: ${cluster_domain_id}
+    egressIpAddresses: ${egress_ip_addresses}
   account:
     name: ${account_name}
   roles:

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -7,6 +7,7 @@ data "template_file" "values" {
     cluster_name                     = "${var.cluster_name}"
     cluster_domain                   = "${var.cluster_domain}"
     cluster_domain_id                = "${var.cluster_domain_id}"
+    egress_ip_addresses              = "${jsonencode(var.egress_ips)}"
     account_name                     = "${var.account_name}"
     account_id                       = "${data.aws_caller_identity.current.account_id}"
     admin_role_arns                  = "${jsonencode(var.admin_role_arns)}"


### PR DESCRIPTION
Only allow connections that originate inside the cluster VPC to connect to harbor's API.