### PR TITLE
Kubernetes privileges for Service Operator dynamic ServiceEntry support

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
@@ -100,4 +100,16 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - serviceentries
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{ end }}


### PR DESCRIPTION
Actual code that uses this to follow in a later PR.