### PR TITLE
Use concourse-provided resource versions

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -30,16 +30,16 @@ spec:
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: "1.2.0"
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     resource_types:
     - name: harbor
       type: docker-image
       privileged: true
       source:
-        repository: govsvc/gsp-harbor-docker-image-resource
-        tag: "0.0.1553882420"
+        repository: ((concourse.harbour-resource-image))
+        tag: ((concourse.harbour-resource-tag))
 
     resources:
     - name: timer

--- a/docs/gds-supported-platform/making-things-private-in-harbor.md
+++ b/docs/gds-supported-platform/making-things-private-in-harbor.md
@@ -30,8 +30,8 @@ private.
     type: docker-image
     privileged: true
     source:
-      repository: govsvc/gsp-harbor-docker-image-resource
-      tag: "0.0.1553882420"
+      repository: ((concourse.harbour-resource-image))
+      tag: ((concourse.harbour-resource-tag))
 
   resources:
   - name: my-image


### PR DESCRIPTION
Apparently the idea we had is that we provide the up-to-date versions
of the resources we provide as pipeline variables.

However this was not well-used.

It's hard to see how our users would use it when our own canary
doesn't, nor does our docs. :P