### PR TITLE
Upgrade K8s nodes to 1.14

### DIFF
--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -5,8 +5,9 @@ Description: Amazon EKS - Node Group
 Parameters:
 
   NodeImageId:
-    Description: AMI id for the node instances.
-    Type: AWS::EC2::Image::Id
+    Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+    Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2/recommended/image_id
+    Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
 
   NodeInstanceType:
     Description: EC2 instance type for the node instances

--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -308,7 +308,7 @@ Resources:
           PropagateAtLaunch: true
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MaxBatchSize: 1
+        MaxBatchSize: 2
         MinInstancesInService: !Ref NodeAutoScalingGroupDesiredCapacity
         PauseTime: PT5M
 

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -40,14 +40,6 @@ resource "aws_cloudwatch_log_group" "eks" {
   }
 }
 
-data "aws_ami" "node_ami" {
-  owners           = ["amazon"]
-  filter {
-    name = "name"
-    values = ["amazon-eks-node-1.13-v20190814"]
-  }
-}
-
 # As per https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
 resource "aws_cloudformation_stack" "worker-nodes" {
   name          = "${var.cluster_name}-worker-nodes"
@@ -62,7 +54,6 @@ resource "aws_cloudformation_stack" "worker-nodes" {
     NodeAutoScalingGroupDesiredCapacity = "${var.worker_count}"
     NodeAutoScalingGroupMaxSize         = "${var.worker_count + 2}"
     NodeInstanceType                    = "${var.worker_instance_type}"
-    NodeImageId                         = "${data.aws_ami.node_ami.image_id}"
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""
     VpcId                               = "${var.vpc_id}"
@@ -85,7 +76,6 @@ resource "aws_cloudformation_stack" "kiam-server-nodes" {
     NodeAutoScalingGroupDesiredCapacity = "2"
     NodeAutoScalingGroupMaxSize         = "3"
     NodeInstanceType                    = "t3.medium"
-    NodeImageId                         = "${data.aws_ami.node_ami.image_id}"
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/cluster-management --register-with-taints=node-role.kubernetes.io/cluster-management=:NoSchedule --event-qps=0\""
     VpcId                               = "${var.vpc_id}"
@@ -108,7 +98,6 @@ resource "aws_cloudformation_stack" "ci-nodes" {
     NodeAutoScalingGroupDesiredCapacity = "${var.ci_worker_count}"
     NodeAutoScalingGroupMaxSize         = "${var.ci_worker_count + 1}"
     NodeInstanceType                    = "${var.ci_worker_instance_type}"
-    NodeImageId                         = "${data.aws_ami.node_ami.image_id}"
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/ci --register-with-taints=node-role.kubernetes.io/ci=:NoSchedule --event-qps=0\""
     VpcId                               = "${var.vpc_id}"


### PR DESCRIPTION
Instead of just bumping the value, use the new SSM trick to get the latest AMI
from amazon.