### PR TITLE
Config as actual YAML in Pipeline resource

### DIFF
--- a/components/concourse-operator/README.md
+++ b/components/concourse-operator/README.md
@@ -19,7 +19,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: canary
 spec:
-  pipelineString: |
+  config:
     resources:
     - name: gsp-canary
       type: git

--- a/components/concourse-operator/config/crds/concourse_v1beta1_pipeline.yaml
+++ b/components/concourse-operator/config/crds/concourse_v1beta1_pipeline.yaml
@@ -26,10 +26,10 @@ spec:
               type: boolean
             paused:
               type: boolean
-            pipelineString:
-              type: string
+            config:
+              type: object
           required:
-          - pipelineString
+          - config
           type: object
         status:
           type: object

--- a/components/concourse-operator/config/crds/concourse_v1beta1_pipeline.yaml
+++ b/components/concourse-operator/config/crds/concourse_v1beta1_pipeline.yaml
@@ -28,8 +28,8 @@ spec:
               type: boolean
             config:
               type: object
-          required:
-          - config
+            pipelineString:
+              type: string
           type: object
         status:
           type: object

--- a/components/concourse-operator/config/samples/concourse_v1beta1_pipeline.yaml
+++ b/components/concourse-operator/config/samples/concourse_v1beta1_pipeline.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: pipeline-sample
 spec:
-  pipelineString: |
+  config:
     jobs:
     - name: hello-world
       plan:

--- a/components/concourse-operator/config/samples/concourse_v1beta1_pipeline_BAD.yaml
+++ b/components/concourse-operator/config/samples/concourse_v1beta1_pipeline_BAD.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: pipeline-sample
 spec:
-  pipelineString: |
+  config:
     resources:
     - name: bad
       type: bad-not-exist

--- a/components/concourse-operator/pkg/apis/concourse/v1beta1/pipeline_types.go
+++ b/components/concourse-operator/pkg/apis/concourse/v1beta1/pipeline_types.go
@@ -27,9 +27,10 @@ import (
 type PipelineSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Config  atc.Config `json:"config"`
-	Paused  bool       `json:"paused,omitempty"`
-	Exposed bool       `json:"exposed,omitempty"`
+	Config         atc.Config `json:"config,omitempty"`
+	PipelineString string     `json:"pipelineString,omitempty"`
+	Paused         bool       `json:"paused,omitempty"`
+	Exposed        bool       `json:"exposed,omitempty"`
 }
 
 // PipelineStatus defines the observed state of Pipeline

--- a/components/concourse-operator/pkg/apis/concourse/v1beta1/pipeline_types.go
+++ b/components/concourse-operator/pkg/apis/concourse/v1beta1/pipeline_types.go
@@ -16,6 +16,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/concourse/concourse/atc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,9 +27,9 @@ import (
 type PipelineSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	PipelineString string `json:"pipelineString"`
-	Paused         bool   `json:"paused,omitempty"`
-	Exposed        bool   `json:"exposed,omitempty"`
+	Config  atc.Config `json:"config"`
+	Paused  bool       `json:"paused,omitempty"`
+	Exposed bool       `json:"exposed,omitempty"`
 }
 
 // PipelineStatus defines the observed state of Pipeline

--- a/components/concourse-operator/pkg/controller/pipeline/pipeline_controller.go
+++ b/components/concourse-operator/pkg/controller/pipeline/pipeline_controller.go
@@ -126,10 +126,18 @@ func (r *ReconcilePipeline) Reconcile(request reconcile.Request) (reconcile.Resu
 
 func (r *ReconcilePipeline) update(teamName string, instance *concoursev1beta1.Pipeline) error {
 	pipelineName := instance.ObjectMeta.Name
+	var pipelineYAML []byte
+	var err error
 
-	pipelineYAML, err := yaml.Marshal(instance.Spec.Config)
-	if err != nil {
-		return err
+	if len(instance.Spec.Config.Jobs) > 0 {
+		pipelineYAML, err = yaml.Marshal(instance.Spec.Config)
+		if err != nil {
+			return err
+		}
+	} else if instance.Spec.PipelineString != "" {
+		pipelineYAML = []byte(instance.Spec.PipelineString)
+	} else {
+		return fmt.Errorf("need to define `config` or `pipelineString` for pipeline '%s' in team '%s'", pipelineName, teamName)
 	}
 
 	// create a token client

--- a/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler.go
+++ b/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler.go
@@ -23,7 +23,6 @@ import (
 
 	concoursev1beta1 "github.com/alphagov/gsp/components/concourse-operator/pkg/apis/concourse/v1beta1"
 	"github.com/concourse/concourse/atc"
-	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
@@ -49,7 +48,7 @@ type PipelineCreateUpdateHandler struct {
 	Decoder types.Decoder
 }
 
-func (h *PipelineCreateUpdateHandler) Validate(config []byte) (bool, string, error) {
+func (h *PipelineCreateUpdateHandler) Validate(config atc.Config) (bool, string, error) {
 	warnings, err := h.validationWarnings(config)
 	if err != nil {
 		msg := fmt.Sprintf("unable to parse pipeline: %s", err.Error())
@@ -62,12 +61,7 @@ func (h *PipelineCreateUpdateHandler) Validate(config []byte) (bool, string, err
 	return true, "ok", nil
 }
 
-func (h *PipelineCreateUpdateHandler) validationWarnings(tmpl []byte) ([]string, error) {
-	var config atc.Config
-	if err := yaml.Unmarshal(tmpl, &config); err != nil {
-		return nil, err
-	}
-
+func (h *PipelineCreateUpdateHandler) validationWarnings(config atc.Config) ([]string, error) {
 	warnings := []string{}
 
 	warningMessages, errorMessages := config.Validate()
@@ -98,7 +92,7 @@ func (h *PipelineCreateUpdateHandler) Handle(ctx context.Context, req types.Requ
 		return admission.ErrorResponse(http.StatusBadRequest, err)
 	}
 
-	allowed, reason, err := h.Validate([]byte(obj.Spec.PipelineString))
+	allowed, reason, err := h.Validate(obj.Spec.Config)
 	if err != nil {
 		return admission.ErrorResponse(http.StatusInternalServerError, err)
 	}

--- a/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
+++ b/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/concourse/concourse/atc"
+	"gopkg.in/yaml.v2"
 )
 
 type ValidationTestCase struct {
@@ -88,7 +91,13 @@ func TestPipelineValidation(t *testing.T) {
 
 func testPipelineValidation(tc ValidationTestCase) error {
 	h := &PipelineCreateUpdateHandler{}
-	valid, validationMessage, handlerError := h.Validate([]byte(tc.Pipeline))
+	var config atc.Config
+	unmarshalError := yaml.Unmarshal([]byte(tc.Pipeline), &config)
+	if unmarshalError != nil {
+		return fmt.Errorf("did not expect unmarshalError but got: %v", unmarshalError)
+	}
+
+	valid, validationMessage, handlerError := h.Validate(config)
 	if handlerError != nil {
 		if tc.HandlerErrorContains == "" {
 			return fmt.Errorf("did not expect handlerError but got: %v", handlerError)

--- a/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
+++ b/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
@@ -97,7 +97,7 @@ func testPipelineValidation(tc ValidationTestCase) error {
 		return fmt.Errorf("did not expect unmarshalError but got: %v", unmarshalError)
 	}
 
-	valid, validationMessage, handlerError := h.Validate(config)
+	valid, validationMessage, handlerError := h.Validate(&config)
 	if handlerError != nil {
 		if tc.HandlerErrorContains == "" {
 			return fmt.Errorf("did not expect handlerError but got: %v", handlerError)


### PR DESCRIPTION
This change replaces `pipelineString` in the `Pipeline` resource with
`config` which expects a YAML object which represents a Concourse
pipeline configuration.