### PR TITLE
remove broken scrape config

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -171,47 +171,6 @@ prometheus-operator:
         - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
           regex: gsp-kiam-server;metrics
-      - job_name: 'kubernetes-pods-istio-secure'
-        scheme: https
-        tls_config:
-          ca_file: /etc/istio-certs/root-cert.pem
-          cert_file: /etc/istio-certs/cert-chain.pem
-          key_file: /etc/istio-certs/key.pem
-          insecure_skip_verify: true  # prometheus does not support secure naming.
-        kubernetes_sd_configs:
-        - role: pod
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        # sidecar status annotation is added by sidecar injector and
-        # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
-        - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
-          action: keep
-          regex: (([^;]+);([^;]*))|(([^;]*);(true))
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
-          action: drop
-          regex: (http)
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__]  # Only keep address that is host:port
-          action: keep    # otherwise an extra target with ':443' is added for https scheme
-          regex: ([^:]+):(\d+)
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: pod_name
       - job_name: 'amazon-vpc-cni'
         scheme: http
         kubernetes_sd_configs:


### PR DESCRIPTION
This is filling the prometheus logs with errors because
`/etc/istio-certs/root-cert.pem` doesn't exist.

This was copypasted from somewhere but we don't use it.  The intention
was that users can annotate their pods `prometheus.io/scrape: true` in
order to be scraped; this is generally not approved of these days (in
part because one pod might have multiple scrapable endpoints).  The
preferred solution is `ServiceMonitor` instead, which is what our
users in fact use.

As a result, this config block is safe to remove.