### PR TITLE
Allow dev role to delete ReplicaSets

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -9,6 +9,11 @@ rules:
     resources: ["pods"]
     verbs:
     - delete
+  - apiGroups: ["extensions"]
+    resources:
+    - replicasets
+    verbs:
+    - delete
   - apiGroups: [""]
     resources: ["pods/portforward"]
     verbs:


### PR DESCRIPTION
Currently, devs can delete pods if they get stuck, but we've seen a
problem where ReplicaSets get stuck (1 desired, 0 started, but the
replicaset never tries to create a new pod).  Devs should be able to
self-service turning things off and turning them on again :)

Deleting ReplicaSets is a pretty safe operation because they will be
managed by a Deployment which will recreate the deleted ReplicaSet.
This is similar to how deleting Pods is pretty safe because an
associated ReplicaSet, StatefulSet, DaemonSet or Job will recreate the
deleted Pod.