### PR TITLE
request more CPU for coredns

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
@@ -64,7 +64,7 @@ spec:
           limits:
             memory: 170Mi
           requests:
-            cpu: 100m
+            cpu: 250m
             memory: 70Mi
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
We consistently see coredns pods using 150m to 300m of CPU.  Therefore
to avoid overloading nodes that host coredns, let's allocate more CPU
to coredns.