### PR TITLE
allow devs to delete both kinds of ReplicaSet

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -9,6 +9,11 @@ rules:
     resources: ["pods"]
     verbs:
     - delete
+  - apiGroups: ["apps"]
+    resources:
+    - replicasets
+    verbs:
+    - delete
   - apiGroups: ["extensions"]
     resources:
     - replicasets


### PR DESCRIPTION
I think at some point replicasets were transitioned from
extentions/v1beta1 to apps/v1 (maybe in kubernetes 1.6?) so for ever
more we're going to be specifying both apiGroups everywhere I guess