### PR TITLE
Expose EKS oidc endpoint as gsp-cluster chart variable

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/deployment.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           value: "aws"
         - name: CLUSTER_NAME
           value: {{ .Values.global.cluster.name | quote }}
+        - name: AWS_OIDC_PROVIDER_URL
+          value: {{ .Values.global.cluster.oidcProviderURL }}
+        - name: AWS_OIDC_PROVIDER_ARN
+          value: {{ .Values.global.cluster.oidcProviderARN }}
         - name: AWS_RDS_SECURITY_GROUP_ID
           value: {{ .Values.RDSFromWorkerSecurityGroup | quote }}
         - name: AWS_RDS_SUBNET_GROUP_NAME

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -5,6 +5,8 @@ global:
     domain: ${cluster_domain}
     domain_id: ${cluster_domain_id}
     egressIpAddresses: ${egress_ip_addresses}
+    oidcProviderURL: ${cluster_oidc_provider_url}
+    oidcProviderARN: ${cluster_oidc_provider_arn}
   account:
     name: ${account_name}
   roles:

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -7,6 +7,8 @@ data "template_file" "values" {
     cluster_name                     = "${var.cluster_name}"
     cluster_domain                   = "${var.cluster_domain}"
     cluster_domain_id                = "${var.cluster_domain_id}"
+    cluster_oidc_provider_url        = "${jsonencode(module.k8s-cluster.oidc_provider_url)}"
+    cluster_oidc_provider_arn        = "${jsonencode(module.k8s-cluster.oidc_provider_arn)}"
     egress_ip_addresses              = "${jsonencode(var.egress_ips)}"
     account_name                     = "${var.account_name}"
     account_id                       = "${data.aws_caller_identity.current.account_id}"

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -31,6 +31,12 @@ resource "aws_eks_cluster" "eks-cluster" {
   }
 }
 
+resource "aws_iam_openid_connect_provider" "eks" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = []
+  url             = "${aws_eks_cluster.eks-cluster.identity.0.oidc.0.issuer}"
+}
+
 resource "aws_cloudwatch_log_group" "eks" {
   name              = "/aws/eks/${var.cluster_name}/cluster"
   retention_in_days = 30

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -33,3 +33,11 @@ output "eks-log-group-name" {
 output "worker_security_group_id" {
   value = "${aws_cloudformation_stack.worker-nodes.outputs["NodeSecurityGroup"]}"
 }
+
+output "oidc_provider_url" {
+  value = "${aws_iam_openid_connect_provider.eks.url}"
+}
+
+output "oidc_provider_arn" {
+  value = "${aws_iam_openid_connect_provider.eks.arn}"
+}


### PR DESCRIPTION
## What

* exposes OIDC endpoint/arn as helm global variables for the gsp-cluster chart
* consumes the endpoint/arn as environment variable

## Why

we need to expose the new oidc provider url and arn as helm values ready
to pass through to the svc-operator as an environment variable so that
we can get the svc-operator to manage IAM roles and policies for the new
service-account based per-pod IAM authentication.

svc-operator needs to know the EKS OIDC url/arn so that it can provision
IAM roles for service accounts and attach policy to those roles.