### PR TITLE
updates the Deployments to use the apps/v1 spec

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/coredns.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.global.runningOnAws }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.global.runningOnAws }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/charts/gsp-cluster/templates/02-gsp-system/metrics-server-deployment.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/metrics-server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server

--- a/components/canary/chart/templates/deployment.yaml
+++ b/components/canary/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "gsp-canary.fullname" . }}

--- a/docs/gds-supported-platform/getting-started-gsp-local.md
+++ b/docs/gds-supported-platform/getting-started-gsp-local.md
@@ -196,7 +196,7 @@ You run an app in the local GSP instance by creating a [Kubernetes Deployment re
 1. Create a `deployment.yaml` file in the `templates` directory with the following:
 
     ```
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: {{ .Release.Name }}-web


### PR DESCRIPTION
we believe some of the issues we have seen with replicasets getting into
poor states, not tidying up replicaset history and stalling / failing to
schdule pods can be attributed to the now deprecated
"extensions/v1beta1" version the Deployment kind.

The stable "apps/v1" Deployment kind has been out for some time now, and
has sensible defaults for replicaset history (keeps 10 old replicasets
max) and has a label based system for tracking target pods.

Hopefully this will resolve the occasional issues we were seeing, but
updating to the stable version would seem sensible anyway.

:warning: kube-proxy and dns are critical components and we will want to feel confident that this change is ok in sandbox by ensuring network connectivity is still good between nodes/services and that DNS is ok.