### PR TITLE
Check that images from the internal registry use digests

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,6 +4,7 @@ tap "homebrew/cask"
 brew "kubernetes-cli"
 brew "kubernetes-helm"
 brew "linuxbrew/extra/minikube" if OS.linux?
+brew "opa"
 
 if OS.mac?
   brew "hyperkit"

--- a/charts/gsp-cluster/policies/README.md
+++ b/charts/gsp-cluster/policies/README.md
@@ -1,0 +1,8 @@
+# OPA policies
+
+## Running Tests
+
+```
+$ opa test policies/digests-on-images
+PASS: 3/3
+```

--- a/charts/gsp-cluster/policies/digests-on-images/src.rego
+++ b/charts/gsp-cluster/policies/digests-on-images/src.rego
@@ -1,0 +1,11 @@
+package digests_on_images
+
+violation[{"msg": msg}] {
+  image := input.review.object.spec.containers[_].image
+  registry := input.parameters.registry
+
+  startswith(image, registry)
+  not re_match("^.*@sha256:[a-f,0-9]{64}$", image)
+
+  msg := sprintf("images from harbor must use digest: %v", [image])
+}

--- a/charts/gsp-cluster/policies/digests-on-images/src_test.rego
+++ b/charts/gsp-cluster/policies/digests-on-images/src_test.rego
@@ -1,0 +1,64 @@
+package digests_on_images
+
+test_allow_docker_hub_images {
+  input := {
+    "parameters": {
+      "registry": "registry.example.com"
+    },
+    "review": {
+      "object": {
+        "spec": {
+          "containers": [{
+            "image": "nginx"
+          }, {
+            "image": "nginx"
+          }]
+        }
+      }
+    }
+  }
+  results := data.digests_on_images.violation with input as input
+  count(results) == 0
+}
+
+test_deny_internal_registry_with_tag {
+  input := {
+    "parameters": {
+      "registry": "registry.example.com"
+    },
+    "review": {
+      "object": {
+        "spec": {
+          "containers": [{
+            "image": "nginx"
+          }, {
+            "image": "registry.example.com:latest"
+          }]
+        }
+      }
+    }
+  }
+  results := data.digests_on_images.violation with input as input
+  count(results) == 1
+}
+
+test_allow_internal_registry_with_digest {
+  input := {
+    "parameters": {
+      "registry": "registry.example.com"
+    },
+    "review": {
+      "object": {
+        "spec": {
+          "containers": [{
+            "image": "nginx"
+          }, {
+            "image": "registry.example.com@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+          }]
+        }
+      }
+    }
+  }
+  results := data.digests_on_images.violation with input as input
+  count(results) == 0
+}

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/constraints/digests-on-internal-registry.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/constraints/digests-on-internal-registry.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: RequireImageDigest
+metadata:
+  name: digests-on-internal-registry
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    registry: "registry.{{ .Values.global.cluster.domain }}"

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/gatekeeper.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/gatekeeper.yaml
@@ -1,0 +1,445 @@
+# Based off: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper.yaml
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: configs.config.gatekeeper.sh
+spec:
+  group: config.gatekeeper.sh
+  names:
+    kind: Config
+    plural: configs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            sync:
+              description: Configuration for syncing k8s objects
+              properties:
+                syncOnly:
+                  description: If non-empty, only entries on this list will be replicated
+                    into OPA
+                  items:
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            validation:
+              description: Configuration for validation
+              properties:
+                traces:
+                  description: List of requests to trace. Both "user" and "kinds"
+                    must be specified
+                  items:
+                    properties:
+                      dump:
+                        description: Also dump the state of OPA with the trace. Set
+                          to `All` to dump everything.
+                        type: string
+                      kind:
+                        description: Only trace requests of the following GroupVersionKind
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          version:
+                            type: string
+                        type: object
+                      user:
+                        description: Only trace requests from the specified user
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          properties:
+            byPod:
+              description: List of statuses as seen by individual pods
+              items:
+                properties:
+                  allFinalizers:
+                    description: List of Group/Version/Kinds with finalizers
+                    items:
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        version:
+                          type: string
+                      type: object
+                    type: array
+                  id:
+                    description: a unique identifier for the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: gatekeeper-manager-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - config.gatekeeper.sh
+  resources:
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - config.gatekeeper.sh
+  resources:
+  - configs/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: gatekeeper-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gatekeeper-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gatekeeper-webhook-server-secret
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: gatekeeper-controller-manager-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: gatekeeper-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  serviceName: gatekeeper-controller-manager-service
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - args:
+        - --auditInterval=30
+        - --port=8443
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SECRET_NAME
+          value: gatekeeper-webhook-server-secret
+        image: quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.1
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 8443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: gatekeeper-webhook-server-secret
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: constrainttemplates.templates.gatekeeper.sh
+spec:
+  group: templates.gatekeeper.sh
+  names:
+    kind: ConstraintTemplate
+    plural: constrainttemplates
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            crd:
+              properties:
+                spec:
+                  properties:
+                    names:
+                      properties:
+                        kind:
+                          type: string
+                      type: object
+                    validation:
+                      type: object
+                  type: object
+              type: object
+            targets:
+              items:
+                properties:
+                  rego:
+                    type: string
+                  target:
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            byPod:
+              items:
+                properties:
+                  errors:
+                    items:
+                      properties:
+                        code:
+                          type: string
+                        location:
+                          type: string
+                        message:
+                          type: string
+                      required:
+                      - code
+                      - message
+                      type: object
+                    type: array
+                  id:
+                    description: a unique identifier for the pod that wrote the status
+                    type: string
+                type: object
+              type: array
+            created:
+              type: boolean
+          type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1alpha1
+    served: true
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/sync.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/sync.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.gatekeeper.sh/v1alpha1
+kind: Config
+metadata:
+  name: config
+  namespace: {{ .Release.Namespace }}
+spec:
+  sync:
+    syncOnly:
+      - group: ""
+        version: "v1"
+        kind: "Pod"

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/templates/digests-on-internal-registry-images.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/templates/digests-on-internal-registry-images.yaml
@@ -1,0 +1,16 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: requireimagedigest
+spec:
+  crd:
+    spec:
+      names:
+        kind: RequireImageDigest
+        listKind: RequireImageDigestList
+        plural: requireimagedigests
+        singular: requireimagedigest
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ .Files.Get "policies/digests-on-images/src.rego" | indent 8 }}


### PR DESCRIPTION
This is the first step in making sure that all our application images
(not images from Docker Hub or elsewhere) have been built by Concourse.

This means that if you try to `kubectl apply` the following:

```
apiVersion: v1
kind: Pod
metadata:
  name: test
  namespace: gsp-system
spec:
  containers:
  - name: lol
    image: registry.local.govsandbox.uk/nginx:latest
    imagePullPolicy: IfNotPresent
```

Then it will deploy correctly but violations will be listed in the
constraint resource:

```
$ kubectl get RequireImageDigest digests-on-internal-registry -n gsp-system -o yaml
...
violations:
- enforcementAction: dryrun
  kind: Pod
  message: 'images from harbor must use digest: registry.local.govsandbox.uk/nginx:latest'
  name: test
  namespace: gsp-system
```