### PR TITLE
Add per-AZ node autoscaling groups

### DIFF
--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -1,0 +1,237 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Amazon EKS - Node Group
+
+Parameters:
+
+  NodeImageId:
+    Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+    Default: /aws/service/eks/optimized-ami/1.14/amazon-linux-2/recommended/image_id
+    Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
+
+  NodeInstanceType:
+    Description: EC2 instance type for the node instances
+    Type: String
+    Default: t3.medium
+    ConstraintDescription: Must be a valid EC2 instance type
+    AllowedValues:
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
+      - m5.large
+      - m5.xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+      - m5.12xlarge
+      - m5.24xlarge
+      - m5d.large
+      - m5d.xlarge
+      - m5d.2xlarge
+      - m5d.4xlarge
+      - m5d.12xlarge
+      - m5d.24xlarge
+      - m5a.large
+      - m5a.xlarge
+      - m5a.2xlarge
+      - m5a.4xlarge
+      - m5a.12xlarge
+      - m5a.24xlarge
+      - m5ad.large
+      - m5ad.xlarge
+      - m5ad.2xlarge
+      - m5ad.4xlarge
+      - m5ad.12xlarge
+      - m5ad.24xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.18xlarge
+      - i3.large
+      - i3.xlarge
+      - i3.2xlarge
+      - i3.4xlarge
+      - i3.8xlarge
+      - i3.16xlarge
+      - x1.16xlarge
+      - x1.32xlarge
+      - p2.xlarge
+      - p2.8xlarge
+      - p2.16xlarge
+      - p3.2xlarge
+      - p3.8xlarge
+      - p3.16xlarge
+      - p3dn.24xlarge
+      - r5.large
+      - r5.xlarge
+      - r5.2xlarge
+      - r5.4xlarge
+      - r5.12xlarge
+      - r5.24xlarge
+      - r5d.large
+      - r5d.xlarge
+      - r5d.2xlarge
+      - r5d.4xlarge
+      - r5d.12xlarge
+      - r5d.24xlarge
+      - z1d.large
+      - z1d.xlarge
+      - z1d.2xlarge
+      - z1d.3xlarge
+      - z1d.6xlarge
+      - z1d.12xlarge
+
+  NodeAutoScalingGroupMinSize:
+    Description: Minimum size of Node Group ASG.
+    Type: Number
+    Default: 1
+
+  NodeAutoScalingGroupMaxSize:
+    Description: Maximum size of Node Group ASG. Set to at least 1 greater than NodeAutoScalingGroupDesiredCapacity.
+    Type: Number
+    Default: 2
+
+  NodeAutoScalingGroupDesiredCapacity:
+    Description: Desired capacity of Node Group ASG.
+    Type: Number
+    Default: 1
+
+  NodeVolumeSize:
+    Description: Node volume size
+    Type: Number
+    Default: 20
+
+  ClusterName:
+    Description: The cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster.
+    Type: String
+
+  BootstrapArguments:
+    Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
+    Type: String
+    Default: ""
+
+  NodeGroupName:
+    Description: Unique identifier for the Node Group.
+    Type: String
+
+  ClusterControlPlaneSecurityGroup:
+    Description: The security group of the cluster control plane.
+    Type: AWS::EC2::SecurityGroup::Id
+
+  VpcId:
+    Description: The VPC of the worker instances
+    Type: AWS::EC2::VPC::Id
+
+  Subnets:
+    Description: The subnets where workers can be created.  Please keep subnets to a single AZ.
+    Type: List<AWS::EC2::Subnet::Id>
+
+  NodeSecurityGroups:
+    Description: The security groups to attach to the workers.
+    Type: List<AWS::EC2::SecurityGroup::Id>
+
+  NodeTargetGroups:
+    Description: The target groups in which to register the workers.
+    Type: List<String>
+
+  NodeInstanceProfile:
+    Description: The instance profile ARN to associate with the workers.
+    Type: String
+
+Metadata:
+
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: EKS Cluster
+        Parameters:
+          - ClusterName
+          - ClusterControlPlaneSecurityGroup
+      - Label:
+          default: Worker Node Configuration
+        Parameters:
+          - NodeGroupName
+          - NodeAutoScalingGroupMinSize
+          - NodeAutoScalingGroupDesiredCapacity
+          - NodeAutoScalingGroupMaxSize
+          - NodeInstanceType
+          - NodeInstanceProfile
+          - NodeImageId
+          - NodeVolumeSize
+          - BootstrapArguments
+      - Label:
+          default: Worker Network Configuration
+        Parameters:
+          - VpcId
+          - Subnets
+          - NodeSecurityGroups
+          - NodeTargetGroups
+
+Resources:
+
+  NodeGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      DesiredCapacity: !Ref NodeAutoScalingGroupDesiredCapacity
+      LaunchTemplateSpecification:
+        LaunchTemplateId: !Ref NodeLaunchTemplate
+      MinSize: !Ref NodeAutoScalingGroupMinSize
+      MaxSize: !Ref NodeAutoScalingGroupMaxSize
+      VPCZoneIdentifier: !Ref Subnets
+      TargetGroupARNs: !Ref NodeTargetGroups
+      # TODO: this is where we can in future provision spot instances
+      # MixedInstancesPolicy:
+      #   InstancesDistribution:
+      #     OnDemandBaseCapacity: !Ref NodeAutoScalingGroupMinSize
+      #   LaunchTemplate:
+      #     LaunchTemplateSpecification:
+      #       LaunchTemplateId: !Ref NodeLaunchTemplate
+      #     Overrides:
+      #       - InstanceType: m5ad.xlarge
+      #       - InstanceType: m5d.xlarge
+      Tags:
+        - Key: Name
+          Value: !Sub ${ClusterName}-${NodeGroupName}
+          PropagateAtLaunch: true
+        - Key: !Sub kubernetes.io/cluster/${ClusterName}
+          Value: owned
+          PropagateAtLaunch: true
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 2
+        MinInstancesInService: !Ref NodeAutoScalingGroupDesiredCapacity
+        PauseTime: PT5M
+
+  NodeLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Ref NodeGroupName
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !Ref NodeInstanceProfile
+        ImageId: !Ref NodeImageId
+        InstanceType: !Ref NodeInstanceType
+        SecurityGroups: !Ref NodeSecurityGroups
+
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              VolumeSize: !Ref NodeVolumeSize
+              VolumeType: gp2
+              DeleteOnTermination: true
+        UserData:
+          Fn::Base64:
+            !Sub |
+              #!/bin/bash
+              set -o xtrace
+              /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
+              /opt/aws/bin/cfn-signal --exit-code $? \
+                       --stack  ${AWS::StackName} \
+                       --resource NodeGroup  \
+                       --region ${AWS::Region}
+

--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -340,8 +340,12 @@ Resources:
 
 Outputs:
 
+  NodeInstanceProfile:
+    Description: The node instance profile ARN
+    Value: !GetAtt NodeInstanceProfile.Arn
+
   NodeInstanceRole:
-    Description: The node instance role
+    Description: The node instance role ARN
     Value: !GetAtt NodeInstanceRole.Arn
 
   NodeSecurityGroup:

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -4,7 +4,7 @@ data "aws_region" "current" {}
 
 data "aws_subnet" "private_subnets" {
   count = "${length(var.private_subnet_ids)}"
-  id    = "${elem(var.private_subnet_ids, count.index)}"
+  id    = "${element(var.private_subnet_ids, count.index)}"
 }
 
 resource "aws_eks_cluster" "eks-cluster" {

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -103,12 +103,8 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
     BootstrapArguments  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""
     VpcId               = "${var.vpc_id}"
     Subnets             = "${element(data.aws_subnet.private_subnets.*.id, count.index)}"
-    NodeSecurityGroups  = ["${aws_security_group.node.id}", "${aws_security_group.worker.id}"]
-
-    NodeTargetGroups = [
-      "${aws_cloudformation_stack.worker-nodes.outputs["HTTPTargetGroup"]}",
-      "${aws_cloudformation_stack.worker-nodes.outputs["TCPTargetGroup"]}",
-    ]
+    NodeSecurityGroups  = "${aws_security_group.node.id},${aws_security_group.worker.id}"
+    NodeTargetGroups    = "${aws_cloudformation_stack.worker-nodes.outputs["HTTPTargetGroup"]},${aws_cloudformation_stack.worker-nodes.outputs["TCPTargetGroup"]}"
   }
 
   depends_on = ["aws_eks_cluster.eks-cluster"]

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -83,7 +83,7 @@ resource "aws_cloudformation_stack" "worker-nodes" {
 }
 
 resource "aws_cloudformation_stack" "worker-nodes-per-az" {
-  count         = "${length(data.aws_subnet.private_subnets.*.id)}"
+  count         = "${length(var.private_subnet_ids)}"
   name          = "${var.cluster_name}-worker-nodes-${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"
   template_body = "${file("${path.module}/data/nodegroup-v2.yaml")}"
   capabilities  = ["CAPABILITY_IAM"]

--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -88,7 +88,7 @@ resource "aws_security_group" "node" {
   }
 }
 
-resource "aws_security_group" "node-egress" {
+resource "aws_security_group_rule" "node-egress" {
   security_group_id = "${aws_security_group.node.id}"
 
   type        = "egress"
@@ -133,7 +133,7 @@ resource "aws_security_group" "worker" {
 }
 
 resource "aws_security_group_rule" "workers-from-public" {
-  security_group_id = "${aws_security_group.worker-node.id}"
+  security_group_id = "${aws_security_group.worker.id}"
 
   type      = "ingress"
   protocol  = "tcp"

--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -8,7 +8,10 @@ resource "aws_security_group" "controller" {
 
   vpc_id = "${var.vpc_id}"
 
-  tags = "${map("Name", "${var.cluster_name}-controller")}"
+  tags = {
+    "Name"                                      = "${var.cluster_name}-controller"
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+  }
 }
 
 resource "aws_security_group_rule" "controller-apiserver-cidrs" {
@@ -71,4 +74,71 @@ resource "aws_security_group_rule" "ci-nodes-from-vpc" {
   from_port   = 0
   to_port     = 0
   cidr_blocks = ["${data.aws_vpc.private.cidr_block}"]
+}
+
+resource "aws_security_group" "node" {
+  name        = "${var.cluster_name}-node"
+  description = "${var.cluster_name} node security group.  All nodes should be in this security group."
+
+  vpc_id = "${var.vpc_id}"
+
+  tags = {
+    "Name"                                      = "${var.cluster_name}-node"
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+  }
+}
+
+resource "aws_security_group" "node-egress" {
+  security_group_id = "${aws_security_group.node.id}"
+
+  type        = "egress"
+  protocol    = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "nodes-from-vpc" {
+  security_group_id = "${aws_security_group.node.id}"
+
+  type      = "ingress"
+  protocol  = "-1"
+  from_port = 0
+  to_port   = 0
+
+  cidr_blocks = ["${data.aws_vpc.private.cidr_block}"]
+}
+
+resource "aws_security_group_rule" "controller-from-nodes" {
+  security_group_id = "${aws_security_group.controller.id}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 443
+  to_port   = 443
+
+  source_security_group_id = "${aws_security_group.node.id}"
+}
+
+resource "aws_security_group" "worker" {
+  name        = "${var.cluster_name}-worker"
+  description = "${var.cluster_name} worker node security group - ie nodes that tenant pods will run on."
+
+  vpc_id = "${var.vpc_id}"
+
+  tags = {
+    "Name"                                      = "${var.cluster_name}-worker"
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+  }
+}
+
+resource "aws_security_group_rule" "workers-from-public" {
+  security_group_id = "${aws_security_group.worker-node.id}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 31390
+  to_port   = 31390
+
+  cidr_blocks = ["0.0.0.0/0"]
 }

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -32,6 +32,11 @@ variable "worker_count" {
   default = "3"
 }
 
+variable "extra_workers_per_az_count" {
+  type    = "string"
+  default = "0"
+}
+
 variable "ci_worker_instance_type" {
   type    = "string"
   default = "t3.medium"

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -537,6 +537,7 @@ resources:
       eks_version: ((eks-version))
       worker_instance_type: ((worker-instance-type))
       worker_count: ((worker-count))
+      extra_workers_per_az_count: ((extra-workers-per-az-count))
       enable_nlb: ((enable-nlb))
       ci_worker_instance_type: ((ci-worker-instance-type))
       ci_worker_count: ((ci-worker-count))


### PR DESCRIPTION
This adds new autoscaling groups for workers in each AZ.

But why tho?
------------

I want to enable the cluster autoscaler (see #244).  But the cluster
autoscaler can only scale with the tools that it has.  In particular,
if one AZ is under contention, it currently can't create a node in
that specific AZ.

What did you do?
----------------

I copied the `nodegroup.yaml` to a `nodegroup-v2.yaml`.  This is
similar to the original nodegroup except:

 - it uses launch templates instead of launch configurations

   - this is (in part) so that we can launch spot instances for
     workers in future

 - it doesn't create the NodeSecurityGroup (this is created in
   terraform instead)

 - it doesn't create the node target groups or node instance
   profiles (it steals them from the existing worker group instead)

 - it disallows outdated instance families in the NodeInstanceType
   field - no `m4` or `t2` instances for you :)

The security group change deserves more detail.  Previously, each node
group got its own security group, but the security groups were almost
identical to each other.  The only difference is that worker nodes
allow 31390 from public IPs, which ci and kiam nodes do not.

This does not scale to creating new worker nodegroups per AZ.  I think
a much simpler model would be to define a single `node` security group
which captures everything that a generic node needs, and if any extra
behaviour is needed (such as port 31390) this can be captured in an
extra security group (eg `worker` in this commit).

This means that, in future, all nodegroups should be in the same
`node` security group.  Particular nodegroups may wish to join other
security groups if they need particular access to extra things.

The new autoscaling groups will be scaled to 0 instances by default.
You can configure this with the `extra_workers_per_az_count` variable.
I'm going to raise a PR to set this to a reasonable value in sandbox
for testing, but I'd rather not create extra instances in verify or
portfolio just yet until we've demonstrated it working in sandbox.