### PR TITLE
bump prometheus-config-reloader CPU limit

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -299,6 +299,7 @@ prometheus-operator:
   prometheusOperator:
     kubeletService:
       enabled: false
+    configReloaderCpu: 200m
   kubelet:
     enabled: false
   alertmanager:


### PR DESCRIPTION
We have been seeing CPUThrottlingHigh alerts for the
prometheus-config-reloader container.  It has a default limit of
`100m`.  I'm hoping that boosting it to `200m` will quench the alerts.