### PR TITLE
bump service operator CPU limit

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/deployment.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           value: {{ .Values.serviceOperator.permissionsBoundaryARN | quote }}
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 100Mi
           requests:
             cpu: 100m


### PR DESCRIPTION
The service operator is getting throttled a lot.  It doesn't use much
CPU on average, but it has a very spiky workload.  Hopefully bumping
the CPU limit up a lot will prevent this throttling.