### PR TITLE
Allow non-admins to see Gatekeeper configuration

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/dev-cluster-role.yaml
@@ -111,6 +111,12 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["templates.gatekeeper.sh", "constraints.gatekeeper.sh"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
 {{- range $extraPermission := .Values.extraPermissionsDev }}
   -
 {{- $extraPermission | toYaml | nindent 4 }}

--- a/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/sre-cluster-role.yaml
@@ -137,6 +137,12 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["templates.gatekeeper.sh", "constraints.gatekeeper.sh"]
+    resources: ["*"]
+    verbs:
+    - get
+    - list
+    - watch
 {{- range $extraPermission := .Values.extraPermissionsSRE }}
   -
 {{- $extraPermission | toYaml | nindent 4 }}


### PR DESCRIPTION
This is probably helpful for being able to see what things are failing
the checks and reasoning about why those things are failing the checks.