### PR TITLE
set default extra-workers-per-az-count

### DIFF
--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -20,6 +20,8 @@ disable-destroy: true
 config-approvers: []
 config-approval-count: 2
 
+extra-workers-per-az-count: 0
+
 task-toolbox-image: govsvc/task-toolbox
 task-toolbox-tag: latest
 


### PR DESCRIPTION
so that the pipelines don't all suddenly break