### PR TITLE
mark worker-nodes-per-az as depending on worker-nodes

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -107,7 +107,7 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
     NodeTargetGroups    = "${aws_cloudformation_stack.worker-nodes.outputs["HTTPTargetGroup"]},${aws_cloudformation_stack.worker-nodes.outputs["TCPTargetGroup"]}"
   }
 
-  depends_on = ["aws_eks_cluster.eks-cluster"]
+  depends_on = ["aws_eks_cluster.eks-cluster", "aws_cloudformation_stack.worker-nodes"]
 }
 
 resource "aws_cloudformation_stack" "kiam-server-nodes" {


### PR DESCRIPTION
We use the outputs from that stack so we should make it clear that we
have a dependency.  Hopefully this will fix the build.