### PR TITLE
Refer to security groups by name, not id

### DIFF
--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -217,7 +217,7 @@ Resources:
           Arn: !Ref NodeInstanceProfile
         ImageId: !Ref NodeImageId
         InstanceType: !Ref NodeInstanceType
-        SecurityGroups: !Ref NodeSecurityGroups
+        SecurityGroupIds: !Ref NodeSecurityGroups
 
         BlockDeviceMappings:
           - DeviceName: /dev/xvda


### PR DESCRIPTION
If you pass `SecurityGroups` to a launch template, it expects security
group names, which is only permitted in EC2 Classic.  In a VPC, you
must use security group ids via `SecurityGroupIds` instead.

This leads to the useful and helpful error message "The parameter
groupName cannot be used with the parameter subnet".  Basically you
can only use `subnet` if you're in a VPC, and you can only use
`groupName` if you're in EC2 Classic (ie not in a VPC).  And these
parameter names don't actually match the CloudFormation names oh well.