### PR TITLE
pass extra_workers_per_az_count through everywhere

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -1,14 +1,15 @@
 module "k8s-cluster" {
-  source                  = "../k8s-cluster"
-  vpc_id                  = "${var.vpc_id}"
-  private_subnet_ids      = ["${var.private_subnet_ids}"]
-  public_subnet_ids       = ["${var.public_subnet_ids}"]
-  cluster_name            = "${var.cluster_name}"
-  worker_count            = "${var.worker_count}"
-  worker_instance_type    = "${var.worker_instance_type}"
-  ci_worker_count         = "${var.ci_worker_count}"
-  ci_worker_instance_type = "${var.ci_worker_instance_type}"
-  eks_version             = "${var.eks_version}"
+  source                     = "../k8s-cluster"
+  vpc_id                     = "${var.vpc_id}"
+  private_subnet_ids         = ["${var.private_subnet_ids}"]
+  public_subnet_ids          = ["${var.public_subnet_ids}"]
+  cluster_name               = "${var.cluster_name}"
+  worker_count               = "${var.worker_count}"
+  worker_instance_type       = "${var.worker_instance_type}"
+  extra_workers_per_az_count = "${var.extra_workers_per_az_count}"
+  ci_worker_count            = "${var.ci_worker_count}"
+  ci_worker_instance_type    = "${var.ci_worker_instance_type}"
+  eks_version                = "${var.eks_version}"
 
   apiserver_allowed_cidrs = ["${concat(
       formatlist("%s/32", var.egress_ips),

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -60,6 +60,11 @@ variable "worker_instance_type" {
   default = "t3.medium"
 }
 
+variable "extra_workers_per_az_count" {
+  type    = "string"
+  default = "0"
+}
+
 variable "ci_worker_count" {
   type    = "string"
   default = "2"

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -58,6 +58,10 @@ variable "worker_count" {
   default = "3"
 }
 
+variable "extra_workers_per_az_count" {
+  type = "string"
+}
+
 variable "ci_worker_instance_type" {
   type    = "string"
   default = "m5d.large"
@@ -130,11 +134,12 @@ module "gsp-cluster" {
     "3.8.110.67/32",     # autom8 concourse
   ]
 
-  eks_version             = "${var.eks_version}"
-  worker_instance_type    = "${var.worker_instance_type}"
-  worker_count            = "${var.worker_count}"
-  ci_worker_instance_type = "${var.ci_worker_instance_type}"
-  ci_worker_count         = "${var.ci_worker_count}"
+  eks_version                = "${var.eks_version}"
+  worker_instance_type       = "${var.worker_instance_type}"
+  worker_count               = "${var.worker_count}"
+  extra_workers_per_az_count = "${var.extra_workers_per_az_count}"
+  ci_worker_instance_type    = "${var.ci_worker_instance_type}"
+  ci_worker_count            = "${var.ci_worker_count}"
 
   vpc_id               = "${module.gsp-network.vpc_id}"
   private_subnet_ids   = "${module.gsp-network.private_subnet_ids}"


### PR DESCRIPTION
You need quite a bit of plumbing to get variables from the concourse
deployer pipeline through to the k8s-cluster module.