### PR TITLE
Add support for custom domains

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## Index
 - [Accessing Concourse](gds-supported-platform/accessing-concourse.md)
 - [Accessing Dashboard](gds-supported-platform/accessing-dashboard.md)
+- [Adding a custom domain to GSP](gds-supported-platform/custom-domains.md)
 - [Architecture Decision Records](/docs/architecture/adr)
 - [Getting started with a local GDS Supported Platform development cluster](/docs/gds-supported-platform/getting-started-gsp-local.md)
 - [GSP Architecture](/docs/architecture/gsp-architecture.md)

--- a/docs/gds-supported-platform/custom-domains.md
+++ b/docs/gds-supported-platform/custom-domains.md
@@ -1,0 +1,36 @@
+# Adding a custom domain to your GSP cluster
+
+You may wish to host your GSP apps on a custom domain.  This guide
+explains how it works.
+
+## Assumptions
+
+We assume that:
+
+ - you want GSP to automatically provision TLS certificates (rather
+   than providing your own)
+ 
+## Telling the cluster about the domain
+
+To tell a cluster that you want it to manage a particular domain, add
+the name to the `extra-zones` value in the cluster-config repository.
+For example:
+
+    extra-zones: ["my-domain.example.com"]
+
+## Delegating the domain to the cluster
+
+Once you have told the cluster about your custom domain, you need to
+delegate the domain to the cluster.  Currently, the way you do this is
+to go into the AWS console to discover the appropriate NS records for
+the zone, then set these NS records in your DNS provider to delegate
+that domain to the cluster.
+
+## Caveats
+
+CNAMEs are not supported.  This is because we use the
+[`tls-dns-01`][acme-challenges] challenge type to verify domains for
+issuing certificates, and to do this we need to be able to create TXT
+records on the domain.
+
+[acme-challenges]: https://letsencrypt.org/docs/challenge-types/

--- a/modules/gsp-cluster/cert-manager.tf
+++ b/modules/gsp-cluster/cert-manager.tf
@@ -9,8 +9,18 @@ data "aws_iam_policy_document" "cert_manager" {
     ]
 
     resources = [
-      "arn:aws:route53:::hostedzone/${var.cluster_domain_id}"
+      "arn:aws:route53:::hostedzone/${var.cluster_domain_id}",
     ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+
+    resources = "${formatlist("arn:aws:route53:::hostedzone/%s", aws_route53_zone.subdomain.*.zone_id)}"
   }
 
   statement {
@@ -21,7 +31,7 @@ data "aws_iam_policy_document" "cert_manager" {
     ]
 
     resources = [
-      "arn:aws:route53:::change/*"
+      "arn:aws:route53:::change/*",
     ]
   }
 
@@ -34,13 +44,13 @@ data "aws_iam_policy_document" "cert_manager" {
     ]
 
     resources = [
-      "*"
+      "*",
     ]
   }
 }
 
 resource "aws_iam_policy" "cert_manager" {
-  name         = "${var.cluster_name}_cert_manager"
+  name        = "${var.cluster_name}_cert_manager"
   description = "Allow cert-manager to use the DNS01 challenge"
 
   policy = "${data.aws_iam_policy_document.cert_manager.json}"
@@ -53,9 +63,11 @@ resource "aws_iam_role" "cert_manager" {
 }
 
 resource "aws_iam_policy_attachment" "cert_manager" {
-  name       = "${var.cluster_name}_cert_manager"
-  roles      = [
+  name = "${var.cluster_name}_cert_manager"
+
+  roles = [
     "${aws_iam_role.cert_manager.name}",
   ]
+
   policy_arn = "${aws_iam_policy.cert_manager.arn}"
 }

--- a/modules/gsp-cluster/extra-zones.tf
+++ b/modules/gsp-cluster/extra-zones.tf
@@ -1,0 +1,5 @@
+resource "aws_route53_zone" "subdomain" {
+  count         = "${length(var.extra_zones)}"
+  name          = "${element(var.extra_zones, count.index)}"
+  force_destroy = true
+}

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -18,6 +18,11 @@ variable "cluster_domain_id" {
   type        = "string"
 }
 
+variable "extra_zones" {
+  description = "Extra DNS zones that you want the cluster to manage"
+  type        = "list"
+}
+
 variable "admin_role_arns" {
   type = "list"
 }

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -22,6 +22,8 @@ config-approval-count: 2
 
 extra-workers-per-az-count: 0
 
+extra-zones: []
+
 task-toolbox-image: govsvc/task-toolbox
 task-toolbox-tag: latest
 

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -15,6 +15,10 @@ variable "cluster_domain" {
   type = "string"
 }
 
+variable "extra_zones" {
+  type = "list"
+}
+
 variable "github_client_id" {
   type = "string"
 }
@@ -117,6 +121,8 @@ module "gsp-cluster" {
   cluster_name      = "${var.cluster_name}"
   cluster_domain    = "${var.cluster_domain}"
   cluster_domain_id = "${module.gsp-domain.zone_id}"
+
+  extra_zones = ["${var.extra_zones}"]
 
   admin_role_arns = [
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/deployer",

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -524,6 +524,7 @@ resources:
       account_name: ((account-name))
       cluster_name: ((cluster-name))
       cluster_domain: ((cluster-domain))
+      extra_zones: ((extra-zones))
       cluster_number: ((cluster-number))
       aws_account_role_arn: ((account-role-arn))
       github_client_id: ((github-client-id))


### PR DESCRIPTION
This adds support for adding a custom domain to the cluster.  Docs in
the markdown file in this commit.

I don't really know if this will work or not so :eyes: would be
welcome.