### PR TITLE
Revert "Remove unneeded security group rules"

### DIFF
--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -109,6 +109,28 @@ resource "aws_security_group_rule" "nodes-from-vpc" {
   cidr_blocks = ["${data.aws_vpc.private.cidr_block}"]
 }
 
+resource "aws_security_group_rule" "nodes-from-controller" {
+  security_group_id = "${aws_security_group.node.id}"
+
+  type      = "ingress"
+  protocol  = "tcp"
+  from_port = 1025
+  to_port   = 65535
+
+  source_security_group_id = "${aws_security_group.controller.id}"
+}
+
+resource "aws_security_group_rule" "controller-to-nodes" {
+  security_group_id = "${aws_security_group.controller.id}"
+
+  type      = "egress"
+  protocol  = "tcp"
+  from_port = 1025
+  to_port   = 65535
+
+  source_security_group_id = "${aws_security_group.node.id}"
+}
+
 resource "aws_security_group_rule" "controller-from-nodes" {
   security_group_id = "${aws_security_group.controller.id}"
 


### PR DESCRIPTION
This reverts commit 3e76e6e114fa7fe3bc2503b95471e641fca730fd.

According to @blairboy362:

> the EKS control plane is magic. Just because ingress rules and
> egress rules cover all protocols over 0.0.0.0/0 doesn’t mean the
> traffic is allowed. The controller security group has to be
> explicitly allowed.

:face_with_rolling_eyes: