### PR TITLE
Document how to use tenant-provided TLS certificates

### DIFF
--- a/docs/gds-supported-platform/tls-certificates.md
+++ b/docs/gds-supported-platform/tls-certificates.md
@@ -1,5 +1,10 @@
 # Public TLS Certificates
 
+All apps in GSP are protected by TLS.  There are two options for this:
+using cluster-provided certificates, or providing your own.
+
+## Using cluster-provided certificates
+
 You can provision TLS certificates using [cert-manager][] in GSP.
 
 By default, the GSP has a `ClusterIssuer` named `letsencrypt-r53` that is configured to provision TLS certificates supplied by [LetsEncrypt][] via the DNS01 ACME challenge. For example, to add a TLS certificate for the [gsp-canary][] in the sandbox cluster use the following kube yaml:
@@ -26,6 +31,76 @@ spec:
 ```
 
 > **Note:** cert-manager will need to be able to modify the DNS of the domains listed in the certificate in order to perform the DNS challenge. At the time of writing that only applies to the cluster domain.
+
+## Providing your own certificates
+
+If you want to provide your own certificate, you will need:
+
+ - a `SealedSecret` resource containing the certificate and key
+ - a `Gateway` resource defining the ingress domain
+
+We assume:
+
+ - you are in a namespace called `my-namespace`
+ - your certificate and key are in files called `my-cert.pem` and
+   `my-cert.key`
+ - you want to create a `SealedSecret` called `my-custom-cert` in a
+   file called `my-custom-cert.yaml`
+ - you are creating the certificate for the `sandbox` cluster
+ - the certificate is for `my-custom-domain.example.com`.
+
+To create a `SealedSecret` with your certificate, run:
+
+    kubectl create -n my-namespace secret generic my-custom-cert --dry-run --from-file=cert=my-cert.pem --from-file=key=my-cert.key --output yaml | gds sandbox seal --format yaml > my-custom-cert.yaml
+
+Here is an example of a `Gateway` that uses this certificate:
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: custom-certificate-gateway
+  namespace: my-namespace
+  annotations:
+    externaldns.k8s.io/namespace: my-namespace
+spec:
+  selector:
+    istio: my-namespace-ingressgateway
+  servers:
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: my-custom-cert
+    hosts:
+      - "my-custom-domain.example.com"
+```
+
+The line `istio: my-namespace-ingressgateway` (replace `my-namespace`
+with your actual namespace name) selects the ingressgateway in your
+namespace.
+
+The line `credentialName: my-custom-cert` tells the `Gateway` to use
+the `SealedSecret` you created above for TLS termination.
+
+The line `- "my-custom-domain.example.com"` tells the `Gateway` to
+listen on the virtual host corresponding to the certificate domain
+name.
+
+### Custom domains
+
+As the example shows, if you provide your own certificates, you can
+use any custom domain you choose; you do not have to use the cluster
+`govsvc.uk` domain.  To use a custom domain, create a CNAME record
+from your domain to the external load balancer for your namespace.
+
+To find the external load balancer name, run:
+
+    kubectl -n my-namespace get svc my-namespace-ingressgateway
+
+and look under the `EXTERNAL-IP` column.
 
 [cert-manager]: https://docs.cert-manager.io/en/latest/
 [gsp-canary]: https://github.com/alphagov/gsp/tree/master/components/canary

--- a/docs/gds-supported-platform/tls-certificates.md
+++ b/docs/gds-supported-platform/tls-certificates.md
@@ -1,9 +1,16 @@
 # Public TLS Certificates
 
-All apps in GSP are protected by TLS.  By default, TLS will use a
-cluster-provided certificate.  However, this does not work with custom
-domains (that is, non-`.govsvc.uk` domains).  If you wish to use a
-custom domain, you must provide your own TLS certificate.
+Your GSP app will need a TLS certificate in order to serve HTTPS
+traffic.  There are two options:
+
+ - use a cluster-provided certificate
+ - provide your own certificate
+
+Cluster-provided certificates require less effort because you don't
+need to provision a certificate for yourself.  However, the cluster
+cannot at this point provide certificates for custom domains (that is,
+non-`.govsvc.uk` domains).  If you wish to use a custom domain, you
+must provide your own TLS certificate.
 
 ## Using cluster-provided certificates
 

--- a/docs/gds-supported-platform/tls-certificates.md
+++ b/docs/gds-supported-platform/tls-certificates.md
@@ -89,18 +89,17 @@ The line `- "my-custom-domain.example.com"` tells the `Gateway` to
 listen on the virtual host corresponding to the certificate domain
 name.
 
-### Custom domains
+### Providing certificates for custom domains
 
 As the example shows, if you provide your own certificates, you can
 use any custom domain you choose; you do not have to use the cluster
 `govsvc.uk` domain.  To use a custom domain, create a CNAME record
-from your domain to the external load balancer for your namespace.
-
-To find the external load balancer name, run:
-
-    kubectl -n my-namespace get svc my-namespace-ingressgateway
-
-and look under the `EXTERNAL-IP` column.
+from your domain to the external load balancer for your namespace.  We
+provide a convenience record called
+`<namespace>.london.<cluster>.govsvc.uk` for this purpose.  For
+example, if your namespace is called `verify-proxy-node-prod` in the
+`verify` cluster, you would create a CNAME from your custom domain to
+`verify-proxy-node-prod.london.verify.govsvc.uk.`.
 
 [cert-manager]: https://docs.cert-manager.io/en/latest/
 [gsp-canary]: https://github.com/alphagov/gsp/tree/master/components/canary

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -81,6 +81,7 @@ generate_user_values: &generate_user_values
 generate_managed_namespaces_values: &generate_managed_namespaces_values
   platform: linux
   params:
+    CONFIG_PATH:
     CONFIG_VALUES_PATH:
   run:
     path: /bin/bash
@@ -90,7 +91,7 @@ generate_managed_namespaces_values: &generate_managed_namespaces_values
     - |
       mkdir -p managed-namespaces-values
       echo "generating istio gateway values for managed namespaces..."
-      gomplate -d config=config/${CONFIG_VALUES_PATH} -f platform/templates/managed-namespaces-gateways.yaml > managed-namespaces-values/gateways-values.yaml
+      gomplate -d config=config/${CONFIG_VALUES_PATH} -d cluster=config/${CONFIG_PATH} -f platform/templates/managed-namespaces-gateways.yaml > managed-namespaces-values/gateways-values.yaml
   inputs:
   - name: platform
   - name: config
@@ -679,6 +680,7 @@ jobs:
       config: *generate_managed_namespaces_values
       image: task-toolbox
       params:
+        CONFIG_PATH: ((config-path))
         CONFIG_VALUES_PATH: ((config-values-path))
   - task: apply-cluster-chart
     image: task-toolbox

--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -62,6 +62,8 @@ istio:
         service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "5"
         service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "3"
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+        external-dns.alpha.kubernetes.io/hostname: |
+          {{ $namespace.name }}.{{ index (datasource "cluster") "cluster-domain" }}
       podAnnotations: {}
       type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
       externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out


### PR DESCRIPTION
Now that we have per-namespace ingressgateways, it's possible for
tenants to provide their own TLS certificates.  This updates the
documentation to show how.

This also shows how to use a custom domain, provided the tenant
provides the certificate.

I tried as much as possible to show the details of exactly how to do
each step.  In particular, I wanted to show how to create the `Secret`
and to seal it, and I wanted to make it easy to do the right thing and
hard to accidentally commit an unsealed seacret.  Hence my slightly
funky bash pipeline to do it all in one line.

PR #599 is a separate approach which would allow tenants to use
cluster-provisioned certificates with custom domains.