### PR TITLE
fix cluster-autoscaler service monitor

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -68,6 +68,7 @@ cluster-autoscaler:
   priorityClassName: system-cluster-critical
   serviceMonitor:
     enabled: true
+    namespace: gsp-system
 
 kiam:
   nameOverride:


### PR DESCRIPTION
it needs to know the namespace that prometheus is running in for some
reason /shrug