### PR TITLE
disable system-cluster-critical on cluster-autoscaler for now

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -65,7 +65,8 @@ cluster-autoscaler:
     balance-similar-node-groups: true
   image:
     tag: v1.14.5 # upgrade this when upgrading kubernetes
-  priorityClassName: system-cluster-critical
+  # we can only set this if cluster-autoscaler is in the kube-system namespace D:
+  # priorityClassName: system-cluster-critical
   serviceMonitor:
     enabled: true
     namespace: gsp-system


### PR DESCRIPTION
You can't use `system-cluster-critical` on pods in namespaces other
than `kube-system` because of the priority admission controller:

https://github.com/kubernetes/kubernetes/blob/ded22e39755418ddeaafd2cac5fde8af6f4443ec/plugin/pkg/admission/priority/admission.go#L148

Disable this for now.  We want to re-enable it (probably by somehow
migrating the cluster autoscaler to kube-system) but for now, to get
it running at all, let's just comment it out.