### PR TITLE
Allow specifying workers to run on spot instances

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -2,17 +2,21 @@ module "k8s-cluster" {
   source = "../k8s-cluster"
   vpc_id = var.vpc_id
 
-  private_subnet_ids           = var.private_subnet_ids
-  public_subnet_ids            = var.public_subnet_ids
-  cluster_name                 = var.cluster_name
-  worker_instance_type         = var.worker_instance_type
-  minimum_workers_per_az_count = var.minimum_workers_per_az_count
-  desired_workers_per_az_map   = var.desired_workers_per_az_map
-  maximum_workers_per_az_count = var.maximum_workers_per_az_count
-  ci_worker_count              = var.ci_worker_count
-  ci_worker_instance_type      = var.ci_worker_instance_type
-  eks_version                  = var.eks_version
-  worker_eks_version           = var.worker_eks_version
+  private_subnet_ids = var.private_subnet_ids
+  public_subnet_ids  = var.public_subnet_ids
+  cluster_name       = var.cluster_name
+
+  worker_instance_type                   = var.worker_instance_type
+  minimum_workers_per_az_count           = var.minimum_workers_per_az_count
+  desired_workers_per_az_map             = var.desired_workers_per_az_map
+  maximum_workers_per_az_count           = var.maximum_workers_per_az_count
+  worker_on_demand_percentage_above_base = var.worker_on_demand_percentage_above_base
+
+  ci_worker_count         = var.ci_worker_count
+  ci_worker_instance_type = var.ci_worker_instance_type
+
+  eks_version        = var.eks_version
+  worker_eks_version = var.worker_eks_version
   apiserver_allowed_cidrs = concat(
     formatlist("%s/32", var.egress_ips),
     var.gds_external_cidrs,

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -56,6 +56,11 @@ variable "maximum_workers_per_az_count" {
   default = "5"
 }
 
+variable "worker_on_demand_percentage_above_base" {
+  type    = "string"
+  default = "100"
+}
+
 variable "ci_worker_count" {
   type    = string
   default = "2"
@@ -186,11 +191,11 @@ variable "availability_zones" {
 }
 
 variable "managed_namespaces_zones" {
-  default = []
+  default     = []
   description = "List of details of delegated zones for managed namespaces"
 }
 
 variable "cluster_zone_ids" {
-  default = []
+  default     = []
   description = "List of DNS zone IDs associated with the cluster"
 }

--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -95,6 +95,11 @@ Parameters:
     Type: Number
     Default: 1
 
+  NodeAutoScalingGroupOnDemandPercentageAboveBase:
+    Description: Percentage of nodes above the base capacity (minimum size) to launch as on-demand (rather than spot instances)
+    Type: Number
+    Default: 100
+
   NodeVolumeSize:
     Description: Node volume size
     Type: Number
@@ -153,6 +158,7 @@ Metadata:
           - NodeAutoScalingGroupMinSize
           - NodeAutoScalingGroupDesiredCapacity
           - NodeAutoScalingGroupMaxSize
+          - NodeAutoScalingGroupOnDemandPercentageAboveBase
           - NodeInstanceType
           - NodeInstanceProfile
           - NodeImageId
@@ -179,16 +185,23 @@ Resources:
       MaxSize: !Ref NodeAutoScalingGroupMaxSize
       VPCZoneIdentifier: !Ref Subnets
       TargetGroupARNs: !Ref NodeTargetGroups
-      # TODO: this is where we can in future provision spot instances
-      # MixedInstancesPolicy:
-      #   InstancesDistribution:
-      #     OnDemandBaseCapacity: !Ref NodeAutoScalingGroupMinSize
-      #   LaunchTemplate:
-      #     LaunchTemplateId: !Ref NodeLaunchTemplate
-      #     Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
-      #     Overrides:
-      #       - InstanceType: m5a.xlarge
-      #       - InstanceType: m5.xlarge
+      MixedInstancesPolicy:
+        InstancesDistribution:
+          OnDemandBaseCapacity: !Ref NodeAutoScalingGroupMinSize
+          OnDemandPercentageAboveBaseCapacity: !Ref NodeAutoScalingGroupOnDemandPercentageAboveBase
+        LaunchTemplate:
+          LaunchTemplateSpecification:
+            LaunchTemplateId: !Ref NodeLaunchTemplate
+            Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
+          Overrides:
+            - InstanceType: m5.xlarge
+            - InstanceType: m5d.xlarge
+            - InstanceType: m5a.xlarge
+            - InstanceType: m5ad.xlarge
+            - InstanceType: r5.xlarge
+            - InstanceType: r5d.xlarge
+            - InstanceType: r5a.xlarge
+            - InstanceType: r5ad.xlarge
       Tags:
         - Key: Name
           Value: !Sub ${ClusterName}-${NodeGroupName}

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -39,13 +39,13 @@ resource "aws_eks_cluster" "eks-cluster" {
 }
 
 resource "aws_iam_openid_connect_provider" "eks" {
-  client_id_list  = ["sts.amazonaws.com"]
+  client_id_list = ["sts.amazonaws.com"]
   # the thumbprint identifies the root CA for the OIDC provider. See
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
   # in this case, this thumbprint is the thumbprint of the root CA
   # presented by `oidc.eks.eu-west-2.amazonaws.com`; this isn't likely to change
   # I checked and the same thumbprint applies to eu-west-1
-  thumbprint_list = [ "9E99A48A9960B14926BB7F3B02E22DA2B0AB7280" ]
+  thumbprint_list = ["9E99A48A9960B14926BB7F3B02E22DA2B0AB7280"]
   url             = aws_eks_cluster.eks-cluster.identity[0].oidc[0].issuer
 }
 
@@ -128,14 +128,17 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
       var.maximum_workers_per_az_count - 1
     ))
     NodeAutoScalingGroupMaxSize = var.maximum_workers_per_az_count
-    NodeInstanceType            = var.worker_instance_type
-    NodeInstanceProfile         = aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceProfile"]
-    NodeVolumeSize              = "40"
-    BootstrapArguments          = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""
-    VpcId                       = var.vpc_id
-    Subnets                     = element(data.aws_subnet.private_subnets.*.id, count.index)
-    NodeSecurityGroups          = "${aws_security_group.node.id},${aws_security_group.worker.id}"
-    NodeTargetGroups            = "${aws_cloudformation_stack.worker-nodes.outputs["HTTPTargetGroup"]},${aws_cloudformation_stack.worker-nodes.outputs["TCPTargetGroup"]}"
+
+    NodeAutoScalingGroupOnDemandPercentageAboveBase = var.worker_on_demand_percentage_above_base
+
+    NodeInstanceType    = var.worker_instance_type
+    NodeInstanceProfile = aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceProfile"]
+    NodeVolumeSize      = "40"
+    BootstrapArguments  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""
+    VpcId               = var.vpc_id
+    Subnets             = element(data.aws_subnet.private_subnets.*.id, count.index)
+    NodeSecurityGroups  = "${aws_security_group.node.id},${aws_security_group.worker.id}"
+    NodeTargetGroups    = "${aws_cloudformation_stack.worker-nodes.outputs["HTTPTargetGroup"]},${aws_cloudformation_stack.worker-nodes.outputs["TCPTargetGroup"]}"
   }
 
   depends_on = [

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -46,6 +46,11 @@ variable "maximum_workers_per_az_count" {
   default = "5"
 }
 
+variable "worker_on_demand_percentage_above_base" {
+  type    = "string"
+  default = "100"
+}
+
 variable "ci_worker_instance_type" {
   type    = string
   default = "t3.medium"

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -26,6 +26,7 @@ config-approval-count: 2
 
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 5
+worker-on-demand-percentage-above-base: 100
 
 task-toolbox-image: govsvc/task-toolbox
 task-toolbox-tag: latest

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -66,6 +66,10 @@ variable "maximum_workers_per_az_count" {
   type = string
 }
 
+variable "worker_on_demand_percentage_above_base" {
+  type = "string"
+}
+
 variable "ci_worker_instance_type" {
   type    = string
   default = "m5.large"
@@ -161,8 +165,11 @@ module "gsp-cluster" {
   minimum_workers_per_az_count = var.minimum_workers_per_az_count
   desired_workers_per_az_map   = var.desired_workers_per_az_map
   maximum_workers_per_az_count = var.maximum_workers_per_az_count
-  ci_worker_instance_type      = var.ci_worker_instance_type
-  ci_worker_count              = var.ci_worker_count
+
+  worker_on_demand_percentage_above_base = var.worker_on_demand_percentage_above_base
+
+  ci_worker_instance_type = var.ci_worker_instance_type
+  ci_worker_count         = var.ci_worker_count
 
   vpc_id = module.gsp-network.vpc_id
 

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -594,6 +594,7 @@ resources:
       worker_instance_type: ((worker-instance-type))
       minimum_workers_per_az_count: ((minimum-workers-per-az-count))
       maximum_workers_per_az_count: ((maximum-workers-per-az-count))
+      worker_on_demand_percentage_above_base: ((worker-on-demand-percentage-above-base))
       enable_nlb: ((enable-nlb))
       ci_worker_instance_type: ((ci-worker-instance-type))
       ci_worker_count: ((ci-worker-count))


### PR DESCRIPTION
This introduces a new cluster variable,
`worker_on_demand_percentage_above_min`, which defines the percentage
of instances that should be on-demand instances.  It defaults to 100.
But you can set it to (for example) 50, which means that the first
`minimum_workers_per_az_count` instances in each AZ nodegroup will be
on-demand, then half the workers beyond that will be on-demand and
half will be spot.

As a result, I expect this change to do nothing on its own, but we
could experiment with setting `worker-on-demand-percentage-above-min`
to different values in tech-ops-cluster-config.

Spot instances require supplying a list of allowed instance types to
use.  I picked instances based on the regex `[mr]5a?d?.xlarge`.  My
criteria were:

 - we don't need instance storage, but it won't hurt if we get some
 - we want instances to be at least `xlarge` so that we get 60 IPs per
   instance
 - we want the memory profile of at least `m5`, so the `c5` instances
   are ruled out
 - we want guaranteed compute capacity, so `t3` are ruled out
 - we don't care if we run Intel or AMD (I think?)

Much of the above is arguable - these aren't hard decisions but rather
just a way of picking something.

I think any of these instance types fit those criteria.  In terms of
on-demand pricing, `m5a` is cheapest and `r5d` is most expensive,
reflecting the fact that a) AMD is cheaper than Intel, and b) `m5` has
less memory than `r5`, and c) instance storage carries a premium.
