### PR TITLE
Cluster autoscaler: Allow describing launch template versions

### DIFF
--- a/modules/gsp-cluster/cluster-autoscaler.tf
+++ b/modules/gsp-cluster/cluster-autoscaler.tf
@@ -13,6 +13,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_policy" {
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Apparently the cluster autoscaler requires this to be able to scale up node
groups from 0.
https://github.com/kubernetes/autoscaler/issues/1943#issuecomment-487455456