### PR TITLE
scale up istio components to min x2 instances

### DIFF
--- a/charts/gsp-istio/values.yaml
+++ b/charts/gsp-istio/values.yaml
@@ -58,23 +58,39 @@ certmanager:
 istio:
   ingress:
     enable: false
+  galley:
+    replicaCount: 2
   certmanager:
     enabled: true
+    replicaCount: 2
   istio_cni:
     enabled: true
   tracing:
     enabled: true
+  mixer:
+    policy:
+      replicaCount: 2
+      autoscaleMin: 2
+    telemetry:
+      replicaCount: 2
+      autoscaleMin: 2
   pilot:
     traceSampling: "100.0"
+    replicaCount: 2
+    autoscaleMin: 2
   prometheus:
     enabled: false
   gateways:
     istio-ingressgateway:
+      replicaCount: 2
+      autoscaleMin: 2
       type: NodePort
       sds:
         enabled: true
     istio-egressgateway:
       enabled: true
+      replicaCount: 2
+      autoscaleMin: 2
       ports:
       - port: 80
         name: http2


### PR DESCRIPTION
poddisruption budgets on istio components only running as single
instances is preventing node draining completing successfully and
preventing a clean rollout of new nodes.

we should run at least two instances of control planes components to
allow deployments/node rollouts that satisfy the disruption budgets set.

(an alternative to this could have been disableing the disruption
budgets for istio components, but we decided that scaling up would be
easier to reason about)