### PR TITLE
Deploy canary more frequently

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -46,7 +46,7 @@ spec:
       type: time
       icon: update
       source:
-        interval: 15m
+        interval: 2m
 
     - name: src
       type: git


### PR DESCRIPTION
This updates our smoke tests to run more frequently.  There is no
science behind my choice of 2 minutes other than "it's more frequently
than 15 minutes".