### PR TITLE
increase number of concourse-web replicas to 2

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -139,6 +139,7 @@ fluentd-cloudwatch:
 concourse:
   web:
     nameOverride: concourse-web
+    replicas: 2
     additionalVolumes:
     - name: ci-web-configuration
       configMap:


### PR DESCRIPTION
we are aiming for high(er) availability of the developement tooling, we
should have two instances of concourse web to reduce the liklihood of
interuption to concourse during rolling of nodes/upgrades/retirement
etc.