### PR TITLE
Add prometheus recording rules for default SLIs

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-slis.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-slis.yaml
@@ -1,0 +1,72 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Release.Name }}-sli-rules
+spec:
+  groups:
+  - name: sli.rules
+    rules:
+    - record: "ingressgateway_destination_response_code:requests:rate5m"
+      expr: |
+        sum by(source_workload,source_workload_namespace,
+               destination_workload,destination_workload_namespace,
+               response_code)
+          (rate(istio_requests_total{
+                  request_protocol="http",
+                  source_workload=~".*-ingressgateway"
+                }[5m]))
+    - record: "ingressgateway_destination:successes_per_response:ratio_rate5m"
+      expr: |
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate5m{response_code!~"5.."})
+        /
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate5m)
+    - record: "ingressgateway_destination_response_code:requests:rate30m"
+      expr: |
+        sum by(source_workload,source_workload_namespace,
+               destination_workload,destination_workload_namespace,
+               response_code)
+          (rate(istio_requests_total{
+                  request_protocol="http",
+                  source_workload=~".*-ingressgateway"
+                }[30m]))
+    - record: "ingressgateway_destination:successes_per_response:ratio_rate30m"
+      expr: |
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate30m{response_code!~"5.."})
+        /
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate30m)
+    - record: "ingressgateway_destination_response_code:requests:rate1h"
+      expr: |
+        sum by(source_workload,source_workload_namespace,
+               destination_workload,destination_workload_namespace,
+               response_code)
+          (rate(istio_requests_total{
+                  request_protocol="http",
+                  source_workload=~".*-ingressgateway"
+                }[1h]))
+    - record: "ingressgateway_destination:successes_per_response:ratio_rate1h"
+      expr: |
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate1h{response_code!~"5.."})
+        /
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate1h)
+    - record: "ingressgateway_destination_response_code:requests:rate6h"
+      expr: |
+        sum by(source_workload,source_workload_namespace,
+               destination_workload,destination_workload_namespace,
+               response_code)
+          (rate(istio_requests_total{
+                  request_protocol="http",
+                  source_workload=~".*-ingressgateway"
+                }[6h]))
+    - record: "ingressgateway_destination:successes_per_response:ratio_rate6h"
+      expr: |
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate6h{response_code!~"5.."})
+        /
+        sum without(response_code)
+          (ingressgateway_destination_response_code:requests:rate6h)


### PR DESCRIPTION
We have a standard route into each namespace via an
istio-ingressgateway.  This provides a good place to gather metrics
for each tenant service.

This adds a PrometheusRule that sets up some useful recording rules
for SLI-type metrics.  This takes the existing-but-unwieldy metric
`istio_requests_total` and rolls it up recorded metrics that are
easier to deal with.  There are two sets:

 - `ingressgateway_destination_response_code:requests:rate<period>`
 - `ingressgateway_destination:successes_per_response:ratio_rate<period>`

The first is an absolute rate-per-second, by ingressgateway,
destination (ie app) and response code.

The second is a measure of successes (ie non-5xx responses) per
response.

I have created rules to measure these over four different time
windows: 5m, 30m, 1h, and 6h.

----

The philosophical thinking here is that we should standardise on how
we measure SLIs.  Different services don't really have different needs
on how to measure SLIs, provided they do the right things in terms of
returing 5xx response codes for actual reliability problems and
non-5xx for service working as expected.

I picked the time windows based on the first two alerts in this
soundcloud blog post:
https://developers.soundcloud.com/blog/alerting-on-slos
(see the section "Multiwindow, Multi-Burn-Rate Alerts").  The blog
post also gives a sense of where this could go in future: towards a
standard set of alerts based on SLOs, where only the SLO itself can be
customized by namespace.

(Note: I'm aware that the proxy node *already* has customized this
stuff because they want to distinguish traffic fetching metadata from
traffic from real users... nevertheless I think this is still an
interesting and worthwhile experiment)