### PR TITLE
Move cluster-autoscaler and gatekeeper to cluster-management nodes

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/gatekeeper.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/gatekeeper.yaml
@@ -348,6 +348,11 @@ spec:
         secret:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-secret
+      nodeSelector:
+        node-role.kubernetes.io/cluster-management: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/cluster-management
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -72,6 +72,11 @@ cluster-autoscaler:
   serviceMonitor:
     enabled: true
     namespace: gsp-system
+  nodeSelector:
+    node-role.kubernetes.io/cluster-management: ""
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/cluster-management
 
 kiam:
   nameOverride:


### PR DESCRIPTION
Target them with a nodeSelector and tolerate their taint, like how
kiam-server's DaemonSet works.