### PR TITLE
Change the volume binding mode of the default storage class.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
@@ -10,6 +10,6 @@ parameters:
   type: gp2
 provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: Delete
-volumeBindingMode: Immediate
+volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 {{ end }}


### PR DESCRIPTION
Now that we're doing more with dynamic scaling across multiple failure
zones it might be a good idea to let the control plane pick the most
appropriate zone for a given volume based on its internal scheduling
rules for pods.

See: https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode
