### PR TITLE
Cluster autoscaler: Fix IAM setup to work on cluster management nodes

### DIFF
--- a/modules/gsp-cluster/cluster-autoscaler.tf
+++ b/modules/gsp-cluster/cluster-autoscaler.tf
@@ -49,8 +49,8 @@ resource "aws_iam_policy_attachment" "cluster-autoscaler" {
   policy_arn = "${aws_iam_policy.cluster-autoscaler.arn}"
 }
 
-resource "aws_iam_policy_attachment" "cluster-autoscaler-new" {
-  name       = "${var.cluster_name}-cluster-autoscaler-new"
-  roles      = ["${aws_cloudformation_stack.kiam-server-nodes.outputs["NodeInstanceRoleName"]}"]
+resource "aws_iam_policy_attachment" "cluster-autoscaler-mgmt" {
+  name       = "${var.cluster_name}-cluster-autoscaler-mgmt"
+  roles      = ["${module.k8s-cluster.kiam-server-node-instance-role-name}"]
   policy_arn = "${aws_iam_policy.cluster-autoscaler.arn}"
 }

--- a/modules/gsp-cluster/cluster-autoscaler.tf
+++ b/modules/gsp-cluster/cluster-autoscaler.tf
@@ -48,3 +48,9 @@ resource "aws_iam_policy_attachment" "cluster-autoscaler" {
   roles      = ["${aws_iam_role.cluster_autoscaler.name}"]
   policy_arn = "${aws_iam_policy.cluster-autoscaler.arn}"
 }
+
+resource "aws_iam_policy_attachment" "cluster-autoscaler-new" {
+  name       = "${var.cluster_name}-cluster-autoscaler-new"
+  roles      = ["${aws_cloudformation_stack.kiam-server-nodes.outputs["NodeInstanceRoleName"]}"]
+  policy_arn = "${aws_iam_policy.cluster-autoscaler.arn}"
+}

--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -348,6 +348,10 @@ Outputs:
     Description: The node instance role ARN
     Value: !GetAtt NodeInstanceRole.Arn
 
+  NodeInstanceRoleName:
+    Description: The node instance role name
+    Value: !Ref NodeInstanceRole
+
   NodeSecurityGroup:
     Description: The security group for the node group
     Value: !Ref NodeSecurityGroup

--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -348,10 +348,6 @@ Outputs:
     Description: The node instance role ARN
     Value: !GetAtt NodeInstanceRole.Arn
 
-  NodeInstanceRoleName:
-    Description: The node instance role name
-    Value: !Ref NodeInstanceRole
-
   NodeSecurityGroup:
     Description: The security group for the node group
     Value: !Ref NodeSecurityGroup


### PR DESCRIPTION
IAM stuff works differently on these nodes - they can't intercept metadata
things and route through KIAM due to hosting the KIAM servers. So there's no
assume role going on here, the cluster-autoscaler has direct access to the
permissions granted to these nodes themselves.

Leaving the old role and attachment in place for the time being.