### PR TITLE
Remove unused cluster autoscaler role

### DIFF
--- a/modules/gsp-cluster/cluster-autoscaler.tf
+++ b/modules/gsp-cluster/cluster-autoscaler.tf
@@ -1,9 +1,3 @@
-resource "aws_iam_role" "cluster_autoscaler" {
-  name = "cluster-autoscaler"
-
-  assume_role_policy = "${data.aws_iam_policy_document.trust_kiam_server.json}"
-}
-
 data "aws_iam_policy_document" "cluster_autoscaler_policy" {
   statement {
     effect = "Allow"
@@ -41,12 +35,6 @@ resource "aws_iam_policy" "cluster-autoscaler" {
   name        = "${var.cluster_name}-cluster-autoscaler"
   description = "Policy for the cluster autoscaler"
   policy      = "${data.aws_iam_policy_document.cluster_autoscaler_policy.json}"
-}
-
-resource "aws_iam_policy_attachment" "cluster-autoscaler" {
-  name       = "${var.cluster_name}-cluster-autoscaler"
-  roles      = ["${aws_iam_role.cluster_autoscaler.name}"]
-  policy_arn = "${aws_iam_policy.cluster-autoscaler.arn}"
 }
 
 resource "aws_iam_policy_attachment" "cluster-autoscaler-mgmt" {

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -45,8 +45,6 @@ cluster-autoscaler:
   awsRegion: eu-west-2
   autoDiscovery:
     clusterName: ${cluster_name}
-  podAnnotations:
-    iam.amazonaws.com/role: ${cluster_autoscaler_role_name}
 
 concourseMainTeamGithubTeams: ${concourse_main_team_github_teams}
 concourse:

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -17,7 +17,6 @@ data "template_file" "values" {
     sre_role_arns                    = "${jsonencode(var.sre_role_arns)}"
     sre_user_arns                    = "${jsonencode(var.sre_user_arns)}"
     bootstrap_role_arns              = "${jsonencode(module.k8s-cluster.bootstrap_role_arns)}"
-    cluster_autoscaler_role_name     = "${aws_iam_role.cluster_autoscaler.name}"
     concourse_admin_password         = "${random_string.concourse_password.result}"
     concourse_teams                  = "${jsonencode(concat(list("main"), var.concourse_teams))}"
     concourse_main_team_github_teams = "${jsonencode(var.concourse_main_team_github_teams)}"
@@ -58,7 +57,6 @@ data "template_file" "values" {
 
     permitted_roles_regex = "^(${join("|", list(
       aws_iam_role.cloudwatch_log_shipping_role.name,
-      aws_iam_role.cluster_autoscaler.name,
       aws_iam_role.concourse.name,
       aws_iam_role.grafana.name,
       aws_iam_role.gsp-service-operator.name,


### PR DESCRIPTION
We moved to the cluster management nodes where this is unused.