### PR TITLE
add "control-plane" label to gsp-system ns

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/gsp-system-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/gsp-system-namespace.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     namespace: gsp-system
     istio-injection: disabled
+    control-plane: "true"
   annotations:
     iam.amazonaws.com/permitted: {{ .Values.permittedRolesRegex | quote }}


### PR DESCRIPTION
the validating webhook created by gatekeeper attempts to exclude
resources within namespaces with a "control-plane" label present from
being validated. The "control-plane" label is not configurable it is
just hard-coded at this time.

To ensure that the gatekeep manager does not prevent itself (or any
other control-plane/gsp-system components) from running and causing
cluster wide issues we add the "control-plane" label to the gsp-system
namespace.