### PR TITLE
Revert "Change the volume binding mode of the default storage class."

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/default-storage-class.yaml
@@ -10,6 +10,6 @@ parameters:
   type: gp2
 provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: Immediate
 allowVolumeExpansion: true
 {{ end }}


### PR DESCRIPTION
Reverts alphagov/gsp#624

`The StorageClass "gp2" is invalid: volumeBindingMode: Invalid value: "WaitForFirstConsumer": field is immutable`
