### PR TITLE
fix concourse dashboard to match new recording rules

### DIFF
--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -390,10 +390,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{pod_name=~\"gsp-concourse-web.*\"}) without (container_name)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"gsp-concourse-web.*"}) without (container)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "CPU usage - {{pod}}",
           "refId": "A"
         }
       ],
@@ -476,10 +476,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{pod_name=~\"gsp-concourse-worker.*\"}) without (container_name)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"gsp-concourse-worker.*"}) without (container)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "CPU usage - {{pod_name}}",
+          "legendFormat": "CPU usage - {{pod}}",
           "refId": "A"
         }
       ],

--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -390,7 +390,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"gsp-concourse-web.*"}) without (container)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"gsp-concourse-web.*\"}) without (container)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "CPU usage - {{pod}}",
@@ -476,7 +476,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~"gsp-concourse-worker.*"}) without (container)",
+          "expr": "sum(namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{pod=~\"gsp-concourse-worker.*\"}) without (container)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "CPU usage - {{pod}}",


### PR DESCRIPTION
Some of the recording rules got renamed in the recent
prometheus-operator upgrade