### PR TITLE
Create gsp-critical PriorityClass

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/gsp-priorityclass.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gsp-priorityclass.yaml
@@ -1,0 +1,15 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gsp-critical
+# This PriorityClass exists because the admission controller won't let
+# you use `system-cluster-critical` in non-`kube-system` namespaces,
+# but we still have pods we want to run in gsp-system at high priority
+# level.  We create a priority class with the highest-allowed
+# userspace priority value (which is still lower than
+# system-cluster-critical) as a workaround.
+# See also https://github.com/kubernetes/kubernetes/issues/60596
+description: |
+  Used for GSP critical pods that must run in the cluster.
+value: 1000000000
+

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -67,8 +67,7 @@ cluster-autoscaler:
     tag: v1.14.5 # upgrade this when upgrading kubernetes
   rbac:
     create: true
-  # we can only set this if cluster-autoscaler is in the kube-system namespace D:
-  # priorityClassName: system-cluster-critical
+  priorityClassName: gsp-critical
   serviceMonitor:
     enabled: true
     namespace: gsp-system


### PR DESCRIPTION
And get cluster-autoscaler to use it.

I've tested this by snowflaking in sandbox.

I think there may be a race condition here when spinning up a new
cluster: I don't know how to ensure the PriorityClass gets created
before the things that use it.

This is a proof of concept; we should have a conversation about which
things should run with this priority class (gatekeeper, the istio
sidecar injector, ...?).