### PR TITLE
Remove the old static worker node group

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -4,7 +4,6 @@ module "k8s-cluster" {
   private_subnet_ids           = ["${var.private_subnet_ids}"]
   public_subnet_ids            = ["${var.public_subnet_ids}"]
   cluster_name                 = "${var.cluster_name}"
-  worker_count                 = "${var.worker_count}"
   worker_instance_type         = "${var.worker_instance_type}"
   minimum_workers_per_az_count = "${var.minimum_workers_per_az_count}"
   maximum_workers_per_az_count = "${var.maximum_workers_per_az_count}"

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -50,11 +50,6 @@ variable "sre_user_arns" {
   default     = []
 }
 
-variable "worker_count" {
-  type    = "string"
-  default = "2"
-}
-
 variable "worker_instance_type" {
   type    = "string"
   default = "t3.medium"

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -52,7 +52,35 @@ resource "aws_cloudwatch_log_group" "eks" {
 }
 
 # As per https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
+resource "aws_cloudformation_stack" "worker-nodes" {
+  name          = "${var.cluster_name}-worker-nodes"
+  template_body = "${file("${path.module}/data/nodegroup.yaml")}"
+  capabilities  = ["CAPABILITY_IAM"]
 
+  parameters = {
+    ClusterName                         = "${var.cluster_name}"
+    ClusterControlPlaneSecurityGroup    = "${aws_security_group.controller.id}"
+    NodeGroupName                       = "worker"
+    NodeAutoScalingGroupMinSize         = "0"
+    NodeAutoScalingGroupDesiredCapacity = "0"
+    NodeAutoScalingGroupMaxSize         = "0"
+    NodeInstanceType                    = "${var.worker_instance_type}"
+    NodeVolumeSize                      = "40"
+    BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""
+    VpcId                               = "${var.vpc_id}"
+    Subnets                             = "${join(",", var.private_subnet_ids)}"
+  }
+
+  timeouts {
+    create = "30m"
+
+    # rolling worker nodes 1 at a time could be time consuming. Stop concourse going red
+    update = "90m"
+    delete = "30m"
+  }
+
+  depends_on = ["aws_eks_cluster.eks-cluster"]
+}
 resource "aws_cloudformation_stack" "worker-nodes-per-az" {
   count         = "${length(var.private_subnet_ids)}"
   name          = "${var.cluster_name}-worker-nodes-${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -27,11 +27,6 @@ variable "worker_instance_type" {
   default = "t3.medium"
 }
 
-variable "worker_count" {
-  type    = "string"
-  default = "3"
-}
-
 variable "minimum_workers_per_az_count" {
   type    = "string"
   default = "1"

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -53,11 +53,6 @@ variable "worker_instance_type" {
   default = "m5d.large"
 }
 
-variable "worker_count" {
-  type    = "string"
-  default = "3"
-}
-
 variable "minimum_workers_per_az_count" {
   type = "string"
 }
@@ -140,7 +135,6 @@ module "gsp-cluster" {
 
   eks_version                  = "${var.eks_version}"
   worker_instance_type         = "${var.worker_instance_type}"
-  worker_count                 = "${var.worker_count}"
   minimum_workers_per_az_count = "${var.minimum_workers_per_az_count}"
   maximum_workers_per_az_count = "${var.maximum_workers_per_az_count}"
   ci_worker_instance_type      = "${var.ci_worker_instance_type}"

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -537,7 +537,6 @@ resources:
       hsm_splunk_index: ((hsm-splunk-index))
       eks_version: ((eks-version))
       worker_instance_type: ((worker-instance-type))
-      worker_count: ((worker-count))
       minimum_workers_per_az_count: ((minimum-workers-per-az-count))
       maximum_workers_per_az_count: ((maximum-workers-per-az-count))
       enable_nlb: ((enable-nlb))

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -24,7 +24,7 @@ config-approval-count: 0
 config-approvers: ["chrisfarms"]
 disable-destroy: false
 worker-instance-type: t3.medium
-worker-count: 3
+minimum-workers-per-az-count: 1
 ci-worker-instance-type: t3.medium
 ci-worker-count: 3
 config-uri: "https://github.com/alphagov/gsp.git"


### PR DESCRIPTION
It's not scaled by the autoscaler and is now dangerous as it won't have access
to CloudHSM, RDS, the PSN, etc. etc.