### PR TITLE
give SLIs dashboard a unique uid

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/dashboards/sli.json
+++ b/charts/gsp-cluster/charts/gsp-monitoring/dashboards/sli.json
@@ -295,6 +295,6 @@
   },
   "timezone": "browser",
   "title": "SLIs",
-  "uid": "UnE9X_2Wz",
+  "uid": "gsp_slis",
   "version": 1
 }


### PR DESCRIPTION
I created this dashboard by editing the `etcd` dashboard in place but
I didn't change the uid.  I think this has confused grafana a bit.

I have decided to give it a vanity uid since I can.