### PR TITLE
Separate worker version from control-plane version.

### DIFF
--- a/hack/lint-terraform-values-output.sh
+++ b/hack/lint-terraform-values-output.sh
@@ -19,6 +19,7 @@ set -eu
 		--var cluster_domain=x \
 		--var aws_account_role_arn=x \
 		--var eks_version=x \
+		--var worker_eks_version=x \
 		--var minimum_workers_per_az_count=1 \
 		--var maximum_workers_per_az_count=3 \
 )

--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -11,6 +11,7 @@ module "k8s-cluster" {
   ci_worker_count              = "${var.ci_worker_count}"
   ci_worker_instance_type      = "${var.ci_worker_instance_type}"
   eks_version                  = "${var.eks_version}"
+  worker_eks_version           = "${var.worker_eks_version}"
 
   apiserver_allowed_cidrs = ["${concat(
       formatlist("%s/32", var.egress_ips),

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -26,6 +26,10 @@ variable "eks_version" {
   type = "string"
 }
 
+variable "worker_eks_version" {
+  type = "string"
+}
+
 variable "dev_user_arns" {
   description = "A list of user ARNs that will be mapped to the cluster dev role"
   type        = "list"

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -58,7 +58,7 @@ resource "aws_cloudformation_stack" "worker-nodes" {
   capabilities  = ["CAPABILITY_IAM"]
 
   parameters = {
-    NodeImageId                         = "/aws/service/eks/optimized-ami/${var.eks_version}/amazon-linux-2/recommended/image_id"
+    NodeImageId                         = "/aws/service/eks/optimized-ami/${var.worker_eks_version}/amazon-linux-2/recommended/image_id"
     ClusterName                         = "${var.cluster_name}"
     ClusterControlPlaneSecurityGroup    = "${aws_security_group.controller.id}"
     NodeGroupName                       = "worker"
@@ -90,7 +90,7 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
   capabilities  = ["CAPABILITY_IAM"]
 
   parameters = {
-    NodeImageId                      = "/aws/service/eks/optimized-ami/${var.eks_version}/amazon-linux-2/recommended/image_id"
+    NodeImageId                      = "/aws/service/eks/optimized-ami/${var.worker_eks_version}/amazon-linux-2/recommended/image_id"
     ClusterName                      = "${var.cluster_name}"
     ClusterControlPlaneSecurityGroup = "${aws_security_group.controller.id}"
     NodeGroupName                    = "worker-${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"
@@ -118,7 +118,7 @@ resource "aws_cloudformation_stack" "kiam-server-nodes" {
   capabilities  = ["CAPABILITY_IAM"]
 
   parameters = {
-    NodeImageId                         = "/aws/service/eks/optimized-ami/${var.eks_version}/amazon-linux-2/recommended/image_id"
+    NodeImageId                         = "/aws/service/eks/optimized-ami/${var.worker_eks_version}/amazon-linux-2/recommended/image_id"
     ClusterName                         = "${var.cluster_name}"
     ClusterControlPlaneSecurityGroup    = "${aws_security_group.controller.id}"
     NodeGroupName                       = "kiam"
@@ -141,7 +141,7 @@ resource "aws_cloudformation_stack" "ci-nodes" {
   capabilities  = ["CAPABILITY_IAM"]
 
   parameters = {
-    NodeImageId                         = "/aws/service/eks/optimized-ami/${var.eks_version}/amazon-linux-2/recommended/image_id"
+    NodeImageId                         = "/aws/service/eks/optimized-ami/${var.worker_eks_version}/amazon-linux-2/recommended/image_id"
     ClusterName                         = "${var.cluster_name}"
     ClusterControlPlaneSecurityGroup    = "${aws_security_group.controller.id}"
     NodeGroupName                       = "ci"

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -22,6 +22,10 @@ variable "eks_version" {
   type = "string"
 }
 
+variable "worker_eks_version" {
+  type = "string"
+}
+
 variable "worker_instance_type" {
   type    = "string"
   default = "t3.medium"

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -1,4 +1,5 @@
 eks-version: "1.14"
+worker-eks-version: "1.14"
 
 config-trigger: true
 config-version: "master"

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -81,6 +81,10 @@ variable "eks_version" {
   type        = "string"
 }
 
+variable "worker_eks_version" {
+  type = "string"
+}
+
 variable "enable_nlb" {
   type    = "string"
   default = "0"
@@ -139,6 +143,7 @@ module "gsp-cluster" {
   ]
 
   eks_version                  = "${var.eks_version}"
+  worker_eks_version           = "${var.worker_eks_version}"
   worker_instance_type         = "${var.worker_instance_type}"
   worker_count                 = "${var.worker_count}"
   minimum_workers_per_az_count = "${var.minimum_workers_per_az_count}"

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -536,6 +536,7 @@ resources:
       hsm_splunk_hec_token: ((hsm-splunk-hec-token))
       hsm_splunk_index: ((hsm-splunk-index))
       eks_version: ((eks-version))
+      worker_eks_version: ((worker-eks-version))
       worker_instance_type: ((worker-instance-type))
       worker_count: ((worker-count))
       minimum_workers_per_az_count: ((minimum-workers-per-az-count))


### PR DESCRIPTION
We want to be able to upgrade the control-plane separately from the worker
nodes so the version needs to be specified separately. Using a variable to
control it feels better than hard-coding it in various places.

Related: https://github.com/alphagov/gsp/pull/633
