### PR TITLE
set priorityClassName for any pod which implements a webhook

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -293,6 +293,9 @@ prometheus-operator:
     kubeletService:
       enabled: false
     configReloaderCpu: 200m
+    # prometheus-operator runs a validating webhook for
+    # PrometheusRules; let's try to ensure that it runs all the time
+    priorityClassName: gsp-critical
   kubelet:
     enabled: false
   alertmanager:

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/gatekeeper.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/gatekeeper.yaml
@@ -342,6 +342,7 @@ spec:
         - mountPath: /certs
           name: cert
           readOnly: true
+      priorityClassName: gsp-critical
       terminationGracePeriodSeconds: 60
       volumes:
       - name: cert

--- a/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
@@ -66,6 +66,8 @@ spec:
         - mountPath: /tmp/cert
           name: cert
           readOnly: true
+      # concourse-webhook-service is a validatingwebhook so we don't want it to disapper
+      priorityClassName: gsp-critical
       serviceAccountName: {{ template "pipelineOperator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
       volumes:

--- a/charts/gsp-istio/values.yaml
+++ b/charts/gsp-istio/values.yaml
@@ -8,6 +8,11 @@ global:
   outboundTrafficPolicy:
     mode: REGISTRY_ONLY
   disablePolicyChecks: false
+  # istio-galley is a validatingwebhook and istio-sidecar-injector is
+  # a mutating webhook so we don't want them to
+  # disappear. unfortunately the istio helm chart only lets you set
+  # priorityClassName for all services at once
+  priorityClassName: gsp-critical
 
 istio-cni:
   tag: release-1.1-20190808-09-16
@@ -84,6 +89,7 @@ istio:
     istio-ingressgateway:
       enabled: false
   sidecarInjectorWebhook:
+    replicaCount: 2
     enableNamespacesByDefault: true
     rewriteAppHTTPProbe: true
   kiali:


### PR DESCRIPTION
This sets priorityClassName: gsp-critical for any pod which implements
some sort of webhook.  In particular:

 - istio-galley is a validating webhook
 - istio-sidecar-injector is a mutating webhook
 - prometheus-operator is a mutating webhook for PrometheusRules
 - pipeline-operator is a validating webhook for concourse things
 - gatekeeper is a validating webhook for the whole world.

This PR also bumps the istio-sidecar-injector replicas up to 2 (from
1).

I considered bumping some of the other replicas up but:

 - gatekeeper is a StatefulSet and I wasn't sure about the semantics
   of running multiple copies
 - pipeline-operator is also a StatefulSet, ditto
 - the prometheus-operator helm chart hardcodes `replicas: 1` for the
   prometheus operator itself