### PR TITLE
Give concourse grafana dashboard a unique mounted file name.

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/grafana-concourse-dashboard.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/grafana-concourse-dashboard.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     grafana_dashboard: "1"
 data:
-  config.json: |-
+  concourse.json: |-
 {{ .Files.Get "dashboards/concourse.json" | indent 4 }}


### PR DESCRIPTION
All the dashboard configs are mounted into the grafana pod in the same
directory, so if multiple dashboards share the same "key" they overwrite
each other, depending on which order grafana pulls the config maps out
of the k8s control plane.