### PR TITLE
Align the concourse grafana dashboard with the canary's rotate frequency

### DIFF
--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -956,7 +956,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(concourse_builds_finished{team=\"main\", pipeline=\"cd-smoke-test\", status=\"failed\"}[15m]))",
+          "expr": "sum(increase(concourse_builds_finished{team=\"main\", pipeline=\"cd-smoke-test\", status=\"failed\"}[2m]))",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
@adityapahuja tells me this should align with the rotation frequency of the canary, which was recently changed.