### PR TITLE
BAU: Update build errors panel to be more responsive

### DIFF
--- a/charts/gsp-cluster/dashboards/concourse.json
+++ b/charts/gsp-cluster/dashboards/concourse.json
@@ -835,7 +835,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(concourse_builds_errored_total[60m])",
+          "expr": "rate(concourse_builds_errored_total[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Build errors - {{pod}}",


### PR DESCRIPTION
This change shortens the range's time period from 60m to 1m to allow build errors to show when the number of build errors starts increasing and when it stops instead of showing the spike for a period of 60 minutes. For example,

Before change:
![BeforeChange](https://user-images.githubusercontent.com/19972046/66651052-0220db00-ec2a-11e9-8a7c-14bf95277ad1.png)

After change:
![AfterChange](https://user-images.githubusercontent.com/19972046/66651055-051bcb80-ec2a-11e9-931a-f34d31a36a74.png)


Author: @adityapahuja