### PR TITLE
Actually remove old worker group stack

### DIFF
--- a/modules/k8s-cluster/iam.tf
+++ b/modules/k8s-cluster/iam.tf
@@ -46,8 +46,41 @@ resource "aws_iam_role_policy_attachment" "eks-service-policy" {
   role       = "${aws_iam_role.eks-cluster.name}"
 }
 
-data "aws_arn" "worker-nodes-role" {
-  arn = "${aws_iam_role.worker-nodes-role.arn}"
+data "aws_iam_policy_document" "worker-nodes-assume-role-policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals = {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "worker-nodes-role" {
+  name               = "${var.cluster_name}-worker-nodes-role"
+  assume_role_policy = "${data.aws_iam_policy_document.worker-nodes-assume-role-policy.json}"
+}
+
+resource "aws_iam_instance_profile" "worker-nodes-profile" {
+  name = "${var.cluster_name}-worker-nodes-profile"
+  role = "${aws_iam_role.worker-nodes-role.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "worker-nodes-eks-worker-policy-attachment" {
+  role       = "${aws_iam_role.worker-nodes-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "worker-nodes-eks-cni-policy-attachment" {
+  role       = "${aws_iam_role.worker-nodes-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "worker-nodes-ecr-ro-policy-attachment" {
+  role       = "${aws_iam_role.worker-nodes-role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
 data "aws_arn" "kiam-server-nodes-role" {
@@ -65,7 +98,7 @@ resource "aws_iam_policy" "ssm-minimal" {
 
 resource "aws_iam_role_policy_attachment" "worker-nodes-ssm" {
   policy_arn = "${aws_iam_policy.ssm-minimal.arn}"
-  role = "${replace(data.aws_arn.worker-nodes-role.resource, "role/", "")}"
+  role = "${replace(aws_iam_role.worker-nodes-role.arn, "role/", "")}"
 }
 
 resource "aws_iam_role_policy_attachment" "kiam-nodes-ssm" {

--- a/modules/k8s-cluster/iam.tf
+++ b/modules/k8s-cluster/iam.tf
@@ -98,7 +98,7 @@ resource "aws_iam_policy" "ssm-minimal" {
 
 resource "aws_iam_role_policy_attachment" "worker-nodes-ssm" {
   policy_arn = "${aws_iam_policy.ssm-minimal.arn}"
-  role = "${replace(aws_iam_role.worker-nodes-role.arn, "role/", "")}"
+  role = "${aws_iam_role.worker-nodes-role.name}"
 }
 
 resource "aws_iam_role_policy_attachment" "kiam-nodes-ssm" {

--- a/modules/k8s-cluster/iam.tf
+++ b/modules/k8s-cluster/iam.tf
@@ -47,7 +47,7 @@ resource "aws_iam_role_policy_attachment" "eks-service-policy" {
 }
 
 data "aws_arn" "worker-nodes-role" {
-  arn = "${aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceRole"]}"
+  arn = "${aws_iam_role.worker-nodes-role.arn}"
 }
 
 data "aws_arn" "kiam-server-nodes-role" {

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -11,11 +11,11 @@ output "kiam-server-node-instance-role-name" {
 }
 
 output "bootstrap_role_arns" {
-  value = "${list(aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceRole"], aws_cloudformation_stack.kiam-server-nodes.outputs["NodeInstanceRole"], aws_cloudformation_stack.ci-nodes.outputs["NodeInstanceRole"])}"
+  value = "${list(aws_iam_role.worker-nodes-role.arn, aws_cloudformation_stack.kiam-server-nodes.outputs["NodeInstanceRole"], aws_cloudformation_stack.ci-nodes.outputs["NodeInstanceRole"])}"
 }
 
 output "worker_tcp_target_group_arn" {
-  value = "${aws_cloudformation_stack.worker-nodes.outputs["TCPTargetGroup"]}"
+  value = "${aws_lb_target_group.worker-nodes-tcp-target-group.arn}"
 }
 
 output "eks-log-group-arn" {

--- a/modules/k8s-cluster/security.tf
+++ b/modules/k8s-cluster/security.tf
@@ -34,28 +34,6 @@ resource "aws_security_group_rule" "controller-egress" {
   cidr_blocks = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "worker-nodes-from-vpc" {
-  security_group_id = "${aws_cloudformation_stack.worker-nodes.outputs["NodeSecurityGroup"]}"
-
-  type      = "ingress"
-  protocol  = "-1"
-  from_port = 0
-  to_port   = 0
-
-  cidr_blocks = ["${data.aws_vpc.private.cidr_block}"]
-}
-
-resource "aws_security_group_rule" "worker-nodes-from-public" {
-  security_group_id = "${aws_cloudformation_stack.worker-nodes.outputs["NodeSecurityGroup"]}"
-
-  type      = "ingress"
-  protocol  = "tcp"
-  from_port = 31390
-  to_port   = 31390
-
-  cidr_blocks = ["0.0.0.0/0"]
-}
-
 resource "aws_security_group_rule" "kiam-server-from-vpc" {
   security_group_id = "${aws_cloudformation_stack.kiam-server-nodes.outputs["NodeSecurityGroup"]}"
 


### PR DESCRIPTION
Various per-AZ things still relied on things generated in the old worker node
stack. Move those resources out to Terraform and reference that instead.