### PR TITLE
refactor(svc-op): Only spin up k8s control plane once

### DIFF
--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -14,23 +14,12 @@ import (
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("PostgresCloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 30
-	var client client.Client
 	var ctx context.Context = context.Background()
-	var teardown func()
-
-	BeforeEach(func() {
-		client, teardown = SetupControllerEnv()
-	})
-
-	AfterEach(func() {
-		teardown()
-	})
 
 	It("Should create and destroy an Postgres database", func() {
 

--- a/components/service-operator/controllers/principal_cloudformation_test.go
+++ b/components/service-operator/controllers/principal_cloudformation_test.go
@@ -12,23 +12,12 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("PrincipalCloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 15
-	var client client.Client
 	var ctx context.Context = context.Background()
-	var teardown func()
-
-	BeforeEach(func() {
-		client, teardown = SetupControllerEnv()
-	})
-
-	AfterEach(func() {
-		teardown()
-	})
 
 	It("Should create and destroy an IAM role", func() {
 

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -15,23 +15,12 @@ import (
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("S3CloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 15
-	var client client.Client
 	var ctx context.Context = context.Background()
-	var teardown func()
-
-	BeforeEach(func() {
-		client, teardown = SetupControllerEnv()
-	})
-
-	AfterEach(func() {
-		teardown()
-	})
 
 	It("Should create and destroy an S3Bucket bucket", func() {
 

--- a/components/service-operator/controllers/sqs_cloudformation_test.go
+++ b/components/service-operator/controllers/sqs_cloudformation_test.go
@@ -14,23 +14,12 @@ import (
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("SQSCloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 15
-	var client client.Client
 	var ctx context.Context = context.Background()
-	var teardown func()
-
-	BeforeEach(func() {
-		client, teardown = SetupControllerEnv()
-	})
-
-	AfterEach(func() {
-		teardown()
-	})
 
 	It("Should create and destroy an SQS queue", func() {
 

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -37,12 +37,23 @@ import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	cln "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 )
+
+var client cln.Client
+var teardown func()
+
+var _ = BeforeSuite(func() {
+	client, teardown = SetupControllerEnv()
+})
+
+var _ = AfterSuite(func() {
+	teardown()
+})
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.


### PR DESCRIPTION
This spins up the testing control plane once (in a BeforeSuite())
rather than once per test (in a BeforeEach()).  This should reduce
testing times somewhat.

Would appreciate a review from someone who can say if there's a
semantic reason we need a fresh control plane for each test.