### PR TITLE
fix(service-operator): set ownerReferences correctly so GC works

### DIFF
--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -62,7 +62,7 @@ var _ = Describe("PostgresCloudFormationController", func() {
 				Spec: database.PostgresSpec{
 					Secret:       secretName,
 					ServiceEntry: serviceEntryName,
-					AWS:          database.PostgresAWSSpec{
+					AWS: database.PostgresAWSSpec{
 						InstanceCount: 1,
 						InstanceType:  "db.t3.medium",
 					},
@@ -141,6 +141,13 @@ var _ = Describe("PostgresCloudFormationController", func() {
 				HaveKey("location"),
 				HaveKey("resolution"),
 			))
+		})
+
+		By("creating a service entry with an owner reference", func() {
+			Eventually(func() []metav1.OwnerReference {
+				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
+				return serviceEntry.ObjectMeta.OwnerReferences
+			}).Should(HaveLen(1))
 		})
 
 		By("connecting to resource", func() {

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -163,6 +163,13 @@ var _ = Describe("S3CloudFormationController", func() {
 			))
 		})
 
+		By("creating a service entry with an owner reference", func() {
+			Eventually(func() []metav1.OwnerReference {
+				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
+				return serviceEntry.ObjectMeta.OwnerReferences
+			}).Should(HaveLen(1))
+		})
+
 		By("deleting S3Bucket resource with Kubernetes api", func() {
 			err := client.Get(ctx, resourceNamespacedName, &bucket)
 			Expect(err).ToNot(HaveOccurred())

--- a/components/service-operator/internal/aws/cloudformation/controller.go
+++ b/components/service-operator/internal/aws/cloudformation/controller.go
@@ -263,6 +263,10 @@ func (r *Controller) updateServiceEntry(ctx context.Context, o ServiceEntryCreat
 			return err
 		}
 		serviceEntry.Spec = serviceEntrySpec
+		// mark the serviceEntry as owned by the o resource so it gets gc'd
+		if err := controllerutil.SetControllerReference(o, serviceEntry, r.Scheme); err != nil {
+			return err
+		}
 		return nil
 	})
 	r.Log.Info("update-service-entry",
@@ -271,10 +275,6 @@ func (r *Controller) updateServiceEntry(ctx context.Context, o ServiceEntryCreat
 		"err", err,
 	)
 	if err != nil {
-		return err
-	}
-	// mark the serviceEntry as owned by the o resource so it gets gc'd
-	if err := controllerutil.SetControllerReference(o, serviceEntry, r.Scheme); err != nil {
 		return err
 	}
 	return nil
@@ -316,6 +316,10 @@ func (r *Controller) updateCredentialsSecret(ctx context.Context, o StackSecretO
 		for key, value := range outputs {
 			secret.Data[key] = []byte(value)
 		}
+		// mark the secret as owned by the o resource so it gets gc'd
+		if err := controllerutil.SetControllerReference(o, &secret, r.Scheme); err != nil {
+			return err
+		}
 		return nil
 	})
 	r.Log.Info("update-secret",
@@ -324,10 +328,6 @@ func (r *Controller) updateCredentialsSecret(ctx context.Context, o StackSecretO
 		"err", err,
 	)
 	if err != nil {
-		return err
-	}
-	// mark the secret as owned by the o resource so it gets gc'd
-	if err := controllerutil.SetControllerReference(o, &secret, r.Scheme); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
We called `controllerutil.SetControllerReference()` in the wrong
place, so that the resulting `ownerReference` wasn't actually sent to
the apiserver.

This fixes that.  Also, tests! \o/