### PR TITLE
perf(svcop): attempt to get build caching to work again

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -252,7 +252,7 @@ jobs:
     params:
       build: concourse-task-toolbox-source/components/concourse-task-toolbox
       dockerfile: concourse-task-toolbox-source/components/concourse-task-toolbox/Dockerfile
-      load_base: concourse-task-toolbox
+      cache_from: concourse-task-toolbox
       tag_file: concourse-task-toolbox-source/.git/short_ref
       tag_prefix: ((github-release-tag-prefix))v
       tag_as_latest: true


### PR DESCRIPTION
I think `load_base` is for things you might put in `FROM`, while
`cache_from` is for things where you want to re-use the caching
layers.