### PR TITLE
Service operator tests: Name created resources uniquely

### DIFF
--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -25,8 +25,8 @@ var _ = Describe("PostgresCloudFormationController", func() {
 
 		var (
 			name                   = fmt.Sprintf("test-db-%s", time.Now().Format("20060102150405"))
-			secretName             = "test-secret"
-			serviceEntryName       = "test-service-entry"
+			secretName             = "test-postgres-secret"
+			serviceEntryName       = "test-postgres-service-entry"
 			namespace              = "test"
 			resourceNamespacedName = types.NamespacedName{
 				Namespace: namespace,

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -26,8 +26,8 @@ var _ = Describe("S3CloudFormationController", func() {
 
 		var (
 			name                   = fmt.Sprintf("test-bucket-%s", time.Now().Format("20060102150405"))
-			secretName             = "test-secret"
-			serviceEntryName       = "test-service-entry"
+			secretName             = "test-s3-secret"
+			serviceEntryName       = "test-s3-service-entry"
 			principalName          = "test-role"
 			namespace              = "test"
 			resourceNamespacedName = types.NamespacedName{

--- a/components/service-operator/controllers/sqs_cloudformation_test.go
+++ b/components/service-operator/controllers/sqs_cloudformation_test.go
@@ -25,7 +25,7 @@ var _ = Describe("SQSCloudFormationController", func() {
 
 		var (
 			name                   = fmt.Sprintf("test-queue-%s", time.Now().Format("20060102150405"))
-			secretName             = "test-secret"
+			secretName             = "test-sqs-secret"
 			principalName          = "test-role"
 			namespace              = "test"
 			resourceNamespacedName = types.NamespacedName{


### PR DESCRIPTION
Otherwise an S3 bucket secret can be pulled into a postgres test etc. which
breaks everything.

We could clean up at the end of each test instead but this would be needed to
run things in parallel.