### PR TITLE
Give ServiceEntry resources exportTo . annotation

### DIFF
--- a/components/service-operator/apis/database/v1beta1/postgres_types.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types.go
@@ -257,6 +257,7 @@ func (p *Postgres) GetServiceEntrySpec(outputs cloudformation.Outputs) (map[stri
 		},
 		"location":   "MESH_EXTERNAL",
 		"resolution": "DNS",
+		"exportTo": ".",
 	}, nil
 }
 

--- a/components/service-operator/apis/database/v1beta1/postgres_types_test.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Postgres", func() {
 			HaveKeyWithValue("location", "MESH_EXTERNAL"),
 			HaveKey("hosts"),
 			HaveKey("ports"),
+			HaveKeyWithValue("exportTo", "."),
 		))
 		Expect(spec["hosts"]).To(ContainElement(outputs[v1beta1.PostgresEndpoint]))
 		Expect(spec["hosts"]).To(ContainElement(outputs[v1beta1.PostgresReadEndpoint]))

--- a/components/service-operator/apis/storage/v1beta1/s3_types.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types.go
@@ -233,6 +233,7 @@ func (s *S3Bucket) GetServiceEntrySpec(outputs cloudformation.Outputs) (map[stri
 		},
 		"location":   "MESH_EXTERNAL",
 		"resolution": "DNS",
+		"exportTo": ".",
 	}, nil
 }
 

--- a/components/service-operator/apis/storage/v1beta1/s3_types_test.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types_test.go
@@ -72,6 +72,7 @@ var _ = Describe("S3Bucket", func() {
 			HaveKeyWithValue("location", "MESH_EXTERNAL"),
 			HaveKey("hosts"),
 			HaveKey("ports"),
+			HaveKeyWithValue("exportTo", "."),
 		))
 		Expect(spec["hosts"]).To(ContainElement(fmt.Sprintf("%s.s3.eu-west-2.amazonaws.com", outputs[v1beta1.S3BucketName])))
 		Expect(spec["ports"]).To(ContainElement(

--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -140,6 +140,7 @@ var _ = Describe("PostgresCloudFormationController", func() {
 				HaveKey("ports"),
 				HaveKey("location"),
 				HaveKey("resolution"),
+				HaveKey("exportTo"),
 			))
 		})
 
@@ -148,13 +149,6 @@ var _ = Describe("PostgresCloudFormationController", func() {
 				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
 				return serviceEntry.ObjectMeta.OwnerReferences
 			}).Should(HaveLen(1))
-		})
-
-		By("creating a service entry with the correct exportTo annotation", func() {
-			Eventually(func() map[string]string {
-				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
-				return serviceEntry.Annotations
-			}).Should(HaveKeyWithValue("networking.istio.io/exportTo", "."))
 		})
 
 		By("connecting to resource", func() {

--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -150,6 +150,13 @@ var _ = Describe("PostgresCloudFormationController", func() {
 			}).Should(HaveLen(1))
 		})
 
+		By("creating a service entry with the correct exportTo annotation", func() {
+			Eventually(func() map[string]string {
+				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
+				return serviceEntry.Annotations
+			}).Should(HaveKeyWithValue("networking.istio.io/exportTo", "."))
+		})
+
 		By("connecting to resource", func() {
 			// TODO
 		})

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -160,6 +160,7 @@ var _ = Describe("S3CloudFormationController", func() {
 				HaveKey("ports"),
 				HaveKey("location"),
 				HaveKey("resolution"),
+				HaveKey("exportTo"),
 			))
 		})
 
@@ -168,13 +169,6 @@ var _ = Describe("S3CloudFormationController", func() {
 				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
 				return serviceEntry.ObjectMeta.OwnerReferences
 			}).Should(HaveLen(1))
-		})
-
-		By("creating a service entry with the correct exportTo annotation", func() {
-			Eventually(func() map[string]string {
-				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
-				return serviceEntry.Annotations
-			}).Should(HaveKeyWithValue("networking.istio.io/exportTo", "."))
 		})
 
 		By("deleting S3Bucket resource with Kubernetes api", func() {

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -170,6 +170,13 @@ var _ = Describe("S3CloudFormationController", func() {
 			}).Should(HaveLen(1))
 		})
 
+		By("creating a service entry with the correct exportTo annotation", func() {
+			Eventually(func() map[string]string {
+				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
+				return serviceEntry.Annotations
+			}).Should(HaveKeyWithValue("networking.istio.io/exportTo", "."))
+		})
+
 		By("deleting S3Bucket resource with Kubernetes api", func() {
 			err := client.Get(ctx, resourceNamespacedName, &bucket)
 			Expect(err).ToNot(HaveOccurred())

--- a/components/service-operator/internal/aws/cloudformation/controller.go
+++ b/components/service-operator/internal/aws/cloudformation/controller.go
@@ -263,9 +263,6 @@ func (r *Controller) updateServiceEntry(ctx context.Context, o ServiceEntryCreat
 			return err
 		}
 		serviceEntry.Spec = serviceEntrySpec
-		serviceEntry.Annotations = map[string]string {
-			"networking.istio.io/exportTo": ".",
-		}
 		// mark the serviceEntry as owned by the o resource so it gets gc'd
 		if err := controllerutil.SetControllerReference(o, serviceEntry, r.Scheme); err != nil {
 			return err

--- a/components/service-operator/internal/aws/cloudformation/controller.go
+++ b/components/service-operator/internal/aws/cloudformation/controller.go
@@ -263,6 +263,9 @@ func (r *Controller) updateServiceEntry(ctx context.Context, o ServiceEntryCreat
 			return err
 		}
 		serviceEntry.Spec = serviceEntrySpec
+		serviceEntry.Annotations = map[string]string {
+			"networking.istio.io/exportTo": ".",
+		}
 		// mark the serviceEntry as owned by the o resource so it gets gc'd
 		if err := controllerutil.SetControllerReference(o, serviceEntry, r.Scheme); err != nil {
 			return err


### PR DESCRIPTION
Otherwise by default they are assumed by Istio to have been exported globally?