### PR TITLE
Revert "refactor(svc-op): Only spin up k8s control plane once"

### DIFF
--- a/components/service-operator/apis/storage/v1beta1/s3_types_test.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types_test.go
@@ -62,7 +62,7 @@ var _ = Describe("S3Bucket", func() {
 	It("should produce the correct service entry", func() {
 		outputs := cloudformation.Outputs{
 			v1beta1.S3BucketName: "test",
-			v1beta1.S3BucketURL: "testing"
+			v1beta1.S3BucketURL: "testing",
 		}
 
 		spec, err := o.GetServiceEntrySpec(outputs)
@@ -104,7 +104,7 @@ var _ = Describe("S3Bucket", func() {
 			Expect(t.Outputs).To(And(
 				HaveKey("S3BucketName"),
 				HaveKeyWithValue("S3BucketURL", fmt.Sprintf("https://%s.s3.eu-west-2.amazonaws.com", t.Outputs[v1beta1.S3BucketName])),
-				HaveKey("IAMRoleName")
+				HaveKey("IAMRoleName"),
 			))
 		})
 

--- a/components/service-operator/apis/storage/v1beta1/s3_types_test.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types_test.go
@@ -103,7 +103,7 @@ var _ = Describe("S3Bucket", func() {
 			t := o.GetStackTemplate()
 			Expect(t.Outputs).To(And(
 				HaveKey("S3BucketName"),
-				HaveKeyWithValue("S3BucketURL", fmt.Sprintf("https://%s.s3.eu-west-2.amazonaws.com", t.Outputs[v1beta1.S3BucketName])),
+				HaveKey("S3BucketURL"),
 				HaveKey("IAMRoleName"),
 			))
 		})

--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -25,8 +25,8 @@ var _ = Describe("PostgresCloudFormationController", func() {
 
 		var (
 			name                   = fmt.Sprintf("test-db-%s", time.Now().Format("20060102150405"))
-			secretName             = "test-secret"
-			serviceEntryName       = "test-service-entry"
+			secretName             = "test-postgres-secret"
+			serviceEntryName       = "test-postgres-service-entry"
 			namespace              = "test"
 			resourceNamespacedName = types.NamespacedName{
 				Namespace: namespace,

--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -14,12 +14,23 @@ import (
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("PostgresCloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 30
+	var client client.Client
 	var ctx context.Context = context.Background()
+	var teardown func()
+
+	BeforeEach(func() {
+		client, teardown = SetupControllerEnv()
+	})
+
+	AfterEach(func() {
+		teardown()
+	})
 
 	It("Should create and destroy an Postgres database", func() {
 

--- a/components/service-operator/controllers/principal_cloudformation_test.go
+++ b/components/service-operator/controllers/principal_cloudformation_test.go
@@ -12,12 +12,23 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("PrincipalCloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 15
+	var client client.Client
 	var ctx context.Context = context.Background()
+	var teardown func()
+
+	BeforeEach(func() {
+		client, teardown = SetupControllerEnv()
+	})
+
+	AfterEach(func() {
+		teardown()
+	})
 
 	It("Should create and destroy an IAM role", func() {
 

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -26,8 +26,8 @@ var _ = Describe("S3CloudFormationController", func() {
 
 		var (
 			name                   = fmt.Sprintf("test-bucket-%s", time.Now().Format("20060102150405"))
-			secretName             = "test-secret"
-			serviceEntryName       = "test-service-entry"
+			secretName             = "test-s3-secret"
+			serviceEntryName       = "test-s3-service-entry"
 			principalName          = "test-role"
 			namespace              = "test"
 			resourceNamespacedName = types.NamespacedName{

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -15,12 +15,23 @@ import (
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("S3CloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 15
+	var client client.Client
 	var ctx context.Context = context.Background()
+	var teardown func()
+
+	BeforeEach(func() {
+		client, teardown = SetupControllerEnv()
+	})
+
+	AfterEach(func() {
+		teardown()
+	})
 
 	It("Should create and destroy an S3Bucket bucket", func() {
 

--- a/components/service-operator/controllers/sqs_cloudformation_test.go
+++ b/components/service-operator/controllers/sqs_cloudformation_test.go
@@ -14,12 +14,23 @@ import (
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("SQSCloudFormationController", func() {
 
 	var timeout time.Duration = time.Minute * 15
+	var client client.Client
 	var ctx context.Context = context.Background()
+	var teardown func()
+
+	BeforeEach(func() {
+		client, teardown = SetupControllerEnv()
+	})
+
+	AfterEach(func() {
+		teardown()
+	})
 
 	It("Should create and destroy an SQS queue", func() {
 

--- a/components/service-operator/controllers/sqs_cloudformation_test.go
+++ b/components/service-operator/controllers/sqs_cloudformation_test.go
@@ -25,7 +25,7 @@ var _ = Describe("SQSCloudFormationController", func() {
 
 		var (
 			name                   = fmt.Sprintf("test-queue-%s", time.Now().Format("20060102150405"))
-			secretName             = "test-secret"
+			secretName             = "test-sqs-secret"
 			principalName          = "test-role"
 			namespace              = "test"
 			resourceNamespacedName = types.NamespacedName{

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -37,23 +37,12 @@ import (
 	core "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	cln "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 )
-
-var client cln.Client
-var teardown func()
-
-var _ = BeforeSuite(func() {
-	client, teardown = SetupControllerEnv()
-})
-
-var _ = AfterSuite(func() {
-	teardown()
-})
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
@@ -72,7 +61,7 @@ func TestAPIs(t *testing.T) {
 // of the controller which can be used to inspect Reconcile errors and a
 // teardown function that should be called after the test is complete.
 // It is probably not practical to run this in parallel
-func SetupControllerEnv() (cln.Client, func()) {
+func SetupControllerEnv() (client.Client, func()) {
 	os.Setenv("CLOUD_PROVIDER", "aws")
 	os.Setenv("CLUSTER_NAME", "xxx")
 	ctx := context.Background()


### PR DESCRIPTION
This reverts #650 and #654

Unfortunately this makes some state shared between the tests and introduces
bugs that cause the principal AWS client to break and all of the tests to
time out.