### PR TITLE
Serial groups for cd-smoke-test 

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -66,6 +66,7 @@ spec:
     jobs:
     - name: build
       serial: true
+      serial_groups: [smoke-test]
       plan:
       - get: timer
         trigger: true
@@ -81,6 +82,7 @@ spec:
 
     - name: deploy
       serial: true
+      serial_groups: [smoke-test]
       plan:
       - get: src
         passed: ["build"]

--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Values.global.account.name }}-main
 spec:
   exposed: true
-  pipelineString: |
+  config:
 
     harbor_source: &harbor_source
       username: ((harbor.harbor_username))


### PR DESCRIPTION
## What

* pipelineString is deprecated, we should use config with all it's YAMLy
goodness
* add `serial_group` to `build` and `deploy` jobs

## Why

This is a workaround for a rare issue, that has started to show up more
since increasing the cd-smoke-test frequency.

we don't want the deploy job to run at the same time as the build job as
this increases the chance that we hit the "not signed by notary" bug if
a new build finishes before the previous deploy job has really begun.