### PR TITLE
use sed to avoid pipefail in harbor-resource

### DIFF
--- a/components/concourse-harbor-resource/assets/out
+++ b/components/concourse-harbor-resource/assets/out
@@ -34,16 +34,17 @@ username=$(jq -r '.source.username // ""' < "${payload}")
 password=$(jq -r '.source.password // ""' < "${payload}")
 
 log "parsing resporitory uri..."
-repository_array=$(echo -n "${repository}" | tr '/' '\n')
+echo "${repository}" | tr '/' '\n' > repository_array
 
 log "validating repository uri..."
-if [ "$(echo "${repository_array}" | tr '/' '\n' | wc -l | awk '{print $1}')" -ne "3" ]; then
+if [ "$(wc -l < repository_array | awk '{print $1}')" -ne "3" ]; then
 	log "'repository' needs to be a gun (<registry>/<project>/<image>), got: ${repository}"
 	exit 1
 fi
 
 log "determining project name..."
-project_name=$(echo -n "${repository_array}" | head -n2 | tail -n1)
+project_name=$(sed -n '2p' < repository_array)
+echo "project: ${project_name}"
 
 log "loading harbor config..."
 harbor_url=$(jq -r '.source.harbor.url // ""' < "${payload}")


### PR DESCRIPTION
`head` will stop reading from it's stdin once it has happily done
it's job, leaving the stdin stream with unread data.

when used in a chain of processes piped together, leaving unread bytes
on the stream will cause a pipefail error to be raised in the recving
process.

This is all by design. Although the behaviour is somewhat surprizing.

The harbor resource sets `-o pipefail` to abort on any process that
returns a pipefail status (141). This helps us catch errors that occur
in chains of processes, without them being swallowed by the sending
process.

To parse the harbor project-name out of the full image uri, we were
spliting the uri into url segments, then using:
`echo $URI_SEGMENTS | head -n2 | tail -n1`
to grab the 2nd line of the file (the name).

You can simulate something similar by observing the 141 exit code by doing:

```
seq 90000 | cat | head -n2; echo ${PIPESTATUS[@]}
```

I believe this is the culprit for the mysterious failures of the
resource we have seen.

Since the $URI_SEGMENTS string was so short, it is likely that this
almost always fit into the write buffer of the sending process (echo)
and so is instantly consumed in total by `head`... however sometimes
(totally up to the OS, hardware pressure, phase of the moon) the entire
string might not be sent/or read in one go... this would give `head` and
oportunity to stop reading more bytes, and ultimatly cause a pipefail
141 status.

To workaround this issue, I have switched to using `sed` to grab the 2nd
line of the URI_SEGMENTS and avoid the potential for pipefail.