### PR TITLE
chillout canary alert

### DIFF
--- a/components/canary/chart/templates/prometheus-rules.yaml
+++ b/components/canary/chart/templates/prometheus-rules.yaml
@@ -14,6 +14,6 @@ spec:
     - alert: CanaryRotationOverdue
       annotations:
         message: The Canary rotation is overdue. Check in-cluster concourse.
-      expr: time() - max(canary_chart_commit_timestamp{namespace="{{ .Release.Namespace }}"}) without (pod) > 300
+      expr: time() - max(canary_chart_commit_timestamp{namespace="{{ .Release.Namespace }}"}) without (pod) > 600
       labels:
         severity: critical


### PR DESCRIPTION
canary overdue alert goes off a little too frequently for our liking.
Chill it out a bit.