### PR TITLE
disable concourse worker persistant volume

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -198,8 +198,7 @@ concourse:
       enablePipelineAuditing: true
       enableTeamAuditing: true
   persistence:
-    worker:
-      size: 128Gi
+    enabled: false
   postgresql:
     persistence:
       size: 64Gi


### PR DESCRIPTION
I would like to experiment with disabling concourse worker persistence with a hope that it improves performance of concourse tasks starting and makes it easier to destroy workers if we see issues...

I see very little reason to keep the worker state in a persistent
volume when we explicitly tie one worker to one node.

we can use the "emptyDir" volume driver to provision a volume on the
node's local storage (which for m5d class instances is an SSD) which
will still give persistance until the node is terminated.

The main changes here should be that:

* volume/bagageclaim caches will no longer persist past node
  terminations. Personally I think this is fine. Builds logs and state
  are stored in postgres not on the workers so this will continue to be
  stateful.
* the "ci" instance type will dictate the available disk space (ie
  m5d.large is 75GB, m5d.xlarge is 150GB)
