### PR TITLE
Fix default Gateway to exist if ingress is enabled

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -90,6 +90,55 @@ subjects:
 - kind: ServiceAccount
   name: {{ .name }}-ingressgateway-service-account
 ---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: namespace-default
+  namespace: {{ .name }}
+spec:
+  secretName: namespace-default-certificate
+  dnsNames:
+  - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
+  acme:
+    config:
+    - dns01:
+        provider: route53
+      domains:
+      - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
+  issuerRef:
+    name: letsencrypt-r53
+    kind: ClusterIssuer
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: namespace-default
+  annotations:
+    externaldns.k8s.io/namespace: {{ .name }}
+spec:
+  selector:
+    istio: {{ .name }}-ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    tls:
+      httpsRedirect: true
+    hosts:
+    - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      serverCertificate: sds
+      privateKey: sds
+      credentialName: namespace-default-certificate
+    hosts:
+    - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
+---
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -364,54 +413,5 @@ spec:
               echo "applying manifests from ${SRC_URI} at path ${PATH_TO_MANIFESTS} to ${RELEASE_NAMESPACE}"
               kubectl apply $NS_ARGS -R -f "./src/${PATH_TO_MANIFESTS}"
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
-kind: Certificate
-metadata:
-  name: namespace-default
-  namespace: {{ .name }}
-spec:
-  secretName: namespace-default-certificate
-  dnsNames:
-  - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
-  acme:
-    config:
-    - dns01:
-        provider: route53
-      domains:
-      - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
-  issuerRef:
-    name: letsencrypt-r53
-    kind: ClusterIssuer
----
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: namespace-default
-  annotations:
-    externaldns.k8s.io/namespace: {{ .name }}
-spec:
-  selector:
-    istio: {{ .name }}-ingressgateway
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    tls:
-      httpsRedirect: true
-    hosts:
-    - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
-  - port:
-      number: 443
-      name: https
-      protocol: HTTPS
-    tls:
-      mode: SIMPLE
-      serverCertificate: sds
-      privateKey: sds
-      credentialName: namespace-default-certificate
-    hosts:
-    - "{{ .name }}.{{ $.Values.global.cluster.domain }}"
-
 {{- end }}
 {{- end }}


### PR DESCRIPTION
When I put this Gateway and Certificate in, I put them at the end of
the file without thinking too much.  Unfortunately I put them inside
the `if .repository` block, which mean that the canary namespace
didn't get a default Gateway.

This puts it in the correct place - inside the `if (default dict
.ingress).enabled` block, which means that we get a default Gateway if
and only if we have an ingressgateway to attach it to.