### PR TITLE
svcop: Raise control plane start timeout

### DIFF
--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -74,7 +74,7 @@ func SetupControllerEnv() (client.Client, func()) {
 			filepath.Join("..", "config", "crd"),
 			filepath.Join("..", "config", "crd", "bases"),
 		},
-		ControlPlaneStartTimeout: 40 * time.Second
+		ControlPlaneStartTimeout: 40 * time.Second,
 	}
 
 	var err error

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -74,6 +74,7 @@ func SetupControllerEnv() (client.Client, func()) {
 			filepath.Join("..", "config", "crd"),
 			filepath.Join("..", "config", "crd", "bases"),
 		},
+		ControlPlaneStartTimeout: 40 * time.Second
 	}
 
 	var err error

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -74,7 +74,7 @@ func SetupControllerEnv() (client.Client, func()) {
 			filepath.Join("..", "config", "crd"),
 			filepath.Join("..", "config", "crd", "bases"),
 		},
-		ControlPlaneStartTimeout: 40 * time.Second,
+		ControlPlaneStartTimeout: 2 * time.Minute,
 	}
 
 	var err error


### PR DESCRIPTION
Our Concourse is slow, let's increase the timeout to 2 minutes so it stops failing to build due to control plane startup timeouts.