### PR TITLE
Replace critical-pod annotation with priority system-cluster-critical

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
@@ -13,11 +13,10 @@ spec:
       k8s-app: kube-proxy
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         k8s-app: kube-proxy
     spec:
+      priorityClassName: system-cluster-critical
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
@@ -18,13 +18,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
-      annotations:
-        # This, along with the CriticalAddonsOnly toleration below,
-        # marks the pod as a critical add-on, ensuring it gets
-        # priority scheduling and that its resources are reserved
-        # if it ever gets evicted.
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true
@@ -505,9 +500,9 @@ spec:
       labels:
         k8s-app: calico-typha
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical says this is deprecated as of 1.13 and will be removed in future.
I'm not convinced it's doing anything right now.