### PR TITLE
Return calico-typha to cluster-critical

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
@@ -509,7 +509,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         cluster-autoscaler.kubernetes.io/safe-to-evict: 'true'
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: system-cluster-critical
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:


### PR DESCRIPTION
Doesn't need to be node-critical, it's from a Deployment not a DaemonSet.