### PR TITLE
Make fluentd-cloudwatch gsp-critical

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -143,6 +143,7 @@ fluentd-cloudwatch:
   tolerations:
     - key: node-role.kubernetes.io/master
       effect: NoSchedule
+  priorityClassName: gsp-critical
 
 concourse:
   web:


### PR DESCRIPTION
Need one running on each node to ship logs.