### PR TITLE
svcop: Fix ServiceEntry creation/update

### DIFF
--- a/components/service-operator/apis/database/v1beta1/postgres_types.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types.go
@@ -257,7 +257,7 @@ func (p *Postgres) GetServiceEntrySpec(outputs cloudformation.Outputs) (map[stri
 		},
 		"location":   "MESH_EXTERNAL",
 		"resolution": "DNS",
-		"exportTo": ".",
+		"exportTo": []string{"."},
 	}, nil
 }
 

--- a/components/service-operator/apis/database/v1beta1/postgres_types_test.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Postgres", func() {
 			HaveKeyWithValue("location", "MESH_EXTERNAL"),
 			HaveKey("hosts"),
 			HaveKey("ports"),
-			HaveKeyWithValue("exportTo", "."),
+			HaveKey("exportTo"),
 		))
 		Expect(spec["hosts"]).To(ContainElement(outputs[v1beta1.PostgresEndpoint]))
 		Expect(spec["hosts"]).To(ContainElement(outputs[v1beta1.PostgresReadEndpoint]))
@@ -85,6 +85,11 @@ var _ = Describe("Postgres", func() {
 				"number":   portnum,
 				"protocol": "TLS",
 			},
+		))
+
+		Expect(spec["exportTo"]).To(And(
+			HaveLen(1),
+			ContainElement("."),
 		))
 	})
 

--- a/components/service-operator/apis/storage/v1beta1/s3_types.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types.go
@@ -233,7 +233,7 @@ func (s *S3Bucket) GetServiceEntrySpec(outputs cloudformation.Outputs) (map[stri
 		},
 		"location":   "MESH_EXTERNAL",
 		"resolution": "DNS",
-		"exportTo": ".",
+		"exportTo": []string{"."},
 	}, nil
 }
 

--- a/components/service-operator/apis/storage/v1beta1/s3_types_test.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types_test.go
@@ -72,7 +72,7 @@ var _ = Describe("S3Bucket", func() {
 			HaveKeyWithValue("location", "MESH_EXTERNAL"),
 			HaveKey("hosts"),
 			HaveKey("ports"),
-			HaveKeyWithValue("exportTo", "."),
+			HaveKey("exportTo"),
 		))
 		Expect(spec["hosts"]).To(ContainElement(fmt.Sprintf("%s.s3.eu-west-2.amazonaws.com", outputs[v1beta1.S3BucketName])))
 		Expect(spec["ports"]).To(ContainElement(
@@ -81,6 +81,10 @@ var _ = Describe("S3Bucket", func() {
 				"number":   443,
 				"protocol": "TLS",
 			},
+		))
+		Expect(spec["exportTo"]).To(And(
+			HaveLen(1),
+			ContainElement("."),
 		))
 	})
 


### PR DESCRIPTION
Turns out exportTo in a ServiceEntry spec is a list of strings, not a string.
Fixes #657.