### PR TITLE
limit retention size lower than prom disk size

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -18,6 +18,7 @@ prometheus-operator:
         product: local
       replicas: 2
       retention: "60d"
+      retentionSize: "45GB"
       ruleSelectorNilUsesHelmValues: false
       ruleSelector: {}
       secrets: [ istio.gsp-prometheus-operator-prometheus ]


### PR DESCRIPTION
we have seen prometheus use up all the disk space as it tries to keep
metrics for 60d retension ... but the disk is only 50GiB ... to limit
prometheus to less than the available disk space we set retentionSize