### PR TITLE
enable compression for prometheus wal

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -19,6 +19,7 @@ prometheus-operator:
       replicas: 2
       retention: "60d"
       retentionSize: "45GB"
+      walCompression: true
       ruleSelectorNilUsesHelmValues: false
       ruleSelector: {}
       secrets: [ istio.gsp-prometheus-operator-prometheus ]


### PR DESCRIPTION
This flag enables compression of the write-ahead log (WAL). Depending on
your data, you can expect the WAL size to be halved with little extra
cpu load.