### PR TITLE
allow 10m for check-canary

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -712,7 +712,7 @@ jobs:
     trigger: true
   - task: ping
     image: task-toolbox
-    timeout: 5m
+    timeout: 10m
     config: *check_canary
     params:
       CLUSTER_DOMAIN: ((cluster-domain))


### PR DESCRIPTION
5m is too close to the build-deploy loop ... give it a bit more time