### PR TITLE
switch bagageclaim to use buttahheffess

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -183,7 +183,7 @@ concourse:
       ephemeral: true
       baggageclaim:
         logLevel: error
-        driver: overlay
+        driver: btrfs
     web:
       xFrameOptions: "allow-from: https://framesplits.cloudapps.digital/"
       logLevel: error


### PR DESCRIPTION
use the btrfs driver for concourse's baggageclaim storage in the hope
that it avoids the issues we seem to be increasingly observing where
where workers stall with errors like
"baggageclaim.failed-to-set-up-driver".

It's possible the recent change from EBS persistantvolumes to local emptydir volumes is not playing nicely with the overlay driver but to be honest this is a bit of an experiment to see if the situation improves.... there is a similar [thread here](https://discuss.concourse-ci.org/t/overlay-driver-failed-to-set-up-driver-on-5-4-1-5-5-0/1737) and [issue here](https://github.com/helm/charts/issues/5355) describing similar symptoms that are resolved by switching to either `naive` or `btrfs` drivers