### PR TITLE
use clair to power a CVE smoke test tasl in conc

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/vuln-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/vuln-smoke-test-pipeline.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: concourse.k8s.io/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: vuln-smoke-test
+  namespace: {{ .Values.global.account.name }}-main
+spec:
+  exposed: true
+  config:
+
+    task_toolbox: &task_toolbox
+      type: docker-image
+      source:
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
+
+    resources:
+    - name: daily
+      type: time
+      icon: update
+      source:
+        interval: 1d
+
+    jobs:
+    - name: build
+      serial: true
+      serial_groups: [smoke-test]
+      plan:
+      - task: report-vulnerabilities
+        timeout: 2m
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+          - name: manifests
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            KUBERNETES_API: kubernetes.default.svc
+            JSON_OUTPUT: "true"
+            IGNORE_UNFIXED: "true"
+            CLAIR_OUTPUT: "high"
+            CLAIR_ADDR: "localhost:6060"
+          run:
+            path: /bin/bash
+            args:
+            - -eu
+            - -c
+            - |
+              echo "configuring kubectl"
+              echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+              kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+              kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+              kubectl config set-context deployer --user deployer --cluster self
+              kubectl config use-context deployer
+
+              CONTAINER_IMAGES=$(ks get po --all-namespaces -o json | jq .items[].spec.containers[].image -r | sed s#docker.io/## | sort | uniq)
+              for image in $CONTAINER_IMAGES; do
+                klar $image | jq "{name: \"$image\", scan: .}"
+              done
+

--- a/components/concourse-task-toolbox/Dockerfile
+++ b/components/concourse-task-toolbox/Dockerfile
@@ -67,6 +67,12 @@ RUN wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSI
 	&& mv spruce-linux-amd64 /bin/spruce \
 	&& chmod +x /bin/spruce
 
+# install klar (cli for clair)
+ENV KLAR_VERSION=2.4.0
+RUN wget https://github.com/optiopay/klar/releases/download/v${KLAR_VERSION}/klar-${KLAR_VERSION}-linux-amd64 \
+	&& mv klar-${KLAR_VERSION}-linux-amd64 /bin/klar \
+	&& chmod +x /bin/klar
+
 # install aws-iam-authenticator
 RUN curl -LO https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/0.4.0-alpha.1/aws-iam-authenticator_0.4.0-alpha.1_linux_amd64 \
 	&& chmod +x aws-iam-authenticator_0.4.0-alpha.1_linux_amd64 \


### PR DESCRIPTION
we'd like to know when we should be actioning upgrades of certain
components so we have confidence we are not leaving any nasty CVEs
unpatched, one quick idea for this would be to use clair which we
already have running in the cluster to report on any high CVEs from
running containers.

this uses klar (a cli for clair) installed into the task toolbox and
short script to fetch all running container images from the pod specs.