### PR TITLE
Add random newline to concourse-operator source

### DIFF
--- a/components/concourse-operator/README.md
+++ b/components/concourse-operator/README.md
@@ -97,3 +97,4 @@ It was originally built using [kubebuilder](https://github.com/kubernetes-sigs/k
 kubebuilder init --domain k8s.io
 kubebuilder create api --group concourse --version v1beta1 --kind Pipeline
 ```
+


### PR DESCRIPTION
Following #675/#693 we introduced another place where we get
concourse-operator-source - which would be fine except the last commit to that
component was in #571 which was approved by Andy, who left and is no longer on
the list of people trusted to approve.