### PR TITLE
resize prometheus PV to 200GiB

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -35,7 +35,7 @@ prometheus-operator:
             accessModes: ["ReadWriteOnce"]
             resources:
               requests:
-                storage: 50Gi
+                storage: 200Gi
             storageClassName: gp2
       query:
         timeout: 30s


### PR DESCRIPTION
we need at least 100GB for 60 days of retention and would like some
spare room for the WAL log and compression to take place.