### PR TITLE
allow returning multiple ServiceEntries from ServiceEntryCreators

### DIFF
--- a/components/service-operator/apis/database/v1beta1/postgres_types.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types.go
@@ -237,28 +237,43 @@ func (p *Postgres) GetServiceEntryName() string {
 }
 
 // ServiceEntry to whitelist egress access to Postgres port and hosts.
-func (p *Postgres) GetServiceEntrySpec(outputs cloudformation.Outputs) (map[string]interface{}, error) {
+func (p *Postgres) GetServiceEntrySpecs(outputs cloudformation.Outputs) ([]map[string]interface{}, error) {
 	port, err := strconv.Atoi(outputs[PostgresPort])
 	if err != nil {
 		return nil, err
 	}
-
-	return map[string]interface{}{
-		"hosts": []string{
-			outputs[PostgresEndpoint],
-			outputs[PostgresReadEndpoint],
-		},
-		"ports": []interface{}{
-			map[string]interface{}{
-				"name":     "aurora",
-				"number":   port,
-				"protocol": "TLS",
+	specs := []map[string]interface{}{
+		{
+			"hosts": []string{
+				outputs[PostgresEndpoint],
 			},
+			"ports": []interface{}{
+				map[string]interface{}{
+					"name":     "aurora",
+					"number":   port,
+					"protocol": "TCP",
+				},
+			},
+			"location":   "MESH_EXTERNAL",
+			"resolution": "DNS",
+			"exportTo":   []string{"."},
+		}, {
+			"hosts": []string{
+				outputs[PostgresReadEndpoint],
+			},
+			"ports": []interface{}{
+				map[string]interface{}{
+					"name":     "aurora",
+					"number":   port,
+					"protocol": "TCP",
+				},
+			},
+			"location":   "MESH_EXTERNAL",
+			"resolution": "DNS",
+			"exportTo":   []string{"."},
 		},
-		"location":   "MESH_EXTERNAL",
-		"resolution": "DNS",
-		"exportTo": []string{"."},
-	}, nil
+	}
+	return specs, nil
 }
 
 // +kubebuilder:object:root=true

--- a/components/service-operator/apis/storage/v1beta1/s3_types.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types.go
@@ -200,7 +200,7 @@ func (s *S3Bucket) GetStackTemplate() *cloudformation.Template {
 
 	template.Outputs[S3BucketURL] = map[string]interface{}{
 		"Description": "Bucket URL to be returned to the user.",
-		"Value": fmt.Sprintf("https://%s.s3.eu-west-2.amazonaws.com", bucketName),
+		"Value":       fmt.Sprintf("https://%s.s3.eu-west-2.amazonaws.com", bucketName),
 	}
 
 	template.Outputs[IAMRoleParameterName] = map[string]interface{}{
@@ -219,8 +219,8 @@ func (s *S3Bucket) GetServiceEntryName() string {
 }
 
 // ServiceEntry to whitelist egress access to S3 hostname.
-func (s *S3Bucket) GetServiceEntrySpec(outputs cloudformation.Outputs) (map[string]interface{}, error) {
-	return map[string]interface{}{
+func (s *S3Bucket) GetServiceEntrySpecs(outputs cloudformation.Outputs) ([]map[string]interface{}, error) {
+	spec := map[string]interface{}{
 		"hosts": []string{
 			fmt.Sprintf("%s.s3.eu-west-2.amazonaws.com", outputs[S3BucketName]),
 		},
@@ -233,8 +233,9 @@ func (s *S3Bucket) GetServiceEntrySpec(outputs cloudformation.Outputs) (map[stri
 		},
 		"location":   "MESH_EXTERNAL",
 		"resolution": "DNS",
-		"exportTo": []string{"."},
-	}, nil
+		"exportTo":   []string{"."},
+	}
+	return []map[string]interface{}{spec}, nil
 }
 
 // GetStackRoleParameters returns additional params based on a target principal resource

--- a/components/service-operator/apis/storage/v1beta1/s3_types_test.go
+++ b/components/service-operator/apis/storage/v1beta1/s3_types_test.go
@@ -62,11 +62,13 @@ var _ = Describe("S3Bucket", func() {
 	It("should produce the correct service entry", func() {
 		outputs := cloudformation.Outputs{
 			v1beta1.S3BucketName: "test",
-			v1beta1.S3BucketURL: "testing",
+			v1beta1.S3BucketURL:  "testing",
 		}
 
-		spec, err := o.GetServiceEntrySpec(outputs)
+		specs, err := o.GetServiceEntrySpecs(outputs)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(specs).To(HaveLen(1))
+		spec := specs[0]
 		Expect(spec).To(And(
 			HaveKeyWithValue("resolution", "DNS"),
 			HaveKeyWithValue("location", "MESH_EXTERNAL"),

--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -49,9 +49,9 @@ var _ = Describe("S3CloudFormationController", func() {
 				Namespace: namespace,
 				Name:      secretName,
 			}
-			serviceEntryNamespacedName = types.NamespacedName{
+			serviceEntryNamespacedName0 = types.NamespacedName{
 				Namespace: namespace,
-				Name:      serviceEntryName,
+				Name:      fmt.Sprintf("%s-0", serviceEntryName),
 			}
 			principal = access.Principal{
 				TypeMeta: metav1.TypeMeta{
@@ -153,7 +153,7 @@ var _ = Describe("S3CloudFormationController", func() {
 
 		By("creating a service entry with the endpoints", func() {
 			Eventually(func() map[string]interface{} {
-				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
+				_ = client.Get(ctx, serviceEntryNamespacedName0, &serviceEntry)
 				return serviceEntry.Spec
 			}).Should(And(
 				HaveKey("hosts"),
@@ -166,7 +166,7 @@ var _ = Describe("S3CloudFormationController", func() {
 
 		By("creating a service entry with an owner reference", func() {
 			Eventually(func() []metav1.OwnerReference {
-				_ = client.Get(ctx, serviceEntryNamespacedName, &serviceEntry)
+				_ = client.Get(ctx, serviceEntryNamespacedName0, &serviceEntry)
 				return serviceEntry.ObjectMeta.OwnerReferences
 			}).Should(HaveLen(1))
 		})

--- a/components/service-operator/internal/aws/cloudformation/types.go
+++ b/components/service-operator/internal/aws/cloudformation/types.go
@@ -45,5 +45,5 @@ type StackSecretOutputter interface {
 type ServiceEntryCreator interface {
 	Stack
 	GetServiceEntryName() string
-	GetServiceEntrySpec(outputs Outputs) (map[string]interface{}, error)
+	GetServiceEntrySpecs(outputs Outputs) ([]map[string]interface{}, error)
 }


### PR DESCRIPTION
## What

Alter the interface for ServiceEntryCreator to allow returning multiple ServiceEntry specs

## Why 

It's not possible to set multiple hosts for a TCP ServiceEntry with DNS
resolution, so we need to be able to return multiple service entry
specs from a ServiceEntryCreator in order to satisfy the requirements of
services like RDS that can have multiple endpoints.

This should resolve the issue with the current implementation that relies on SNI headers (TLS) that not all postgres clients appear to send.