### PR TITLE
Expose kube-proxy metrics.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
@@ -36,7 +36,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config
+        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config --metrics-bind-address=0.0.0.0
         image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.14.6
         imagePullPolicy: IfNotPresent
         name: kube-proxy


### PR DESCRIPTION
Currently prometheus is reporting that all kube-proxy instances are down.
Hopefully this fixes it.