### PR TITLE
Expose kube-proxy metrics

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/kube-proxy-config.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-proxy-config.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    eks.amazonaws.com/component: kube-proxy
+    k8s-app: kube-proxy
+  name: kube-proxy-config
+  namespace: kube-system
+data:
+  config: |-
+    apiVersion: kubeproxy.config.k8s.io/v1alpha1
+    bindAddress: 0.0.0.0
+    clientConnection:
+      acceptContentTypes: ""
+      burst: 10
+      contentType: application/vnd.kubernetes.protobuf
+      kubeconfig: /var/lib/kube-proxy/kubeconfig
+      qps: 5
+    clusterCIDR: ""
+    configSyncPeriod: 15m0s
+    conntrack:
+      max: 0
+      maxPerCore: 32768
+      min: 131072
+      tcpCloseWaitTimeout: 1h0m0s
+      tcpEstablishedTimeout: 24h0m0s
+    enableProfiling: false
+    healthzBindAddress: 0.0.0.0:10256
+    hostnameOverride: ""
+    iptables:
+      masqueradeAll: false
+      masqueradeBit: 14
+      minSyncPeriod: 0s
+      syncPeriod: 30s
+    ipvs:
+      excludeCIDRs: null
+      minSyncPeriod: 0s
+      scheduler: ""
+      syncPeriod: 30s
+    kind: KubeProxyConfiguration
+    metricsBindAddress: 0.0.0.0:10249
+    mode: "iptables"
+    nodePortAddresses: null
+    oomScoreAdj: -998
+    portRange: ""
+    resourceContainer: ""
+    udpIdleTimeout: 250ms

--- a/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
@@ -36,7 +36,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config --metrics-bind-address=0.0.0.0
+        - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config
         image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.14.6
         imagePullPolicy: IfNotPresent
         name: kube-proxy


### PR DESCRIPTION
Kube-proxy appears to favour the config file value over the command line argument. So we're going to use that instead.
