### PR TITLE
Fix set-deployer-pipeline README to not set unused environment variable

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -3,5 +3,5 @@
 Example for pushing a deployer pipeline to provision a sandbox cluster can be found in `./hack/set-deployer-pipeline.sh`:
 
 ```
-CLUSTER_CONFIG=./pipelines/examples/clusters/sandbox.yaml USER_CONFIGS=./pipelines/examples/users/ ./hack/set-deployer-pipeline.sh
+CLUSTER_CONFIG=./pipelines/examples/clusters/sandbox.yaml ./hack/set-deployer-pipeline.sh
 ```


### PR DESCRIPTION
This is only used in set-release-pipeline