### PR TITLE
Various fixes for new clusters

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -3,5 +3,5 @@
 Example for pushing a deployer pipeline to provision a sandbox cluster can be found in `./hack/set-deployer-pipeline.sh`:
 
 ```
-CLUSTER_CONFIG=./pipelines/examples/clusters/sandbox.yaml USER_CONFIGS=./pipelines/examples/users/ ./hack/set-deployer-pipeline.sh
+CLUSTER_CONFIG=./pipelines/examples/clusters/sandbox.yaml ./hack/set-deployer-pipeline.sh
 ```

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -35,3 +35,4 @@ config-repository: "gsp"
 config-path: "pipelines/examples"
 config-trigger: false
 users-trigger: false
+enable-nlb: true

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -18,6 +18,8 @@ vpc-flow-log-splunk-hec-token: "NOTATOKEN"
 vpc-flow-log-splunk-index: "NOTAURL"
 github-client-secret: "NOTASECRET"
 github-client-id: "NOTID"
+google-oauth-client-id: "NOTASECRET"
+google-oauth-client-secret: "NOTID"
 eks-version: "1.14"
 trusted-developer-keys: []
 config-approval-count: 0

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -18,7 +18,7 @@ vpc-flow-log-splunk-hec-token: "NOTATOKEN"
 vpc-flow-log-splunk-index: "NOTAURL"
 github-client-secret: "NOTASECRET"
 github-client-id: "NOTID"
-eks-version: "1.12"
+eks-version: "1.14"
 trusted-developer-keys: []
 config-approval-count: 0
 config-approvers: ["chrisfarms"]


### PR DESCRIPTION
* Fix set-deployer-pipeline README to not set unused environment variable - this is only used in set-release-pipeline.
* Set EKS version in the example config to the one we actually use.
* Add Google client dummy secrets to the example config.
* Enable NLB in the example config.