### PR TITLE
Brewfile: `minikube` is a standard Homebrew formula now

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,14 +1,11 @@
 tap "homebrew/core"
-tap "homebrew/cask"
 
 brew "kubernetes-cli"
 brew "kubernetes-helm"
-brew "linuxbrew/extra/minikube" if OS.linux?
+brew "minikube"
 brew "opa"
 
 if OS.mac?
   brew "hyperkit"
   brew "docker-machine-driver-hyperkit"
 end
-
-cask "minikube"


### PR DESCRIPTION
- We no longer need the "cask" tap, or the "OS.linux?" conditional to
  pull a different formula.

**This will need pulling and re-signing as I'm no longer a trusted
dev.**