### PR TITLE
Fix Terraform plan for a new cluster

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -1,6 +1,7 @@
 module "k8s-cluster" {
   source                       = "../k8s-cluster"
   vpc_id                       = "${var.vpc_id}"
+  private_subnet_count         = "${var.private_subnet_count}"
   private_subnet_ids           = ["${var.private_subnet_ids}"]
   public_subnet_ids            = ["${var.public_subnet_ids}"]
   cluster_name                 = "${var.cluster_name}"

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -133,6 +133,10 @@ variable "vpc_id" {
   type = "string"
 }
 
+variable "private_subnet_count" {
+  type = "string"
+}
+
 variable "private_subnet_ids" {
   type = "list"
 }

--- a/modules/gsp-network/outputs.tf
+++ b/modules/gsp-network/outputs.tf
@@ -2,6 +2,10 @@ output "vpc_id" {
   value = "${aws_vpc.network.id}"
 }
 
+output "private_subnet_count" {
+  value = "3"
+}
+
 output "private_subnet_ids" {
   value = [
     "${module.subnet-0.private_subnet_id}",

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -3,7 +3,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "aws_subnet" "private_subnets" {
-  count = "${length(var.private_subnet_ids)}"
+  count = "${var.private_subnet_count}"
   id    = "${element(var.private_subnet_ids, count.index)}"
 }
 
@@ -83,7 +83,7 @@ resource "aws_cloudformation_stack" "worker-nodes" {
   depends_on = ["aws_eks_cluster.eks-cluster"]
 }
 resource "aws_cloudformation_stack" "worker-nodes-per-az" {
-  count         = "${length(var.private_subnet_ids)}"
+  count         = "${var.private_subnet_count}"
   name          = "${var.cluster_name}-worker-nodes-${element(data.aws_subnet.private_subnets.*.availability_zone, count.index)}"
   template_body = "${file("${path.module}/data/nodegroup-v2.yaml")}"
   capabilities  = ["CAPABILITY_IAM"]

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -6,6 +6,10 @@ variable "public_subnet_ids" {
   type = "list"
 }
 
+variable "private_subnet_count" {
+  type = "string"
+}
+
 variable "private_subnet_ids" {
   type = "list"
 }

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -146,6 +146,7 @@ module "gsp-cluster" {
   ci_worker_count              = "${var.ci_worker_count}"
 
   vpc_id               = "${module.gsp-network.vpc_id}"
+  private_subnet_count = "${module.gsp-network.private_subnet_count}"
   private_subnet_ids   = "${module.gsp-network.private_subnet_ids}"
   public_subnet_ids    = "${module.gsp-network.public_subnet_ids}"
   egress_ips           = "${module.gsp-network.egress_ips}"


### PR DESCRIPTION
We are currently running into the following Terraform bug when trying to apply
a new cluster using Terraform 0.11:
https://github.com/hashicorp/terraform/issues/12570#issuecomment-309995500
This is because we are trying to run `length()` on a thing that references
another module which has not yet been applied.
We know what the length of it is already, so we can just output the
pre-calculated value.