### PR TITLE
allow tenants to create grafana dashboards

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -288,6 +288,9 @@ prometheus-operator:
       GF_SECURITY_COOKIE_SECURE: "true"
       GF_SESSION_COOKIE_SECURE: "true"
     envFromSecret: grafana
+    sidecar:
+      dashboards:
+        searchNamespace: ALL
 
   prometheusOperator:
     kubeletService:


### PR DESCRIPTION
Right now we only search `gsp-system` for grafana dashboard
ConfigMaps, so tenants can't create their own dashboards.  This
changes it so we search all namespaces.

cc @idrop 