### PR TITLE
Try to fix problems relating to terraform 0.12

### DIFF
--- a/modules/gsp-cluster/nlb.tf
+++ b/modules/gsp-cluster/nlb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "ingress-nlb" {
-  count = var.enable_nlb == 1 ? 1 : 0
+  count = (var.enable_nlb == 1) ? 1 : 0
 
   name               = "${var.cluster_name}-ingress-nlb"
   load_balancer_type = "network"
@@ -22,7 +22,7 @@ resource "aws_lb" "ingress-nlb" {
 }
 
 resource "aws_lb_listener" "ingress-nlb" {
-  count = var.enable_nlb == 1 ? 1 : 0
+  count = (var.enable_nlb == 1) ? 1 : 0
 
   load_balancer_arn = "${aws_lb.ingress-nlb[0].arn}"
   protocol = "TCP"
@@ -35,7 +35,7 @@ resource "aws_lb_listener" "ingress-nlb" {
 }
 
 resource "aws_route53_record" "ingress-nlb" {
-  count = var.enable_nlb == 1 ? 1 : 0
+  count = (var.enable_nlb == 1) ? 1 : 0
 
   zone_id = var.cluster_domain_id
   name    = "nlb.${var.cluster_domain}."

--- a/modules/gsp-network/outputs.tf
+++ b/modules/gsp-network/outputs.tf
@@ -12,9 +12,9 @@ output "private_subnet_ids" {
 
 output "private_subnet_cidr_mapping" {
   value = {
-    module.subnet-0.private_subnet_id = module.subnet-0.private_subnet_cidr
-    module.subnet-1.private_subnet_id = module.subnet-1.private_subnet_cidr
-    module.subnet-2.private_subnet_id = module.subnet-2.private_subnet_cidr
+    "${module.subnet-0.private_subnet_id}" = module.subnet-0.private_subnet_cidr
+    "${module.subnet-1.private_subnet_id}" = module.subnet-1.private_subnet_cidr
+    "${module.subnet-2.private_subnet_id}" = module.subnet-2.private_subnet_cidr
   }
 }
 


### PR DESCRIPTION
Our plan is showing `module.gsp-cluster.aws_lb.ingress-nlb[0] will be destroyed`
So maybe Terraform is now mishandling our count stuff. Trying with brackets.

Meanwhile, it's complaining about making a map with keys by expression, so
revert that back to using string interpolation for the keys.