### PR TITLE
limit concourse worker's disk volume to 60Gi

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -165,6 +165,7 @@ concourse:
     nameOverride: concourse-worker
     replicas: 2
     hardAntiAffinity: true
+    emptyDirSize: 60Gi
     resources:
       requests:
         cpu: 150m

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -158,7 +158,7 @@ resource "aws_cloudformation_stack" "ci-nodes" {
     NodeAutoScalingGroupDesiredCapacity = var.ci_worker_count
     NodeAutoScalingGroupMaxSize         = var.ci_worker_count + 1
     NodeInstanceType                    = var.ci_worker_instance_type
-    NodeVolumeSize                      = "40"
+    NodeVolumeSize                      = "75"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/ci --register-with-taints=node-role.kubernetes.io/ci=:NoSchedule --event-qps=0\""
     VpcId                               = var.vpc_id
     Subnets                             = join(",", var.private_subnet_ids)


### PR DESCRIPTION
Increase node volum storage to 75Gi and limit the empty volume (instance storage) concourse workers are using
for there ephemeral storage to 60Gi so that they don't fill up the
node's disk.

We believe this being unlimited to be a source of previous disk-pressure
and ultimate responsible for the scheduler eviciting important pods
(like CNIs and kube-proxy) to releave that pressure.

The number 60Gi was chosen as as we are setting the node storage to 75Gi and want to leave a decent chunk for the OS and other pods to avoid disk-pressure issues.