### PR TITLE
Actually apply the terraform upgrade

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -626,7 +626,6 @@ jobs:
     params:
       env_name: ((account-name))
       terraform_source: platform/pipelines/deployer
-      plan_only: true
   - task: generate-user-terraform
     image: task-toolbox
     timeout: 10m
@@ -637,7 +636,6 @@ jobs:
     params:
       env_name: ((account-name))
       terraform_source: users-terraform
-      plan_only: true
 
 - name: apply
   serial: true


### PR DESCRIPTION
After https://github.com/alphagov/gsp/pull/719 gets merged, we'll probably be
fine with the minor (potentially nil?) changes it wants to make now in sandbox.
Do we want to check it in verify/portfolio too, i.e. promote that to verify to see
the plan before merging this?