### PR TITLE
Partially revert #706 to get Terraform apply working

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -176,7 +176,7 @@ resource "aws_security_group" "rds-from-worker" {
 }
 
 resource "aws_db_subnet_group" "private" {
-  name = "${var.cluster_name}-private"
+  name = "sandbox-private"
   subnet_ids = var.private_subnet_ids
 }
 


### PR DESCRIPTION
It turns out renaming DB Subnet Groups, as this was going to do in Verify,
results in the replacement of the attached RDS Clusters.