### PR TITLE
Use the internal service to access Harbor API

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -14,7 +14,6 @@ spec:
       username: ((harbor.harbor_username))
       password: ((harbor.harbor_password))
       harbor:
-        url: ((harbor.harbor_url))
         prevent_vul: "false"
         public: "false"
       notary:

--- a/docs/gds-supported-platform/making-things-private-in-harbor.md
+++ b/docs/gds-supported-platform/making-things-private-in-harbor.md
@@ -12,7 +12,6 @@ private.
     username: ((harbor.harbor_username))
     password: ((harbor.harbor_password))
     harbor:
-      url: ((harbor.harbor_url))
       prevent_vul: "false"
       public: "false"
     notary:


### PR DESCRIPTION
We want to be able to remove the client IP safelist. We've decided to do
this by removing the need to have an ingress for the API entirely. This
change will mean that Concourse will use the internal service for the
Harbor API because the `concourse-harbor-resource` will use it by
default.