### PR TITLE
use externalTrafficPolicy: Cluster for ingress LBs

### DIFF
--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -64,7 +64,6 @@ istio:
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
       podAnnotations: {}
       type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
-      externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out
       ports:
         ## You can add custom gateway ports
         # Note that AWS ELB will by default perform health checks on the first port

--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -31,13 +31,7 @@ istio:
         app: istio-ingressgateway
         istio: {{ $namespace.name }}-ingressgateway
       autoscaleEnabled: true
-      # minimum of 1 per AZ. According to
-      # https://kubernetes.io/docs/setup/best-practices/multiple-zones/#pods-are-spread-across-zones
-      # pods are spread across "failure zones" by default. NLB cross-zone routing isn't in this version
-      # of kubernetes and as we've enabled `externalTrafficPolicy: Local` connections to the NLB in an AZ
-      # that has no ingressgateway results in timeouts. Once k8s 1.14 lands the following annotation solves it
-      # service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled
-      autoscaleMin: 3
+      autoscaleMin: 2
       autoscaleMax: 5
       # specify replicaCount when autoscaleEnabled: false
       # replicaCount: 1


### PR DESCRIPTION
sets the managed namespace loadbalaners to use the "cluster" mode (the
default mode). In this mode, loadbalancers will include all node in
there target groups and will rely on the inter-cluster networking to
route traffic to the correct pod, instead of directly targeting the node
where pod is currently located. This looks less effcient, but is less
sensitive to node failure.

we previously used externalTrafficPolicy: Local as we believed we had a
need to preserve client ip addrs to perform whitelisting tasks.

we have since discovered that we can relax this need and have removed
our use of ip whitelisting of resources from the system.

we suspect having the ingress loadbalancer service in
`externalTrafficPolicy: Local` mode has contributed to problems we have
seen during node rollouts (slower to update target groups on loss of a
node) and control plane upgrades (load balancers in a poor state after
upgrade - potentially as this configuration is less common and less
tested by the masses).