### PR TITLE
ensure canary deploys from a trusted release

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -186,6 +186,7 @@ data:
   cloudHsmIp: {{ $.Values.global.cloudHsm.ip | b64enc }}
   privateKey: {{ $.Values.global.cluster.privateKey | b64enc }}
   publicKey: {{ $.Values.global.cluster.publicKey | b64enc }}
+  releaseVersion: {{ $.Values.global.cluster.releaseVersion | b64enc }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -30,6 +30,11 @@ spec:
       source:
         repository: ((concourse.harbor-resource-image))
         tag: ((concourse.harbor-resource-tag))
+    - name: github
+      type: registry-image
+      source:
+        repository: ((concourse.github-resource-image))
+        tag: ((concourse.github-resource-tag))
 
     resources:
     - name: timer
@@ -39,10 +44,18 @@ spec:
         interval: 2m
 
     - name: src
-      type: git
+      type: github
       icon: github-circle
       source:
         uri: https://github.com/alphagov/gsp.git
+        organization: alphagov
+        owner: alphagov
+        repository: gsp
+        github_api_token: ((github.api-token))
+        access_token: ((github.api-token))
+        approvers: ((trusted-developers.github-accounts))
+        required_approval_count: 0
+        branch: ((cluster.releaseVersion))
         paths:
         - components/canary
 

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -5,6 +5,7 @@ global:
     domain: "example.com"
     domain_id: ""
     egressIpAddresses: ["127.0.0.1"]
+    releaseVersion: master
   account:
     name: ""
   roles:

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -179,6 +179,7 @@ apply_cluster_chart: &apply_cluster_chart
         --set "googleOauthClientSecret=${GOOGLE_OAUTH_CLIENT_SECRET}" \
         --set "global.cluster.privateKey=${CLUSTER_PRIVATE_KEY}" \
         --set "global.cluster.publicKey=${CLUSTER_PUBLIC_KEY}" \
+        --set "global.cluster.releaseVersion=${RELEASE_TAG}" \
         --output-dir manifests \
         gsp/gsp-cluster-*.tgz
       echo "rendering gsp-istio chart..."
@@ -189,6 +190,7 @@ apply_cluster_chart: &apply_cluster_chart
         --values config/${CONFIG_VALUES_PATH} \
         --values managed-namespaces-values/gateways-values.yaml \
         --set global.runningOnAws=true \
+        --set "global.cluster.releaseVersion=${RELEASE_TAG}" \
         gsp/gsp-istio-*.tgz
       rm -rf manifests/gsp-istio/charts/istio-cni
       helm template \
@@ -197,6 +199,7 @@ apply_cluster_chart: &apply_cluster_chart
         --output-dir kube-system-manifests \
         --values config/${CONFIG_VALUES_PATH} \
         --set global.runningOnAws=true \
+        --set "global.cluster.releaseVersion=${RELEASE_TAG}" \
         gsp/gsp-istio-*.tgz
       function apply() {
         echo "applying ${1} from ${CHART_NAME} chart..."


### PR DESCRIPTION
## What

* Use our github-resource (albeit in a configuration that doesn't fully test it) in the cd-smoke-test pipeline
* Make use of the `((trusted-developers.github-accounts))` and `((github.api-token))` secrets to ensure their existance
* Pull the canary source from the `((cluster.release))` that the cluster was deployed from instead of `master` so it is in sync with the deployment

## Why

* So that changes to the canary are not rolled out to clusters that are not ready for the new changes yet
* So that we at least know that the github-resource work as we are not testing it anywhere else
* So that we know that the secrets (which we tell service teams to use in their pipelines) actually exist

Closes #214