### PR TITLE
AUT70: Add 3 new log group names

### DIFF
--- a/modules/gsp-cluster/monitoring-system.tf
+++ b/modules/gsp-cluster/monitoring-system.tf
@@ -49,3 +49,17 @@ resource "aws_cloudwatch_log_group" "logs" {
   retention_in_days = 30
 }
 
+resource "aws_cloudwatch_log_group" "application_logs" {
+  name              = "/aws/containerinsights/${var.cluster_name}/application"
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_group" "host_logs" {
+  name              = "/aws/containerinsights/${var.cluster_name}/host"
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_group" "dataplane_logs" {
+  name              = "/aws/containerinsights/${var.cluster_name}/dataplane"
+  retention_in_days = 30
+}

--- a/modules/gsp-cluster/splunk-system.tf
+++ b/modules/gsp-cluster/splunk-system.tf
@@ -10,6 +10,42 @@ module "k8s_lambda_splunk_forwarder" {
   splunk_index              = var.k8s_splunk_index
 }
 
+module "k8s_app_lambda_splunk_forwarder" {
+  source                    = "../lambda_splunk_forwarder"
+  enabled                   = var.splunk_enabled
+  name                      = "application"
+  cloudwatch_log_group_arn  = aws_cloudwatch_log_group.application_logs.arn
+  cloudwatch_log_group_name = aws_cloudwatch_log_group.application_logs.name
+  cluster_name              = var.cluster_name
+  splunk_hec_token          = var.k8s_splunk_hec_token
+  splunk_hec_url            = var.splunk_hec_url
+  splunk_index              = var.k8s_splunk_index
+}
+
+module "k8s_host_lambda_splunk_forwarder" {
+  source                    = "../lambda_splunk_forwarder"
+  enabled                   = var.splunk_enabled
+  name                      = "host"
+  cloudwatch_log_group_arn  = aws_cloudwatch_log_group.host_logs.arn
+  cloudwatch_log_group_name = aws_cloudwatch_log_group.host_logs.name
+  cluster_name              = var.cluster_name
+  splunk_hec_token          = var.k8s_splunk_hec_token
+  splunk_hec_url            = var.splunk_hec_url
+  splunk_index              = var.k8s_splunk_index
+}
+
+module "k8s_dataplane_lambda_splunk_forwarder" {
+  source                    = "../lambda_splunk_forwarder"
+  enabled                   = var.splunk_enabled
+  name                      = "dataplane"
+  cloudwatch_log_group_arn  = aws_cloudwatch_log_group.dataplane_logs.arn
+  cloudwatch_log_group_name = aws_cloudwatch_log_group.dataplane_logs.name
+  cluster_name              = var.cluster_name
+  splunk_hec_token          = var.k8s_splunk_hec_token
+  splunk_hec_url            = var.splunk_hec_url
+  splunk_index              = var.k8s_splunk_index
+}
+
 module "eks_lambda_splunk_forwarder" {
   source                    = "../lambda_splunk_forwarder"
   enabled                   = var.splunk_enabled


### PR DESCRIPTION
This change adds three new log group names and configures Lambda Splunk Forwarder to start forwarding these log groups to Splunk.

1. /aws/containerinsights/Cluster_Name/application: it contains all log files in /var/log/containers
2. /aws/containerinsights/Cluster_Name/host: it contains logs from /var/log/dmesg, /var/log/secure, and /var/log/messages
3. /aws/containerinsights/Cluster_Name/dataplane: it contains logs in /var/log/journal for kubelet.service, kubeproxy.service, and docker.service. Please note that kubeproxy is running in pod and will appear in the application group.

AWS CloudWatch documentation (https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html) uses these three log group names.

Author: @adityapahuja