### PR TITLE
fix: quench KubeVersionMismatch alert

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
@@ -22,7 +22,7 @@ spec:
           {{`There are {{ $value }} different semantic versions of Kubernetes
           components running.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
-      expr: count(count by(major, minor) (kubernetes_build_info))
+      expr: count(count by (gitVersion) (label_replace(kubernetes_build_info,"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*).*"))
         > 1
       for: 1h
       labels:


### PR DESCRIPTION
This alert, last touched in f1ef6a3d2d8c2a2fb0b001b22a7fb89489837844,
was firing.  This was because some components have a `minor` label of
`14` and some have `14+` so the alert treats these as two different
versions of kubernetes.

This partly reverts f1ef6a3d2d8c2a2fb0b001b22a7fb89489837844 back to
the regex way of doing things, but edits the regex to only look at the
first two components of the `gitVersion` label (ie 1.14, not 1.14.6).
This should silence the currently firing KubeVersionMismatch alerts.