### PR TITLE
AUT70: Add missing resources to cloudwatch_log_shipping_policy

### DIFF
--- a/modules/gsp-cluster/monitoring-system.tf
+++ b/modules/gsp-cluster/monitoring-system.tf
@@ -18,7 +18,12 @@ data "aws_iam_policy_document" "cloudwatch_log_shipping_policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = [aws_cloudwatch_log_group.logs.arn]
+    resources = [
+      aws_cloudwatch_log_group.logs.arn,
+      aws_cloudwatch_log_group.application_logs.arn,
+      aws_cloudwatch_log_group.dataplane_logs.arn,
+      aws_cloudwatch_log_group.host_logs.arn,
+    ]
   }
 }
 


### PR DESCRIPTION
This change allows cloudwatch_log_shipping_role to have access to the following three new resources.

1. application_logs
2. dataplane_logs
2. host_logs

Author: @adityapahuja