### PR TITLE
Fix syntax of KubeVersionMismatch rule

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/templates/rules-kubernetes-system.yaml
@@ -22,7 +22,7 @@ spec:
           {{`There are {{ $value }} different semantic versions of Kubernetes
           components running.`}}
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch
-      expr: count(count by (gitVersion) (label_replace(kubernetes_build_info,"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*).*"))
+      expr: count(count by (gitVersion) (label_replace(kubernetes_build_info,"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*).*")))
         > 1
       for: 1h
       labels:


### PR DESCRIPTION
The  "prometheusrules" is invalid: : group "kubernetes-system", rule 1,
"KubeVersionMismatch": could not parse expression: parse error at char 123:
unclosed left parenthesis