### PR TITLE
Remove public access to the Habor API/Portal

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/harbor-virtual-service.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/harbor-virtual-service.yaml
@@ -16,32 +16,10 @@ spec:
   http:
   - match:
     - uri:
-        prefix: /api/
-    - uri:
-        prefix: /service/
-    - uri:
         prefix: /v2/
-    - uri:
-        prefix: /chartrepo/
-    - uri:
-        prefix: /c/
     route:
     - destination:
         host: gsp-harbor-core
-        port:
-          number: 80
-      {{- if .Values.global.runningOnAws }}
-      headers:
-        request:
-          set:
-            "x-forwarded-proto": "https"
-      {{- end }}
-  - match:
-    - uri:
-        prefix: /
-    route:
-    - destination:
-        host: gsp-harbor-portal
         port:
           number: 80
       {{- if .Values.global.runningOnAws }}


### PR DESCRIPTION
We don't require access to the portal at all. We reference the internal
harbor API service when we require API access. We only require API
access from within the cluster.