### PR TITLE
Allow all users to see NLB tags

### DIFF
--- a/modules/gsp-user/iam.tf
+++ b/modules/gsp-user/iam.tf
@@ -69,8 +69,12 @@ resource "aws_iam_role_policy_attachment" "user-defaults-iam" {
   policy_arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "user-defaults-load-balancing-read-only" {
+  role       = aws_iam_role.user.name
+  policy_arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingReadOnly"
+}
+
 resource "aws_iam_role_policy_attachment" "user-defaults-view-only" {
   role       = aws_iam_role.user.name
   policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }
-


### PR DESCRIPTION
Currently, we tag our NLBs to make it clear which
namespace/service/whatever they belong to.  However
ordinary (non-full-IAM-admin) users don't have permission to see these
tags.  Confusingly, if you don't have
`elasticloadbalancing:DescribeTags` permissions, the AWS Console will
tell you that the loadbalancer doesn't have any tags, not that you
don't have permission to see the tags.

Also confusingly, ViewOnlyAccess doesn't give permission to see load
balancer tags, even though it gives permission to see all sorts of
other tags.

Attaching the ElasticLoadBalancingReadOnly managed policy is
sufficient to allow users to see NLB tags.  I have tested this in
sandbox using admin powers on my non-admin user :snowflake: