### PR TITLE
Remove non-essential, non-registry related Harbor routes

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/harbor-virtual-service.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/harbor-virtual-service.yaml
@@ -16,32 +16,12 @@ spec:
   http:
   - match:
     - uri:
-        prefix: /api/
-    - uri:
         prefix: /service/
     - uri:
         prefix: /v2/
-    - uri:
-        prefix: /chartrepo/
-    - uri:
-        prefix: /c/
     route:
     - destination:
         host: gsp-harbor-core
-        port:
-          number: 80
-      {{- if .Values.global.runningOnAws }}
-      headers:
-        request:
-          set:
-            "x-forwarded-proto": "https"
-      {{- end }}
-  - match:
-    - uri:
-        prefix: /
-    route:
-    - destination:
-        host: gsp-harbor-portal
         port:
           number: 80
       {{- if .Values.global.runningOnAws }}


### PR DESCRIPTION
This should remove routes that are not essential to regular Docker registry interactions (for example `docker pull/push`).

This might work, or might not work. This time round I'll actually do a bit more checking to see that sandbox is actually working before promoting.