### PR TITLE
Cleanup old client IP safelisting stuff

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -215,6 +215,10 @@ apply_cluster_chart: &apply_cluster_chart
       apply manifests/gsp-istio/charts/istio
       apply manifests/${CHART_NAME}/templates/01-aws-system/
       apply manifests/
+      kubectl delete handler -n gsp-system harbor-ip-safelist || true
+      kubectl delete instance -n gsp-system harbor-ip-safelist-originip || true
+      kubectl delete rule -n gsp-system harbor-api-ip-safelist || true
+      kubectl delete rule -n gsp-system harbor-portal-ip-safelist || true
   inputs:
   - name: cluster-values
   - name: config


### PR DESCRIPTION
We are just blocking the things we were concerned about being open
entirely therefore removing the need for the safelist.

This cleans up the resources that have been removed as part of a
previous PR[1].

This can be reverted once it's deployed everywhere.

[1] https://github.com/alphagov/gsp/pull/746