### PR TITLE
Allow configured namespaces to connect to the PSN.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
@@ -11,6 +11,9 @@ metadata:
 {{- if .talksToHsm }}
     talksToHsm: "true"
 {{- end }}
+{{- if .talksToPsn }}
+    talksToPsn: "true"
+{{- end }}
   annotations:
     iam.amazonaws.com/permitted: {{ $permittedRolesRegex | quote }}
 {{- end }}


### PR DESCRIPTION
Feels like this should be replaced by a `additionalNamespaceLabels` cluster-config construct. But that's a bigger change than the scope of this story.