### PR TITLE
make everyone an Editor in grafana org=1

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -171,6 +171,8 @@ gsp-monitoring:
           root_url: https://grafana.${cluster_domain}
         users:
           viewers_can_edit: true
+          auto_assign_org: true
+          auto_assign_org_role: Editor
 
 serviceOperator:
   kiamServerRoleARN: ${kiam_server_role_arn}


### PR DESCRIPTION
allow everyone to edit dashboards in grafana.

even though we do not persist grafana configuration (prefuring to setup
dashboards declaratively) it is still useful to be able to click around
and make changes in the UI to test out dashboard changes.

the viewers_can_edit permisisons only gets us so far, but is missing
some key editing features like "creating a dashboard"

:information_source: not actually sure this will work for oauth users, or maybe it will only work for "new" oauth users, so might want to give grafana pod a kick to clear out it's state if this doesn't have an immediate effect.