### PR TITLE
Follow-up #761: Fix release pipeline by uploading pipeline directory

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -686,7 +686,7 @@ jobs:
       commitish: platform-version/ref
       globs:
       - cluster-package/*
-      - deployer-package/*
+      - deployer-package/pipelines/deployer/*
       - istio-package/*
     get_params:
       include_source_tarball: true


### PR DESCRIPTION
uploading /tmp/build/put/deployer-package/pipelines
error running command: the asset to upload can't be a directory