### PR TITLE
Avoid bash syntax error in check-canary, add pipefail

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -309,7 +309,8 @@ check_canary: &check_canary
   run:
     path: /bin/bash
     args:
-      - -eu
+      - -euo
+      - pipefail
       - -c
       - |
         now="$(date '+%s')"


### PR DESCRIPTION
If curl fails we don't want it going `/bin/bash: line 5: [: : integer expression expected`