### PR TITLE
resolve check-logging flakes for fast loggroups

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -387,7 +387,7 @@ check_cloudwatch: &check_cloudwatch
 
         echo "   Logs Since: $LOGS_SINCE"
         echo "    Logs Seen: $LASTSEENLOG"
-        if (( ${LASTSEENLOG} > ${LOGS_SINCE} )); then
+        if (( ${LASTSEENLOG} >= ${LOGS_SINCE} )); then
           echo "PASS: Logs have been reached cloudwatch"
           echo "Logs received at: $LASTSEENLOG in $LOGGROUP"
           exit 0


### PR DESCRIPTION
the eks logs arrive fast, and the acuracy of the timestamp is not enough
causing the test to fail as there are logs since exactly the time
requested.