### PR TITLE
Expose the ingress and egress IPs in the terraform output.

### DIFF
--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -196,3 +196,10 @@ output "cluster_domain" {
   value = var.cluster_domain
 }
 
+output "provisioned_eips_marked_for_ingress" {
+  value = module.gsp-network.ingress_ips
+}
+
+output "egress_ips" {
+  value = module.gsp-network.egress_ips
+}


### PR DESCRIPTION
We get requests for this information a lot. So it makes sense to print
them out during the deployment pipeline for easy reference.