### PR TITLE
build and package aws-node-lifecycle-hook release

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -683,14 +683,16 @@ jobs:
         - -c
         - |
           if [ "$PLATFORM_RESOURCE_TYPE" == "github-release" ]; then
-            # This task only necessary for the git resource type
-            exit 0
+            echo "copying aws-node-lifecycle-hook..."
+            cp platform/aws-node-lifecycle-hook-*.zip platform/modules/k8s-cluster/aws-node-lifecycle-hook.zip
+          else
+            echo "building aws-node-lifecycle-hook"
+            cd platform/components/aws-node-lifecycle-hook
+            go build
+            apt-get update
+            apt install -y zip
+            zip ../../modules/k8s-cluster/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook
           fi
-          cd platform/components/aws-node-lifecycle-hook
-          go build
-          apt-get update
-          apt install -y zip
-          zip ../../modules/k8s-cluster/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook
       inputs:
       - name: platform
       outputs:

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -79,6 +79,12 @@ resources:
     branch: ((branch))
     commit_verification_keys: ((trusted-developer-keys))
 
+- name: aws-node-lifecycle-hook
+  type: s3
+  source:
+    bucket: ((readonly_private_bucket_name))
+    versioned_file: aws-node-lifecycle-hook.zip
+
 - name: concourse-task-toolbox-source
   type: github
   source:
@@ -339,7 +345,7 @@ jobs:
       inputs:
       - name: aws-node-lifecycle-hook-source
       outputs:
-      - name: aws-node-lifecycle-hook
+      - name: aws-node-lifecycle-hook-zip
       run:
         path: /bin/bash
         args:
@@ -347,10 +353,17 @@ jobs:
           - pipefail
           - -c
           - |
-            mkdir -p aws-node-lifecycle-hook
-            cd components/aws-node-lifecycle-hook
+            mkdir -p aws-node-lifecycle-hook-zip
+            cd aws-node-lifecycle-hook-source/components/aws-node-lifecycle-hook
+            echo "running aws-node-lifecycle-hook tests..."
             go test -v ./...
-            go build
+            echo "building components/aws-node-lifecycle-hook..."
+            go build -o aws-node-lifecycle-hook
+            echo "zipping up lambda binary..."
+            zip aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook
+  - put: aws-node-lifecycle-hook
+    params:
+      file: aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip
 
 - name: build-concourse-github-resource
   serial: true
@@ -470,7 +483,7 @@ jobs:
     - get: platform
       passed: [selfupdate]
       trigger: true
-    - get: aws-node-lifecycle-hook-source
+    - get: aws-node-lifecycle-hook
       passed: [build-aws-node-lifecycle-hook]
       trigger: true
     - get: concourse-task-toolbox
@@ -526,7 +539,7 @@ jobs:
       passed: [bump-version]
     - get: service-operator-source
       passed: [build-service-operator]
-    - get: aws-node-lifecycle-hook-source
+    - get: aws-node-lifecycle-hook
       passed: [build-aws-node-lifecycle-hook]
     - get: concourse-task-toolbox-source
       passed: [build-concourse-task-toolbox]
@@ -734,23 +747,6 @@ jobs:
           cat overrides.yaml
           echo "merging with default values..."
           spruce merge ./platform/pipelines/deployer/deployer.defaults.yaml ./overrides.yaml | tee ./deployer-package/pipelines/deployer/deployer.defaults.yaml
-  - task: package-aws-node-lifecycle-hook
-    image: concourse-task-toolbox
-    config:
-      platform: linux
-      inputs:
-      - name: platform
-      - name: aws-node-lifecycle-hook-source
-      outputs:
-      - name: aws-node-lifecycle-hook-package
-      run:
-        path: /bin/bash
-        args:
-        - -euo pipefail
-        - -c
-        - |
-          mkdir -p aws-node-lifecycle-hook-package/
-          zip aws-node-lifecycle-hook-package/modules/k8s-cluster/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook-package/components/aws-node-lifecycle-hook/aws-node-lifecycle-hook
   - put: candidate-release
     params:
       name: semver/version
@@ -761,7 +757,7 @@ jobs:
       - cluster-package/*
       - deployer-package/pipelines/deployer/*
       - istio-package/*
-      - aws-node-lifecycle-hook-package/*
+      - aws-node-lifecycle-hook/aws-node-lifecycle-hook.zip
     get_params:
       include_source_tarball: true
   - task: sign-release


### PR DESCRIPTION
build the lifecycle hook lambda binary, zip it up and store it in s3
(for use elsewhere in release pipelin) then package it up along with the
main gsp release (for consumption by public/deployer pipelines)

updates the deployer pipelines to consume the released zip when the
resource type is set to release.