### PR TITLE
remove redundent keys.vars.yaml from selfupdate

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -642,7 +642,6 @@ jobs:
         - platform/pipelines/deployer/deployer.defaults.yaml
         - config/((config-path))
         - trusted-contributors/github.vars.yaml
-        - trusted-contributors/keys.vars.yaml
 
 - name: deploy
   serial: true

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -301,7 +301,6 @@ jobs:
         config_file: platform/pipelines/release/release.yaml
         vars_files:
         - trusted-contributors/github.vars.yaml
-        - trusted-contributors/keys.vars.yaml
         vars:
           branch: ((branch))
           pipeline-name: ((pipeline-name))


### PR DESCRIPTION
we have removed the gpg keys requirements, so no longer require that
selfupdate adds the secrets for the keys to the pipeline during
selfupdate