### PR TITLE
Add CLS integration support

### DIFF
--- a/modules/gsp-cluster/splunk-system.tf
+++ b/modules/gsp-cluster/splunk-system.tf
@@ -9,6 +9,13 @@ module "k8s_lambda_splunk_forwarder" {
   splunk_hec_url            = var.splunk_hec_url
   splunk_index              = var.k8s_splunk_index
 }
+resource "aws_cloudwatch_log_subscription_filter" "legacy_logs" {
+  count           = var.cls_destination_enabled == "1" ? 1 : 0
+  name            = "legacy_logs"
+  log_group_name  = aws_cloudwatch_log_group.logs.name
+  filter_pattern  = ""
+  destination_arn = var.cls_destination_arn
+}
 
 module "k8s_app_lambda_splunk_forwarder" {
   source                    = "../lambda_splunk_forwarder"
@@ -20,6 +27,13 @@ module "k8s_app_lambda_splunk_forwarder" {
   splunk_hec_token          = var.k8s_splunk_hec_token
   splunk_hec_url            = var.splunk_hec_url
   splunk_index              = var.k8s_splunk_index
+}
+resource "aws_cloudwatch_log_subscription_filter" "application_logs" {
+  count           = var.cls_destination_enabled == "1" ? 1 : 0
+  name            = "application_logs"
+  log_group_name  = aws_cloudwatch_log_group.application_logs.name
+  filter_pattern  = ""
+  destination_arn = var.cls_destination_arn
 }
 
 module "k8s_host_lambda_splunk_forwarder" {
@@ -33,6 +47,13 @@ module "k8s_host_lambda_splunk_forwarder" {
   splunk_hec_url            = var.splunk_hec_url
   splunk_index              = var.k8s_splunk_index
 }
+resource "aws_cloudwatch_log_subscription_filter" "host_logs" {
+  count           = var.cls_destination_enabled == "1" ? 1 : 0
+  name            = "host_logs"
+  log_group_name  = aws_cloudwatch_log_group.host_logs.name
+  filter_pattern  = ""
+  destination_arn = var.cls_destination_arn
+}
 
 module "k8s_dataplane_lambda_splunk_forwarder" {
   source                    = "../lambda_splunk_forwarder"
@@ -44,6 +65,13 @@ module "k8s_dataplane_lambda_splunk_forwarder" {
   splunk_hec_token          = var.k8s_splunk_hec_token
   splunk_hec_url            = var.splunk_hec_url
   splunk_index              = var.k8s_splunk_index
+}
+resource "aws_cloudwatch_log_subscription_filter" "dataplane_logs" {
+  count           = var.cls_destination_enabled == "1" ? 1 : 0
+  name            = "dataplane_logs"
+  log_group_name  = aws_cloudwatch_log_group.dataplane_logs.name
+  filter_pattern  = ""
+  destination_arn = var.cls_destination_arn
 }
 
 module "eks_lambda_splunk_forwarder" {
@@ -57,4 +85,10 @@ module "eks_lambda_splunk_forwarder" {
   splunk_hec_url            = var.splunk_hec_url
   splunk_index              = var.k8s_splunk_index
 }
-
+resource "aws_cloudwatch_log_subscription_filter" "eks_logs" {
+  count           = var.cls_destination_enabled == "1" ? 1 : 0
+  name            = "eks_logs"
+  log_group_name  = module.k8s-cluster.eks-log-group-name
+  filter_pattern  = ""
+  destination_arn = var.cls_destination_arn
+}

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -183,3 +183,13 @@ variable "enable_nlb" {
   description = "create an NLB for the worker nodes"
 }
 
+variable "cls_destination_enabled" {
+  default = "0"
+  type    = string
+}
+
+variable "cls_destination_arn" {
+  default = ""
+  type    = string
+}
+

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -35,3 +35,5 @@ github-resource-tag: latest
 
 terraform-resource-image: govsvc/terraform-resource
 terraform-resource-tag: latest
+
+cls-destination-enabled: false

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -85,6 +85,15 @@ variable "enable_nlb" {
   default = "0"
 }
 
+variable "cls_destination_enabled" {
+  type    = string
+  default = "0"
+}
+
+variable "cls_destination_arn" {
+  type = string
+}
+
 data "aws_caller_identity" "current" {
 }
 
@@ -161,6 +170,9 @@ module "gsp-cluster" {
   github_client_secret = var.github_client_secret
 
   enable_nlb = var.enable_nlb
+
+  cls_destination_enabled = var.cls_destination_enabled
+  cls_destination_arn     = var.cls_destination_arn
 }
 
 output "kubeconfig" {

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -578,6 +578,8 @@ resources:
       enable_nlb: ((enable-nlb))
       ci_worker_instance_type: ((ci-worker-instance-type))
       ci_worker_count: ((ci-worker-count))
+      cls_destination_enabled: ((cls-destination-enabled))
+      cls_destination_arn: ((cls-destination-arn))
 - name: user-state
   type: terraform
   source:

--- a/pipelines/examples/clusters/sandbox.yaml
+++ b/pipelines/examples/clusters/sandbox.yaml
@@ -35,3 +35,4 @@ config-path: "pipelines/examples"
 config-trigger: false
 users-trigger: false
 enable-nlb: true
+cls-destination-enabled: false


### PR DESCRIPTION
Destination to be enabled on a per-cluster basis (so we can start off with
sandbox and see how things look), and the destination ARN will come from a Big
Concourse secret, due to containing the CLS account ID.