### PR TITLE
Fix path that aws-node-lifecycle-hook binary gets zipped to in release

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -365,7 +365,7 @@ jobs:
               go build -o aws-node-lifecycle-hook \
             )
             echo "zipping up lambda binary..."
-            zip aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook-source/components/aws-node-lifecycle-hook/aws-node-lifecycle-hook
+            zip aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook-source/aws-node-lifecycle-hook
   - put: aws-node-lifecycle-hook
     params:
       file: aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip


### PR DESCRIPTION
The deployer pipeline copies this to the expected location, and this was the
old path anyway.