### PR TITLE
Follow-up #799: Fix aws-node-lifecycle-hook release

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -362,10 +362,10 @@ jobs:
             echo "building components/aws-node-lifecycle-hook..."
             (
               cd aws-node-lifecycle-hook-source/components/aws-node-lifecycle-hook && \
-              go build -o aws-node-lifecycle-hook \
+              go build -o ../../../aws-node-lifecycle-hook \
             )
             echo "zipping up lambda binary..."
-            zip aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook-source/aws-node-lifecycle-hook
+            zip aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip aws-node-lifecycle-hook
   - put: aws-node-lifecycle-hook
     params:
       file: aws-node-lifecycle-hook-zip/aws-node-lifecycle-hook.zip


### PR DESCRIPTION
That changed not only the place it was putting the file inside the zip but also
the place it looks for the file.