### PR TITLE
Revert "Temporarily re-allow existing instance types"

### DIFF
--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -33,8 +33,6 @@ Parameters:
       - m5a.4xlarge
       - m5a.12xlarge
       - m5a.24xlarge
-      - m5d.large
-      - m5d.xlarge
       - c5.large
       - c5.xlarge
       - c5.2xlarge

--- a/modules/k8s-cluster/data/nodegroup.yaml
+++ b/modules/k8s-cluster/data/nodegroup.yaml
@@ -41,8 +41,6 @@ Parameters:
       - m5.4xlarge
       - m5.12xlarge
       - m5.24xlarge
-      - m5d.large
-      - m5d.xlarge
       - c4.large
       - c4.xlarge
       - c4.2xlarge


### PR DESCRIPTION
This reverts commits e1b9475691788bab68731726e64f3118ad2550a2 and be3edf543c72fdee1a9337176e7082b522e98bd6.

Don't merge until we've done https://github.com/alphagov/tech-ops-cluster-config/pull/274 and https://github.com/alphagov/tech-ops-cluster-config/pull/275