### PR TITLE
build(svcop): use GOPROXY to fetch go modules

### DIFF
--- a/components/service-operator/Dockerfile
+++ b/components/service-operator/Dockerfile
@@ -28,6 +28,7 @@ ENV CGO_ENABLED="0"
 ENV GOOS="linux"
 ENV GOARCH="amd64"
 ENV GO111MODULE="on"
+ENV GOPROXY=https://proxy.golang.org,direct
 
 # Build args for integration testing
 ARG AWS_INTEGRATION="false"

--- a/components/service-operator/go.mod
+++ b/components/service-operator/go.mod
@@ -21,7 +21,3 @@ require (
 // two different hashes floating around
 // https://github.com/gomodules/jsonpatch/issues/21
 replace gomodules.xyz/jsonpatch/v2 => gomodules.xyz/jsonpatch/v2 v2.0.1
-
-// fix broken upstream
-// https://github.com/dominikh/go-tools/issues/658
-replace honnef.co/go/tools => github.com/dominikh/go-tools v0.0.0-20190102054323-c2f93a96b099

--- a/components/service-operator/go.sum
+++ b/components/service-operator/go.sum
@@ -86,7 +86,6 @@ github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsv
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
-github.com/dominikh/go-tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:qBNLV2EQXN9hMDGPA+nlUNDKcPCtmEvCC8iVgA6uBic=
 github.com/dropbox/godropbox v0.0.0-20190501155911-5749d3b71cbe/go.mod h1:glr97hP/JuXb+WMYCizc4PIFuzw1lCR97mwbe1VVXhQ=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=


### PR DESCRIPTION
This sets the GOPROXY environment variable to the default version in
go 1.13.  This means we fetch modules from the golang.org go proxy,
rather than direct.  This would have avoided the issues we saw with
honnef.co the other day (so I have reverted that change).  I also
think that it may make the build faster on concourse; it's worth a go.

In any case, when we upgrade to go 1.13, this will be the default
setting so we might as well try it out now.