### PR TITLE
svcop: document dead-letter queue support

### DIFF
--- a/components/service-operator/apis/queue/v1beta1/sqs_types_test.go
+++ b/components/service-operator/apis/queue/v1beta1/sqs_types_test.go
@@ -67,8 +67,11 @@ var _ = Describe("SQS", func() {
 
 		It("should have outputs for connection details", func() {
 			t := sqs.GetStackTemplate()
-			Expect(t.Outputs).To(HaveKey("QueueURL"))
-			Expect(t.Outputs).To(HaveKey("IAMRoleName"))
+			Expect(t.Outputs).To(And(
+				HaveKey("QueueURL"),
+				HaveKey("DLQueueURL"),
+				HaveKey("IAMRoleName"),
+			))
 		})
 
 		It("should map role name to role parameter", func() {

--- a/components/service-operator/controllers/sqs_cloudformation_test.go
+++ b/components/service-operator/controllers/sqs_cloudformation_test.go
@@ -135,6 +135,7 @@ var _ = Describe("SQSCloudFormationController", func() {
 				return secret.Data
 			}).Should(And(
 				HaveKey("QueueURL"),
+				HaveKey("DLQueueURL"),
 				HaveKey("IAMRoleName"),
 			))
 		})

--- a/docs/gds-supported-platform/gsp-service-operator.md
+++ b/docs/gds-supported-platform/gsp-service-operator.md
@@ -87,7 +87,7 @@ This will create a Postgres database on AWS including the name alexs-test-db, wi
 
 ## How to connect to a created queue
 
-The URL of the Queue will be stored inside the `secret` you specified as `QueueURL`. If you make a pod like:
+The URL of the Queue will be stored inside the `secret` you specified as `QueueURL` (in addition, if you specified the `redriveMaxReceiveCount` parameter in the spec a redrive policy will have been configured with it pointing at the queue URL stored in key `DLQueueURL`). If you make a pod like:
 ```
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
also add the output to a few places we were listing the ordinary queue URL