### PR TITLE
Add control-plane label to kube-system.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/kube-system-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-system-namespace.yaml
@@ -7,3 +7,4 @@ metadata:
     namespace: kube-system
     istio-injection: disabled
     kube-system: "true"
+    control-plane: "true"


### PR DESCRIPTION
If a node is removed that carries the only running instance of a webhook
target without a notification to the apiserver the control-plane
effectively breaks because the webhook is called as part of controller-
manager calls into the apiserver. Excluding the kube control-plane from
such checks allows the cluster to continue to function.