### PR TITLE
svcop: Permit overriding dummy cloudformation outputs in tests

### DIFF
--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -142,6 +142,8 @@ var _ = Describe("PostgresCloudFormationController", func() {
 			}).Should(And(
 				HaveKey("hosts"),
 				HaveKey("ports"),
+				HaveKey("addresses"),
+				HaveKey("endpoints"),
 				HaveKey("location"),
 				HaveKey("resolution"),
 				HaveKey("exportTo"),
@@ -155,6 +157,8 @@ var _ = Describe("PostgresCloudFormationController", func() {
 			}).Should(And(
 				HaveKey("hosts"),
 				HaveKey("ports"),
+				HaveKey("addresses"),
+				HaveKey("endpoints"),
 				HaveKey("location"),
 				HaveKey("resolution"),
 				HaveKey("exportTo"),

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -115,10 +115,16 @@ func SetupControllerEnv() (client.Client, func()) {
 
 	// controllers under test
 	cs := []controllers.Controller{
-		controllers.S3CloudFormationController(newAWSClient()),
-		controllers.SQSCloudFormationController(newAWSClient()),
-		controllers.PrincipalCloudFormationController(newAWSClient()),
-		controllers.PostgresCloudFormationController(newAWSClient()),
+		controllers.S3CloudFormationController(newAWSClient(nil)),
+		controllers.SQSCloudFormationController(newAWSClient(nil)),
+		controllers.PrincipalCloudFormationController(newAWSClient(nil)),
+		controllers.PostgresCloudFormationController(newAWSClient(map[string]string{
+			"Endpoint": "something.local.govsandbox.uk",
+			"ReadEndpoint": "something-ro.local.govsandbox.uk",
+			"Port": "3306",
+			"Username": "someusername",
+			"Password": "snakeoil",
+		})),
 	}
 
 	// wrap controllers in error checkers and register with manager
@@ -158,7 +164,7 @@ func reconcileErrorMonitor(controller *controllers.ControllerWrapper, stop chan 
 	}
 }
 
-func newAWSClient() sdk.Client {
+func newAWSClient(fakeOutputs map[string]string) sdk.Client {
 	if env.AWSIntegrationTestEnabled() {
 		return sdk.NewClient()
 	} else {
@@ -167,6 +173,6 @@ func newAWSClient() sdk.Client {
 		os.Setenv("AWS_RDS_SUBNET_GROUP_NAME", "dummy-value")
 		os.Setenv("AWS_PRINCIPAL_SERVER_ROLE_ARN", "dummy-value")
 		os.Setenv("AWS_PRINCIPAL_PERMISSIONS_BOUNDARY_ARN", "dummy-value")
-		return sdkfakes.NewHappyClient()
+		return sdkfakes.NewHappyClient(fakeOutputs)
 	}
 }

--- a/components/service-operator/internal/aws/sdk/sdkfakes/fake_client_happy.go
+++ b/components/service-operator/internal/aws/sdk/sdkfakes/fake_client_happy.go
@@ -39,7 +39,7 @@ type FakeTemplate struct {
 //
 // stacks returned from DescribeStack methods will contain Outputs extracted from
 // the template used in CreateStack.
-func NewHappyClient() *FakeClient {
+func NewHappyClient(outputs map[string]string) *FakeClient {
 
 	var transitionDelay = time.Second * 2 // how long before switching from CREATING->CREATED etc
 	var client = &FakeClient{}
@@ -67,7 +67,7 @@ func NewHappyClient() *FakeClient {
 			stack.Outputs = append(stack.Outputs, &cloudformation.Output{
 				Description: aws.String(v.Description),
 				OutputKey:   aws.String(k),
-				OutputValue: aws.String("0"),
+				OutputValue: aws.String(outputs[k]),
 			})
 		}
 	}


### PR DESCRIPTION
And use it in RDS to ensure we get a hostname we can resolve.