### PR TITLE
CloudForm a default desired worker node count of maximum

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -103,7 +103,7 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
       count.index,
     )}"
     NodeAutoScalingGroupMinSize         = var.minimum_workers_per_az_count
-    NodeAutoScalingGroupDesiredCapacity = var.minimum_workers_per_az_count
+    NodeAutoScalingGroupDesiredCapacity = var.maximum_workers_per_az_count
     NodeAutoScalingGroupMaxSize         = var.maximum_workers_per_az_count
     NodeInstanceType                    = var.worker_instance_type
     NodeInstanceProfile                 = aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceProfile"]


### PR DESCRIPTION
We think that when the launch template changes CloudFormation resets the
desired count away from whatever the autoscaler left back to what we put in
CloudFormation. This leads to the cluster scaling down to the minimum size as
old nodes are killed and replaced only with the minimum amount.
The cluster should heal itself when (if) the autoscaler comes back up, but we
may prefer a situation where it creates more than it needs and then the
autoscaler is responsible for removing unnecessary nodes.