### PR TITLE
add ServiceEntry for s3 global endpoint too

### DIFF
--- a/components/service-operator/controllers/s3_cloudformation_test.go
+++ b/components/service-operator/controllers/s3_cloudformation_test.go
@@ -53,6 +53,10 @@ var _ = Describe("S3CloudFormationController", func() {
 				Namespace: namespace,
 				Name:      fmt.Sprintf("%s-0", serviceEntryName),
 			}
+			serviceEntryNamespacedName1 = types.NamespacedName{
+				Namespace: namespace,
+				Name:      fmt.Sprintf("%s-1", serviceEntryName),
+			}
 			principal = access.Principal{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: access.GroupVersion.Group,
@@ -151,12 +155,25 @@ var _ = Describe("S3CloudFormationController", func() {
 			}).Should(HaveKey("IAMRoleName"))
 		})
 
-		By("creating a service entry with the endpoints", func() {
+		By("creating a service entry with the regional s3 endpoint", func() {
 			Eventually(func() map[string]interface{} {
 				_ = client.Get(ctx, serviceEntryNamespacedName0, &serviceEntry)
 				return serviceEntry.Spec
 			}).Should(And(
-				HaveKey("hosts"),
+				HaveKeyWithValue("hosts", ContainElement(ContainSubstring("s3.eu-west-2.amazonaws.com"))),
+				HaveKey("ports"),
+				HaveKey("location"),
+				HaveKey("resolution"),
+				HaveKey("exportTo"),
+			))
+		})
+
+		By("creating a second service entry with the global s3 endpoint", func() {
+			Eventually(func() map[string]interface{} {
+				_ = client.Get(ctx, serviceEntryNamespacedName1, &serviceEntry)
+				return serviceEntry.Spec
+			}).Should(And(
+				HaveKeyWithValue("hosts", ContainElement(ContainSubstring("s3.amazonaws.com"))),
 				HaveKey("ports"),
 				HaveKey("location"),
 				HaveKey("resolution"),

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -115,15 +115,20 @@ func SetupControllerEnv() (client.Client, func()) {
 
 	// controllers under test
 	cs := []controllers.Controller{
-		controllers.S3CloudFormationController(newAWSClient(nil)),
+		controllers.S3CloudFormationController(newAWSClient(map[string]string{
+			"S3BucketName":   "testbucket",
+			"S3BucketRegion": "eu-west-2",
+			"S3BucketURL":    "https://testbucket.s3.eu-west-2.amazonaws.com",
+			"IAMRoleName":    "testrole",
+		})),
 		controllers.SQSCloudFormationController(newAWSClient(nil)),
 		controllers.PrincipalCloudFormationController(newAWSClient(nil)),
 		controllers.PostgresCloudFormationController(newAWSClient(map[string]string{
-			"Endpoint": "something.local.govsandbox.uk",
+			"Endpoint":     "something.local.govsandbox.uk",
 			"ReadEndpoint": "something-ro.local.govsandbox.uk",
-			"Port": "3306",
-			"Username": "someusername",
-			"Password": "snakeoil",
+			"Port":         "3306",
+			"Username":     "someusername",
+			"Password":     "snakeoil",
 		})),
 	}
 


### PR DESCRIPTION
ensure that istio knows about the global s3 endpoint for any svc-op
provisioned s3 buckets.

sometimes the sdk talks to the regional s3 endpoint
(xxx.s3.eu-west-2.amazonaws.com) and sometimes it talks to the global s3
endpoint (xxx.s3.amazonaws.com) this means we should create
ServiceEntries for both.

also make the region a little less hard-coded, by doing some of the work to read it from outputs 