### PR TITLE
Encode Grafana admin password as it can contain special characters

### DIFF
--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -54,7 +54,7 @@ data "template_file" "values" {
     rds_from_worker_security_group   = aws_security_group.rds-from-worker.id
     private_db_subnet_group          = aws_db_subnet_group.private.id
     external_dns_iam_role_name       = aws_iam_role.external_dns.name
-    grafana_default_admin_password   = random_password.grafana_default_admin_password.result
+    grafana_default_admin_password   = jsonencode(random_password.grafana_default_admin_password.result)
     eks_version                      = var.eks_version
     cert_manager_role_name           = aws_iam_role.cert_manager.name
     permitted_roles_regex = "^(${join(


### PR DESCRIPTION
I had one generated starting with a close curly bracket `}`, this lead to an
error like:
Error: failed to parse cluster-values/values.yaml: error converting YAML to
JSON: yaml: line 169: did not find expected node content