### PR TITLE
Override Terraform desired worker counts in existing clusters with current values

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -7,6 +7,7 @@ module "k8s-cluster" {
   cluster_name                 = var.cluster_name
   worker_instance_type         = var.worker_instance_type
   minimum_workers_per_az_count = var.minimum_workers_per_az_count
+  desired_workers_per_az_map   = var.desired_workers_per_az_map
   maximum_workers_per_az_count = var.maximum_workers_per_az_count
   ci_worker_count              = var.ci_worker_count
   ci_worker_instance_type      = var.ci_worker_instance_type

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -64,6 +64,11 @@ variable "minimum_workers_per_az_count" {
   default = "1"
 }
 
+variable "desired_workers_per_az_map" {
+  type    = map(number)
+  default = {}
+}
+
 variable "maximum_workers_per_az_count" {
   type    = string
   default = "5"

--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -200,7 +200,7 @@ Resources:
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MaxBatchSize: 1
-        MinInstancesInService: !Ref NodeAutoScalingGroupDesiredCapacity
+        MinInstancesInService: !Ref NodeAutoScalingGroupMinInstancesInService
         PauseTime: PT5M
 
   NodeLaunchTemplate:

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -36,6 +36,11 @@ variable "minimum_workers_per_az_count" {
   default = "1"
 }
 
+variable "desired_workers_per_az_map" {
+  type    = map(number)
+  default = {}
+}
+
 variable "maximum_workers_per_az_count" {
   type    = string
   default = "5"

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -57,6 +57,11 @@ variable "minimum_workers_per_az_count" {
   type = string
 }
 
+variable "desired_workers_per_az_map" {
+  type    = map(number)
+  default = {}
+}
+
 variable "maximum_workers_per_az_count" {
   type = string
 }
@@ -154,6 +159,7 @@ module "gsp-cluster" {
   worker_eks_version           = var.worker_eks_version
   worker_instance_type         = var.worker_instance_type
   minimum_workers_per_az_count = var.minimum_workers_per_az_count
+  desired_workers_per_az_map   = var.desired_workers_per_az_map
   maximum_workers_per_az_count = var.maximum_workers_per_az_count
   ci_worker_instance_type      = var.ci_worker_instance_type
   ci_worker_count              = var.ci_worker_count

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -731,10 +731,44 @@ jobs:
                   echo "done"
               fi
           fi
+  - task: generate-terraform-var-overrides
+    image: task-toolbox
+    timeout: 40s
+    params:
+      CLUSTER_NAME: ((cluster-name))
+      ACCOUNT_ROLE_ARN: ((account-role-arn))
+      AWS_REGION: eu-west-2
+      AWS_DEFAULT_REGION: eu-west-2
+    config:
+      platform: linux
+      run:
+        path: /bin/bash
+        args:
+        - -euo
+        - pipefail
+        - -c
+        - |
+          echo "assuming aws deployer role..."
+          AWS_CREDS="$(aws-assume-role $ACCOUNT_ROLE_ARN)"
+          eval "${AWS_CREDS}"
+          # Look for worker node ASGs for this cluster and make a map of their AZs to desired counts
+          export JQ_FILTER=$(echo '{desired_workers_per_az_map: [' \
+            '.AutoScalingGroups[] | ' \
+             "select (.Tags | from_entries .Name | startswith(\"$CLUSTER_NAME-worker-\")) | " \
+            '{key: .AvailabilityZones[0], value: .DesiredCapacity}' \
+          '] | from_entries}')
+          export DESIRED_MAP=$(aws autoscaling describe-auto-scaling-groups | jq "$JQ_FILTER")
+          mkdir -p terraform-var-overrides
+          echo $DESIRED_MAP
+          echo $DESIRED_MAP > terraform-var-overrides/overrides.tfvars.json
+      outputs:
+      - name: terraform-var-overrides
   - put: cluster-state
     params:
       env_name: ((account-name))
       terraform_source: platform/pipelines/deployer
+      var_files:
+      - terraform-var-overrides/overrides.tfvars.json
   - task: generate-user-terraform
     image: task-toolbox
     timeout: 10m


### PR DESCRIPTION
We want these to be managed by the cluster autoscaler, not Terraform.