### PR TITLE
Reduce traffic sampling sent to jaeger to 5%

### DIFF
--- a/charts/gsp-istio/values.yaml
+++ b/charts/gsp-istio/values.yaml
@@ -73,7 +73,7 @@ istio:
       replicaCount: 2
       autoscaleMin: 2
   pilot:
-    traceSampling: "100.0"
+    traceSampling: "5.0" # send 5% of traffic to jaeger
     replicaCount: 2
     autoscaleMin: 2
   prometheus:


### PR DESCRIPTION
drop the percentage of traffic sent to jaeger/tracing from 100% down to
5%.

The "out of the box" jaeger bundled with istio is struggling in
production deployments to handle 100% sampling rate, the istio-tracing
workloads end up using 10GB+ of ram and stealing alot of the node's CPU.

We don't currently rely heavily on the tracing ui/visualizations that
jaeger bring to the table so we are happy dropping the sample rate
significantly.

If in the future we want to take advantage of sampling every single
request, then we should consider using the [jaeger operator](https://github.com/jaegertracing/jaeger-operator) to deploy a
more production-grade scalable deployment, since the istio-bundled one is
really just ment to get you started.