### PR TITLE
add layer:cicd label to canary alert

### DIFF
--- a/components/canary/chart/templates/prometheus-rules.yaml
+++ b/components/canary/chart/templates/prometheus-rules.yaml
@@ -17,3 +17,4 @@ spec:
       expr: time() - max(canary_chart_commit_timestamp{namespace="{{ .Release.Namespace }}"}) without (pod) > 600
       labels:
         severity: critical
+        layer: cicd


### PR DESCRIPTION
we only route alerts to the re-autom8-alerts channel that have a "layer"
label present... so this adds a suitable label of "cicd" to denote that
this alert is related to the continuous delivery system and to ensure it
gets piped to the channel.

## Related

https://github.com/alphagov/prometheus-aws-configuration-beta/pull/354