### PR TITLE
Remove the temporary removal of gatekeeper sync resource

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -183,9 +183,6 @@ apply_cluster_chart: &apply_cluster_chart
       kubectl config set-context $(kubectl config get-contexts -o name) \
         --namespace "${DEFAULT_NAMESPACE}"
       echo "RELEASE_TAG=${RELEASE_TAG}"
-      ### Temporary tidyup
-      kubectl -n gsp-system delete --ignore-not-found=true config config
-      ### End of temporary tidyup
       echo "rendering ${CHART_NAME} chart..."
       mkdir -p manifests
       mkdir -p kube-system-manifests


### PR DESCRIPTION
This change has been deployed out and can be removed now.