### PR TITLE
disable autoscaling of ingressgateways

### DIFF
--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -30,11 +30,11 @@ istio:
       labels:
         app: istio-ingressgateway
         istio: {{ $namespace.name }}-ingressgateway
-      autoscaleEnabled: true
-      autoscaleMin: 2
-      autoscaleMax: 5
+      autoscaleEnabled: false
+      autoscaleMin: 3
+      autoscaleMax: 3
       # specify replicaCount when autoscaleEnabled: false
-      # replicaCount: 1
+      replicaCount: 3
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
fix the number of ingressgateways replicas to 3 instances and disable the
HPA (HorizontalPodAutoscaler) for all managed-namespaces.

We have evidence that connections are getting dropped when the
ingressgateways are scaled-in, and are seeing the HPA agressively scale
in/out the ingressgateways (possibly due to the low-traffic they
encounter).

We intend to fix the ingressgateways at 3 replicas for now and monitor the
situation, if we stop seeing the check-canary failures after this point,
then this will be strong evidence that the HPA of the ingressgateways
with low-traffic was the source of the issues and we can revisit how/if
we should/could re-enable autoscaling to maintain the cost benefits it
brings.