### PR TITLE
hardcode autoscaling of ingressgateways to 3x

### DIFF
--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -30,7 +30,7 @@ istio:
       labels:
         app: istio-ingressgateway
         istio: {{ $namespace.name }}-ingressgateway
-      autoscaleEnabled: false
+      autoscaleEnabled: true
       autoscaleMin: 3
       autoscaleMax: 3
       # specify replicaCount when autoscaleEnabled: false


### PR DESCRIPTION
fix the number of ingressgateways replicas to 3 instances and
(effectivly) disable the HPA (HorizontalPodAutoscaler) for all
managed-namespaces.

We believe that connections are sometimes getting dropped when the
ingressgateways are scaled-in, and are seeing the HPA agressively scale
in/out the ingressgateways (possibly due to the low-traffic they
encounter).

We intend to fix the ingressgateways at 3 replicas and monitor the
situation, if we stop seeing the check-canary failures after this point,
then this will be strong evidence that the HPA of the ingressgateways
with low-traffic was the source of the issues and we can revisit how/if
we should/could re-enable autoscaling to maintain the cost benefits it
brings.