### PR TITLE
Delete svcop resources on cluster destroy

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -462,6 +462,10 @@ drain_cluster_task: &drain_cluster_task
       echo "fetching kubeconfig from aws..."
       aws eks update-kubeconfig --name "${CLUSTER_NAME}" --kubeconfig ./kubeconfig
       export KUBECONFIG=$(pwd)/kubeconfig
+
+      export RESOURCE_TYPES=$(kubectl get crd -o json | jq -r '.items[] | select (.spec.group | endswith(".govsvc.uk")) | .spec.names.singular')
+      kubectl delete -A --all $(echo $RESOURCE_TYPES | tr ' ' ',')
+
       echo "fetching cluster VPC ID..."
       CLUSTER_VPC_ID=$(aws eks describe-cluster --name "${CLUSTER_NAME}" | jq .cluster.resourcesVpcConfig.vpcId -r)
       echo "deleting any LoadBalancer services..."


### PR DESCRIPTION
We don't want anything left around costing money that isn't being managed by
a cluster. Also if you leave e.g. Postgres stuff lying around, terraform destroy can
fail due to trying to remove stuff like DB Subnet Groups and Security Groups that
are still in use.