### PR TITLE
Remove timeout for drain step in cluster destroy.

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -900,7 +900,6 @@ jobs:
       PLATFORM_RESOURCE_TYPE: ((platform-resource-type))
   - task: drain-cluster
     image: task-toolbox
-    timeout: 30m
     config: *drain_cluster_task
     params:
       ACCOUNT_ROLE_ARN: ((account-role-arn))


### PR DESCRIPTION
Several contributing factors:
- ASG scale-down goes in 5 minute steps (so if one AZ has 6 nodes that's
  30 minutes)
- deleting AWS resources such as RDS can take significant time (~12 mins)
- predicting how long a sensible timeout would be is nearly impossible for
  a dynamic payload
- the "deploy" step has no timeout