### PR TITLE
reduce time waiting between node launches to 2 minutes

### DIFF
--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -206,7 +206,7 @@ Resources:
       AutoScalingRollingUpdate:
         MaxBatchSize: 1
         MinInstancesInService: !Ref NodeAutoScalingGroupMinInstancesInService
-        PauseTime: PT5M
+        PauseTime: PT2M
 
   NodeLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate


### PR DESCRIPTION
We currently wait 5 minutes after terminating and launching an
instance in the worker node group ASG.

We now have lifecycle hooks to ensure we are confident that terminated
instances have successfully evicted their pods onto other nodes.

I think we could *possibly* get rid of PauseTime entirely, but this is
a more conservative proposal for now.