### PR TITLE
Set log forwarding runtime to python3.7

### DIFF
--- a/modules/lambda_splunk_forwarder/lambda.tf
+++ b/modules/lambda_splunk_forwarder/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "lambda_log_forwarder" {
 
   role        = "${aws_iam_role.lambda_log_forwarder[0].arn}"
   handler     = "lambda_function.lambda_handler"
-  runtime     = "python3.6"
+  runtime     = "python3.7"
   timeout     = "120"
   memory_size = "128"
   description = "A function to forward logs from AWS to a Splunk HEC using a manual zip of https://github.com/alphagov/cyber-cloudwatch-fluentd-to-hec"


### PR DESCRIPTION
I built the ZIP in #847 from a Debian Buster VM instead of something else like
Ubuntu Bionic, and the default version of Python 3 was 3.7 rather than 3.6.
This should be fine. However it does seem to mean we need to bump the version
of python used to run the lambda.

Alternatively I could make the ZIP again using a distro with Python 3.6 by
default, or attempt to get Python 3.6 on Debian Buster and make the ZIP
build process use that.