### PR TITLE
remove cd-smoke-test serial group

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -69,7 +69,6 @@ spec:
     jobs:
     - name: build
       serial: true
-      serial_groups: [smoke-test]
       plan:
       - get: timer
         trigger: true
@@ -85,7 +84,6 @@ spec:
 
     - name: deploy
       serial: true
-      serial_groups: [smoke-test]
       plan:
       - get: src
         passed: ["build"]


### PR DESCRIPTION
the serial-group, preventing the "build" and "deploy" jobs of the
cd-smoke-test pipeline running at the same time, was added to work
around the notary-only-signs-latest-tag bug. This bug is no longer a
factor as we are not signing the images with notary, so it's fine to
deploy old versions of images and we can safely remove the serial group.