### PR TITLE
Add pod security policies as described by ADR044.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/gsp-default-psp-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/gsp-default-psp-cluster-role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gsp-default-psp
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - gsp-default
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/gsp-cluster/templates/00-aws-auth/gsp-default-psp-default-role-binding.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/gsp-default-psp-default-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gsp-default-psp
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gsp-default-psp
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated

--- a/charts/gsp-cluster/templates/00-aws-auth/gsp-default-psp.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/gsp-default-psp.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: gsp-default
+  seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  # Assume that persistentVolumes set up by the cluster admin are safe to use.
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false

--- a/charts/gsp-cluster/templates/00-aws-auth/psp-system-bindings.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/psp-system-bindings.yaml
@@ -1,0 +1,43 @@
+# based on https://docs.aws.amazon.com/eks/latest/userguide/pod-security-policy.html
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eks:podsecuritypolicy:authenticated
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eks:podsecuritypolicy:privileged
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eks:podsecuritypolicy:authenticated
+  namespace: gsp-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eks:podsecuritypolicy:privileged
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eks:podsecuritypolicy:authenticated
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eks:podsecuritypolicy:privileged
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -356,4 +356,18 @@ spec:
               kubectl apply -n ${RELEASE_NAMESPACE} -R -f "./src/${PATH_TO_MANIFESTS}"
 ---
 {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gsp-default-psp
+  namespace: {{ .name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gsp-default-psp
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:authenticated
 {{- end }}

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -183,6 +183,8 @@ apply_cluster_chart: &apply_cluster_chart
       kubectl config set-context $(kubectl config get-contexts -o name) \
         --namespace "${DEFAULT_NAMESPACE}"
       echo "RELEASE_TAG=${RELEASE_TAG}"
+      echo "Removing EKS-provided pod security policy clusterrolebinding (if it exists)"
+      kubectl delete --ignore-not-found=true clusterrolebinding eks:podsecuritypolicy:authenticated
       echo "rendering ${CHART_NAME} chart..."
       mkdir -p manifests
       mkdir -p kube-system-manifests


### PR DESCRIPTION
As a first pass we make use of the existing EKS-provided security policy
for the *-system namespaces, with the more restrictive policy being
deployed across all tenant namespaces.