### PR TITLE
Isolate DNS management per namespace.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ output/
 *.coverprofile
 .idea/
 modules/k8s-cluster/aws-node-lifecycle-hook.zip
+pipelines/deployer/managed-namespaces-zones.tf

--- a/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.namespaces }}
 {{- $defaultedPermittedRolesRegex := .permittedRolesRegex | default "^$" }}
-{{- $permittedRolesRegex := printf "%s|^svcop-%s-%s-.*$|^%s$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name $.Values.externalDns.iamRoleName }}
+{{- $permittedRolesRegex := printf "%s|^svcop-%s-%s-.*$|^%s-%s-external-dns$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name $.Values.global.cluster.name .name }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
@@ -21,16 +21,13 @@
 #
 # The various resources were then updated manually with necessary templating to bring inline with gsp-cluster
 
-
-{{- $allNamespaces := prepend $.Values.namespaces (dict "name" "gsp-system" "ingress" (dict "enabled" true)) }}
-{{- range $allNamespaces }}
-{{- if (default dict .ingress).enabled }}
+{{- range .Values.external_dns }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $.Release.Name }}-external-dns
-  namespace: {{ .name }}
+  namespace: {{ .namespace }}
   labels:
     app.kubernetes.io/name: external-dns
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
@@ -40,7 +37,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ $.Release.Name }}-external-dns-{{ .name }}
+  name: {{ $.Release.Name }}-external-dns-{{ .namespace }}
   labels:
     app.kubernetes.io/name: external-dns
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
@@ -53,13 +50,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ $.Release.Name }}-external-dns
-  namespace: {{ .name }}
+  namespace: {{ .namespace }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $.Release.Name }}-external-dns
-  namespace: {{ .name }}
+  namespace: {{ .namespace }}
   labels:
     app.kubernetes.io/name: external-dns
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
@@ -80,7 +77,7 @@ spec:
         app.kubernetes.io/managed-by: {{ $.Release.Service }}
 {{ if $.Values.global.runningOnAws }}
       annotations:
-        iam.amazonaws.com/role: {{ $.Values.externalDns.iamRoleName }}
+        iam.amazonaws.com/role: {{ .role_name }}
 {{ end }}
     spec:
       securityContext:
@@ -94,14 +91,17 @@ spec:
         args:
         # Generic arguments
         - --log-level=info
+        - --zone-id-filter={{ .zone_id }}
+        {{- if eq .namespace "gsp-system" }}
         - --zone-id-filter={{ $.Values.global.cluster.domain_id }}
+        {{- end }}
         - --policy=upsert-only
         - --provider=aws
         - --registry=txt
-        - --interval=1m
-        - --txt-owner-id=external-dns-{{ $.Values.global.cluster.name }}-{{ .name }}
-        - --annotation-filter=externaldns.k8s.io/namespace={{ .name }}
-        - --istio-ingress-gateway={{ .name }}/{{ .name }}-ingressgateway
+        - --interval=10m
+        - --txt-owner-id=external-dns-{{ $.Values.global.cluster.name }}-{{ .namespace }}
+        - --annotation-filter=externaldns.k8s.io/namespace={{ .namespace }}
+        - --istio-ingress-gateway={{ .namespace }}/{{ .namespace }}-ingressgateway
         - --source=istio-gateway
         # AWS arguments
         - --aws-zone-type=public
@@ -165,7 +165,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $.Release.Name }}-external-dns
-  namespace: {{ .name }}
+  namespace: {{ .namespace }}
   labels:
     app.kubernetes.io/name: external-dns
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
@@ -181,5 +181,4 @@ spec:
       app.kubernetes.io/name: external-dns
       app.kubernetes.io/instance: {{ $.Release.Name }}
   type: ClusterIP
-{{- end}}
 {{- end}}

--- a/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
@@ -35,7 +35,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: {{ $.Release.Name }}-external-dns-{{ .namespace }}
   labels:

--- a/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
@@ -21,7 +21,7 @@
 #
 # The various resources were then updated manually with necessary templating to bring inline with gsp-cluster
 
-{{- range .Values.external_dns }}
+{{- range .Values.externalDns }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -77,7 +77,7 @@ spec:
         app.kubernetes.io/managed-by: {{ $.Release.Service }}
 {{ if $.Values.global.runningOnAws }}
       annotations:
-        iam.amazonaws.com/role: {{ .role_name }}
+        iam.amazonaws.com/role: {{ .roleName }}
 {{ end }}
     spec:
       securityContext:
@@ -91,7 +91,7 @@ spec:
         args:
         # Generic arguments
         - --log-level=info
-        - --zone-id-filter={{ .zone_id }}
+        - --zone-id-filter={{ .zoneId }}
         {{- if eq .namespace "gsp-system" }}
         - --zone-id-filter={{ $.Values.global.cluster.domain_id }}
         {{- end }}

--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -191,12 +191,12 @@ spec:
           image_resource: *task_toolbox
           params:
             CLUSTER_DOMAIN: ((cluster.domain))
-            CLUSTER_NAME: ((cluster.name))
+            NAMESPACE: ((namespace-deployer.namespace))
           run:
             path: /bin/bash
             args:
               - -eu
               - -c
               - |
-                echo "pinging https://canary.${CLUSTER_NAME}-main.${CLUSTER_DOMAIN}/metrics to check ingress..."
-                curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_NAME}-main.${CLUSTER_DOMAIN}/metrics
+                echo "pinging https://canary.${NAMESPACE}.${CLUSTER_DOMAIN}/metrics to check ingress..."
+                curl --silent --show-error --max-time 5 --fail https://canary.${NAMESPACE}.${CLUSTER_DOMAIN}/metrics

--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -191,11 +191,12 @@ spec:
           image_resource: *task_toolbox
           params:
             CLUSTER_DOMAIN: ((cluster.domain))
+            CLUSTER_NAME: ((cluster.name))
           run:
             path: /bin/bash
             args:
               - -eu
               - -c
               - |
-                echo "pinging https://canary.${CLUSTER_DOMAIN}/metrics to check ingress..."
-                curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_DOMAIN}/metrics
+                echo "pinging https://canary.${CLUSTER_NAME}-main.${CLUSTER_DOMAIN}/metrics to check ingress..."
+                curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_NAME}-main.${CLUSTER_DOMAIN}/metrics

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -889,9 +889,6 @@ concourseResources:
       repository: govsvc/task-toolbox
       tag: latest
 
-externalDns:
-  iamRoleName: ""
-
 gatekeeper:
   enabled: true
 

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -889,6 +889,11 @@ concourseResources:
       repository: govsvc/task-toolbox
       tag: latest
 
+# externalDns:
+# - namespace: verify-metadata-controller
+#   zoneId: ZX03812
+#   roleName: verify-metadata-controller-external-dns
+
 gatekeeper:
   enabled: true
 

--- a/components/canary/chart/templates/gateway.yaml
+++ b/components/canary/chart/templates/gateway.yaml
@@ -20,7 +20,7 @@ spec:
     tls:
       httpsRedirect: true
     hosts:
-    - "canary.{{ .Values.global.cluster.domain }}"
+    - "canary.{{ .Release.Namespace }}.{{ .Values.global.cluster.domain }}"
   - port:
       number: 443
       name: https
@@ -31,4 +31,4 @@ spec:
       privateKey: sds
       credentialName: {{ include "gsp-canary.fullname" . }}-ingress-certificate
     hosts:
-    - "canary.{{ .Values.global.cluster.domain }}"
+    - "canary.{{ .Release.Namespace }}.{{ .Values.global.cluster.domain }}"

--- a/components/canary/chart/templates/ingress-certificate.yaml
+++ b/components/canary/chart/templates/ingress-certificate.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   secretName: {{ include "gsp-canary.fullname" . }}-ingress-certificate
   dnsNames:
-  - "canary.{{ .Values.global.cluster.domain }}"
+  - "canary.{{ .Release.Namespace }}.{{ .Values.global.cluster.domain }}"
   issuerRef:
     name: letsencrypt-r53
     kind: ClusterIssuer

--- a/components/canary/chart/templates/virtual-service.yaml
+++ b/components/canary/chart/templates/virtual-service.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   hosts:
-  - canary.{{ .Values.global.cluster.domain }}
+  - canary.{{ .Release.Namespace }}.{{ .Values.global.cluster.domain }}
   gateways:
   - {{ include "gsp-canary.fullname" . }}-ingress
   http:

--- a/hack/lint-terraform-values-output.sh
+++ b/hack/lint-terraform-values-output.sh
@@ -64,13 +64,13 @@ namespaces:
   ingress:
     enabled: true
 - name: test-operators
-external_dns:
+externalDns:
 - namespace: gsp-system
-  role_name: sandbox-gsp-system-external-dns
-  zone_id: gspsystem
+  roleName: sandbox-gsp-system-external-dns
+  zoneId: gspsystem
 - namespace: verify-proxy-node-build
-  role_name: sandbox-verify-proxy-node-build-external-dns
-  zone_id: proxynode
+  roleName: sandbox-verify-proxy-node-build-external-dns
+  zoneId: proxynode
 users:
 - name: chris.farmiloe
   email: chris.farmiloe@digital.cabinet-office.gov.uk
@@ -121,7 +121,7 @@ $helm template \
 		| sed 's/${concourse_teams}/["org:team"]/' \
 		| sed 's/${egress_ip_addresses}/[]/' \
 		| sed 's/${eks_version}/1.14/' \
-		| sed 's/${external_dns_map}/external_dns: []/' \
+		| sed 's/${external_dns_map}/externalDns: []/' \
 	) \
 	--values output/values.yaml \
 	--set 'global.cloudHsm.enabled=true' \

--- a/modules/gsp-cluster/cert-manager.tf
+++ b/modules/gsp-cluster/cert-manager.tf
@@ -8,9 +8,7 @@ data "aws_iam_policy_document" "cert_manager" {
       "route53:ListResourceRecordSets",
     ]
 
-    resources = [
-      "arn:aws:route53:::hostedzone/${var.cluster_domain_id}",
-    ]
+    resources = formatlist("arn:aws:route53:::hostedzone/%s", var.cluster_zone_ids)
   }
 
   statement {

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -194,8 +194,7 @@ serviceOperator:
 RDSFromWorkerSecurityGroup: ${rds_from_worker_security_group}
 privateDBSubnetGroup: ${private_db_subnet_group}
 
-externalDns:
-  iamRoleName: ${external_dns_iam_role_name}
+${external_dns_map}
 
 cert-manager:
   podAnnotations:

--- a/modules/gsp-cluster/external-dns.tf
+++ b/modules/gsp-cluster/external-dns.tf
@@ -1,48 +1,5 @@
-data "aws_iam_policy_document" "external_dns" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "route53:ChangeResourceRecordSets",
-    ]
-
-    resources = [
-      "arn:aws:route53:::hostedzone/${var.cluster_domain_id}",
-    ]
-  }
-
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "route53:ListHostedZones",
-      "route53:ListResourceRecordSets",
-    ]
-
-    resources = [
-      "*",
-    ]
+locals {
+  external_dns = {
+    "external_dns" = var.managed_namespaces_zones,
   }
 }
-
-resource "aws_iam_policy" "external_dns" {
-  name        = "${var.cluster_name}_external_dns"
-  description = "Allow external-dns to do its job"
-
-  policy = data.aws_iam_policy_document.external_dns.json
-}
-
-resource "aws_iam_role" "external_dns" {
-  name = "${var.cluster_name}_external_dns"
-
-  assume_role_policy = data.aws_iam_policy_document.trust_kiam_server.json
-}
-
-resource "aws_iam_policy_attachment" "external_dns" {
-  name = "${var.cluster_name}_external_dns"
-  roles = [
-    aws_iam_role.external_dns.name,
-  ]
-  policy_arn = aws_iam_policy.external_dns.arn
-}
-

--- a/modules/gsp-cluster/external-dns.tf
+++ b/modules/gsp-cluster/external-dns.tf
@@ -1,5 +1,5 @@
 locals {
   external_dns = {
-    "external_dns" = var.managed_namespaces_zones,
+    "externalDns" = var.managed_namespaces_zones,
   }
 }

--- a/modules/gsp-cluster/outputs.tf
+++ b/modules/gsp-cluster/outputs.tf
@@ -11,3 +11,6 @@ output "values" {
   value     = data.template_file.values.rendered
 }
 
+output "trust_kiam_server_policy_json" {
+  value = data.aws_iam_policy_document.trust_kiam_server.json
+}

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -54,7 +54,7 @@ data "template_file" "values" {
     service_operator_role_arn        = aws_iam_role.gsp-service-operator.arn
     rds_from_worker_security_group   = aws_security_group.rds-from-worker.id
     private_db_subnet_group          = aws_db_subnet_group.private.id
-    external_dns_iam_role_name       = aws_iam_role.external_dns.name
+    external_dns_map                 = yamlencode(local.external_dns)
     grafana_default_admin_password   = jsonencode(random_password.grafana_default_admin_password.result)
     eks_version                      = var.eks_version
     cert_manager_role_name           = aws_iam_role.cert_manager.name
@@ -65,10 +65,13 @@ data "template_file" "values" {
         aws_iam_role.grafana.name,
         aws_iam_role.gsp-service-operator.name,
         aws_iam_role.harbor.name,
-        aws_iam_role.external_dns.name,
         aws_iam_role.cert_manager.name,
+        # Filth.
+        # Should match the aws iam role name "template" given in
+        # templates/managed-namespaces-zones.tf
+        # for the "gsp-system" namespace
+        "${var.cluster_name}-gsp-system-external-dns",
       ],
     )})$"
   }
 }
-

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -188,3 +188,13 @@ variable "availability_zones" {
 variable "harbor_rds_skip_final_snapshot" {
   default = false
 }
+
+variable "managed_namespaces_zones" {
+  default = []
+  description = "List of details of delegated zones for managed namespaces"
+}
+
+variable "cluster_zone_ids" {
+  default = []
+  description = "List of DNS zone IDs associated with the cluster"
+}

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -189,6 +189,9 @@ module "gsp-cluster" {
   cls_destination_arn     = var.cls_destination_arn
 
   harbor_rds_skip_final_snapshot = var.harbor_rds_skip_final_snapshot
+
+  managed_namespaces_zones = local.external-dns-namespace-zones
+  cluster_zone_ids         = local.cluster_zone_ids
 }
 
 output "kubeconfig" {

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -82,6 +82,24 @@ generate_user_values: &generate_user_values
   outputs:
   - name: user-values
 
+generate_managed_namespaces_zones: &generate_managed_namespaces_zones
+  platform: linux
+  params:
+    CONFIG_VALUES_PATH:
+  run:
+    path: /bin/bash
+    args:
+    - -eu
+    - -c
+    - |
+      echo "generating external dns config for managed namespaces..."
+      gomplate -d config=config/${CONFIG_VALUES_PATH} -f platform/templates/managed-namespaces-zones.tf > platform/pipelines/deployer/managed-namespaces-zones.tf
+  inputs:
+  - name: platform
+  - name: config
+  outputs:
+  - name: platform
+
 generate_managed_namespaces_values: &generate_managed_namespaces_values
   platform: linux
   params:
@@ -306,6 +324,7 @@ check_canary: &check_canary
   platform: linux
   params:
     CLUSTER_DOMAIN:
+    CLUSTER_NAME:
   run:
     path: /bin/bash
     args:
@@ -315,9 +334,9 @@ check_canary: &check_canary
       - |
         now="$(date '+%s')"
         echo "Current time: ${now}"
-        echo "pinging https://canary.${CLUSTER_DOMAIN}/metrics to check ingress, expecting the deployment to happen soon..."
+        echo "pinging https://canary.${CLUSTER_NAME}-main.${CLUSTER_DOMAIN}/metrics to check ingress, expecting the deployment to happen soon..."
         while true; do
-          last_deploy="$(curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_DOMAIN}/metrics | awk '$1 ~ /^canary_build_timestamp/ {print $2 * 2 / 2}')"
+          last_deploy="$(curl --silent --show-error --max-time 5 --fail https://canary.${CLUSTER_NAME}-main.${CLUSTER_DOMAIN}/metrics | awk '$1 ~ /^canary_build_timestamp/ {print $2 * 2 / 2}')"
           if [ "${last_deploy}" -ge "${now}" ]; then
             echo "OK!"
             exit 0
@@ -757,6 +776,12 @@ jobs:
           echo $DESIRED_MAP > terraform-var-overrides/overrides.tfvars.json
       outputs:
       - name: terraform-var-overrides
+  - task: generate-managed-namespaces-zones
+    timeout: 10m
+    config: *generate_managed_namespaces_zones
+    image: task-toolbox
+    params:
+      CONFIG_VALUES_PATH: ((config-values-path))
   - put: cluster-state
     params:
       env_name: ((account-name))
@@ -892,6 +917,7 @@ jobs:
     config: *check_canary
     params:
       CLUSTER_DOMAIN: ((cluster-domain))
+      CLUSTER_NAME: ((cluster-name))
 
 - name: check-logging
   plan:
@@ -1022,6 +1048,12 @@ jobs:
       - name: platform
       outputs:
       - name: platform
+  - task: generate-managed-namespaces-zones
+    timeout: 10m
+    config: *generate_managed_namespaces_zones
+    image: task-toolbox
+    params:
+      CONFIG_VALUES_PATH: ((config-values-path))
   - put: cluster-state
     params:
       env_name: ((account-name))

--- a/templates/managed-namespaces-zones.tf
+++ b/templates/managed-namespaces-zones.tf
@@ -1,0 +1,110 @@
+{{- $allNamespaces := prepend (dict "name" "gsp-system" "ingress" (dict "enabled" true)) (datasource "config").namespaces }}
+{{- range $namespace := $allNamespaces }}
+{{- if (has $namespace "ingress") }}
+{{- if (has $namespace.ingress "enabled") }}
+{{- if $namespace.ingress.enabled }}
+
+resource "aws_route53_zone" "{{ $namespace.name }}" {
+  name          = "{{ $namespace.name }}.${var.cluster_domain}"
+  force_destroy = true
+}
+
+resource "aws_route53_record" "{{ $namespace.name }}-ns" {
+  zone_id  = module.gsp-domain.zone_id
+  name     = "{{ $namespace.name }}.${var.cluster_domain}"
+  type     = "NS"
+  ttl      = "30"
+
+  records = [
+    aws_route53_zone.{{ $namespace.name }}.name_servers[0],
+    aws_route53_zone.{{ $namespace.name }}.name_servers[1],
+    aws_route53_zone.{{ $namespace.name }}.name_servers[2],
+    aws_route53_zone.{{ $namespace.name }}.name_servers[3],
+  ]
+}
+
+data "aws_iam_policy_document" "{{ $namespace.name }}-external-dns" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+
+    resources = [
+      "arn:aws:route53:::hostedzone/${aws_route53_zone.{{ $namespace.name }}.zone_id}",
+{{- if eq "gsp-system" $namespace.name }}
+      "arn:aws:route53:::hostedzone/${module.gsp-domain.zone_id}",
+{{- end }}
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "{{ $namespace.name }}-external-dns" {
+  name        = "${var.cluster_name}-{{ $namespace.name }}-external-dns"
+  description = "Allow external-dns to do its job"
+
+  policy = data.aws_iam_policy_document.{{ $namespace.name }}-external-dns.json
+}
+
+resource "aws_iam_role" "{{ $namespace.name }}-external-dns" {
+  name = "${var.cluster_name}-{{ $namespace.name }}-external-dns"
+
+  assume_role_policy = module.gsp-cluster.trust_kiam_server_policy_json
+}
+
+resource "aws_iam_policy_attachment" "{{ $namespace.name }}-external-dns" {
+  name = "${var.cluster_name}-{{ $namespace.name }}-external-dns"
+  roles = [
+    aws_iam_role.{{ $namespace.name }}-external-dns.name,
+  ]
+  policy_arn = aws_iam_policy.{{ $namespace.name }}-external-dns.arn
+}
+
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+locals {
+  external-dns-namespace-zones = [
+{{- range $namespace := $allNamespaces }}
+{{- if (has $namespace "ingress") }}
+{{- if (has $namespace.ingress "enabled") }}
+{{- if $namespace.ingress.enabled }}
+    {
+      namespace = "{{ $namespace.name }}",
+      zone_id = aws_route53_zone.{{ $namespace.name }}.zone_id,
+      role_name = aws_iam_role.{{ $namespace.name }}-external-dns.name
+    },
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+  ]
+  cluster_zone_ids = [
+    module.gsp-domain.zone_id,
+{{- range $namespace := $allNamespaces }}
+{{- if (has $namespace "ingress") }}
+{{- if (has $namespace.ingress "enabled") }}
+{{- if $namespace.ingress.enabled }}
+    aws_route53_zone.{{ $namespace.name }}.zone_id,
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+  ]
+}

--- a/templates/managed-namespaces-zones.tf
+++ b/templates/managed-namespaces-zones.tf
@@ -87,8 +87,8 @@ locals {
 {{- if $namespace.ingress.enabled }}
     {
       namespace = "{{ $namespace.name }}",
-      zone_id = aws_route53_zone.{{ $namespace.name }}.zone_id,
-      role_name = aws_iam_role.{{ $namespace.name }}-external-dns.name
+      zoneId = aws_route53_zone.{{ $namespace.name }}.zone_id,
+      roleName = aws_iam_role.{{ $namespace.name }}-external-dns.name
     },
 {{- end }}
 {{- end }}


### PR DESCRIPTION
⚠️ At time of writing this is a breaking change for proxy-node (and maybe DCS as well) ⚠️ 

This is fairly ugly so let's break it down:
* uses -cluster-config to get a list of namespaces
* for each "ingress-enabled" namespace some terraform is generated to
create a route53 zone and an iam role with permissions to manage it
* iam permissions are added to the global cert-manager to allow it to
perform the DNS challenges in each delegated zone
* the iam role name is built from components in several places that
"happen to match", which is not ideal
* the canary has been updated to use its now namespace-isolated DNS name
* the deployer pipeline has been updated to ping the new DNS entry for
the canary
* the "gsp-system" instance of external-dns is able to manage the root
zone as well as its namespace-delegated one

Hopefully someone can come up with something less horrible.

## Testing

Please note that this cannot be tested in an on-demand cluster in its current state. The canary will fail to build because its changes haven't been merged via an approved PR. One way around this is to change the resource from `github` to `git` in the pipeline. I backed that change out as we don't want to merge that to master.