### PR TITLE
add advice on disabling splunk for on-demand clusters

### DIFF
--- a/docs/gds-supported-platform/bootstrapping-clusters.md
+++ b/docs/gds-supported-platform/bootstrapping-clusters.md
@@ -6,6 +6,8 @@
   * Set `config-version` to the branch name you chose.
   * Set `config-path` to the path to your new cluster YAML file, relative to the root of tech-ops-cluster-config.
   * Set `config-values-path` to the path of your new cluster values YAML file, relative to the root of tech-ops-cluster-config.
+  * Set `splunk-enabled` to "0" if you don't require Splunk in your cluster.
+
   * Set the following vars:
       * account-id: "011571571136"
       * account-name: "sandbox"
@@ -18,6 +20,7 @@
       * k8s-splunk-hec-token: "NOTATOKEN"
       * google-oauth-client-secret: "NOTID"
       * google-oauth-client-id: "NOTASECRET"
+
 * Commit and push that, open a draft PR. You don't need to get it merged.
 * Ensure your fly config has a `cd-gsp` target pointing to the `gsp` team in Big Concourse.
 * Change directory to top level of `gsp` repo


### PR DESCRIPTION

**Why**
Error: Error creating Cloudwatch log subscription filter: ResourceNotFoundException: The specified log group does not exist.
	status code: 400, request id: ae870fb7-36e4-4835-bfcf-fe601a3068a7
**What**
Add advice to documentation to disable Splunk and show how to.