### PR TITLE
add a note about being admin and change -D into --decode for operability

### DIFF
--- a/docs/gds-supported-platform/bootstrapping-clusters.md
+++ b/docs/gds-supported-platform/bootstrapping-clusters.md
@@ -38,9 +38,9 @@
 * Service-operator'd resources will not be deleted on cluster destroy.
 * After you destroy and re-create a cluster, you must `gds sandbox -c name-of-my-cluster update-kubeconfig`, or you will get errors like `Unable to connect to the server: dial tcp: lookup 8D8F3A460045AFA69F63F44F8DAB3F68.yl4.eu-west-2.eks.amazonaws.com: no such host` when trying to use kubectl.
 * You can choose a custom branch to deploy Terraform/Helm with `platform-version` (and also setting `platform-resource-type` to `git` and `platform-tag-filter` to the empty string) but this does not enable the testing of e.g. the components, the differences between the deployment pipelines, or the release pipeline.
-* Will not have external secrets - e.g. GitHub and Google integration. Therefore no Google login for Grafana, or GitHub login for Concourse.
-  * You can log into Concourse with username `pipeline-operator` and password coming from `gds sandbox -c name-of-my-cluster kubectl get -n gsp-system secret gsp-pipeline-operator -o json | jq -r '.data.concourse_password' | base64 -D -`
-  * You can log into Grafana with username `admin` and password coming from `gds sandbox -c name-of-my-cluster kubectl get -n gsp-system secret gsp-grafana -o json | jq -r '.data["admin-password"]' | base64 -D -`
+* Will not have external secrets - e.g. GitHub and Google integration. Therefore no Google login for Grafana, or GitHub login for Concourse. (NOTE: You need to be 'admin' in repo: gds-trusted-developers for these commands to function).
+  * You can log into Concourse with username `pipeline-operator` and password coming from `gds sandbox -c name-of-my-cluster kubectl get -n gsp-system secret gsp-pipeline-operator -o json | jq -r '.data.concourse_password' | base64 --decode -`
+  * You can log into Grafana with username `admin` and password coming from `gds sandbox -c name-of-my-cluster kubectl get -n gsp-system secret gsp-grafana -o json | jq -r '.data["admin-password"]' | base64 --decode -`
 
 ## Troubleshooting
 


### PR DESCRIPTION

**What**
Add note about need to be admin.
Change base64 -D into --decode.

**Why**
In discussion with @samcrang, user needs to be 'admin' rather than 'sre' in order to access the required secrets mentioned in the doc.
Also discussed with Sam, the gnubin base64 requires -d rather than -D, so altering that to --decode for compatibility between these versions.