### PR TITLE
Allow final RDS snapshot to be disabled

### DIFF
--- a/docs/gds-supported-platform/bootstrapping-clusters.md
+++ b/docs/gds-supported-platform/bootstrapping-clusters.md
@@ -20,6 +20,7 @@
       * k8s-splunk-hec-token: "NOTATOKEN"
       * google-oauth-client-secret: "NOTID"
       * google-oauth-client-id: "NOTASECRET"
+      * harbor-rds-skip-final-snapshot: true
 
 * Commit and push that, open a draft PR. You don't need to get it merged.
 * Ensure your fly config has a `cd-gsp` target pointing to the `gsp` team in Big Concourse.

--- a/modules/gsp-cluster/harbor.tf
+++ b/modules/gsp-cluster/harbor.tf
@@ -149,6 +149,7 @@ resource "aws_rds_cluster" "harbor" {
   db_subnet_group_name      = aws_db_subnet_group.private.name
   vpc_security_group_ids    = [aws_security_group.rds-from-worker.id]
   final_snapshot_identifier = "${var.cluster_name}-harbor-final"
+  skip_final_snapshot       = "${var.harbor_rds_skip_final_snapshot}"
   tags = {
     Name = var.cluster_name
   }

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -202,3 +202,7 @@ variable "availability_zones" {
   type        = list
   description = "List of availability zones for the cluster"
 }
+
+variable "harbor_rds_skip_final_snapshot" {
+  default = false
+}

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -37,3 +37,5 @@ terraform-resource-image: govsvc/terraform-resource
 terraform-resource-tag: latest
 
 cls-destination-enabled: false
+
+harbor-rds-skip-final-snapshot: false

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -99,6 +99,10 @@ variable "cls_destination_arn" {
   type = string
 }
 
+variable "harbor_rds_skip_final_snapshot" {
+  default = false
+}
+
 data "aws_caller_identity" "current" {
 }
 
@@ -183,6 +187,8 @@ module "gsp-cluster" {
 
   cls_destination_enabled = var.cls_destination_enabled
   cls_destination_arn     = var.cls_destination_arn
+
+  harbor_rds_skip_final_snapshot = var.harbor_rds_skip_final_snapshot
 }
 
 output "kubeconfig" {

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -580,6 +580,7 @@ resources:
       ci_worker_count: ((ci-worker-count))
       cls_destination_enabled: ((cls-destination-enabled))
       cls_destination_arn: ((cls-destination-arn))
+      harbor_rds_skip_final_snapshot: ((harbor-rds-skip-final-snapshot))
 - name: user-state
   type: terraform
   source:


### PR DESCRIPTION
When using on-demand clusters there's not much need to take a snapshot
when destroying the Harbor RDS cluster.

Without this change a snapshot hangs around after the cluster has gone
and stops destroys from working correctly if an on-demand cluster with
the same name is created later.