### PR TITLE
Delete PodDisruptionBudgets when destroying cluster

### DIFF
--- a/modules/gsp-cluster/harbor.tf
+++ b/modules/gsp-cluster/harbor.tf
@@ -161,6 +161,7 @@ resource "aws_rds_cluster_instance" "harbor" {
   cluster_identifier   = aws_rds_cluster.harbor.id
   engine               = "aurora-postgresql"
   engine_version       = "10.7"
+  ca_cert_identifier   = "rds-ca-2015"
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.private.name
 

--- a/modules/gsp-cluster/harbor.tf
+++ b/modules/gsp-cluster/harbor.tf
@@ -161,7 +161,7 @@ resource "aws_rds_cluster_instance" "harbor" {
   cluster_identifier   = aws_rds_cluster.harbor.id
   engine               = "aurora-postgresql"
   engine_version       = "10.7"
-  ca_cert_identifier   = "rds-ca-2015"
+  ca_cert_identifier   = "rds-ca-2019"
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.private.name
 

--- a/modules/gsp-cluster/harbor.tf
+++ b/modules/gsp-cluster/harbor.tf
@@ -162,6 +162,7 @@ resource "aws_rds_cluster_instance" "harbor" {
   engine               = "aurora-postgresql"
   engine_version       = "10.7"
   ca_cert_identifier   = "rds-ca-2019"
+  apply_immediately    = true
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.private.name
 

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -449,7 +449,11 @@ drain_cluster_task: &drain_cluster_task
       export KUBECONFIG=$(pwd)/kubeconfig
 
       export RESOURCE_TYPES=$(kubectl get crd -o json | jq -r '.items[] | select (.spec.group | endswith(".govsvc.uk")) | .spec.names.singular')
+      echo 'deleting govsvc.uk CRDs'
       kubectl delete -A --all $(echo $RESOURCE_TYPES | tr ' ' ',')
+
+      echo 'deleting PodDisruptionBudgets'
+      kubectl delete -A --all poddisruptionbudget
 
       echo "fetching cluster VPC ID..."
       CLUSTER_VPC_ID=$(aws eks describe-cluster --name "${CLUSTER_NAME}" | jq .cluster.resourcesVpcConfig.vpcId -r)


### PR DESCRIPTION
Without this change the termination lifecycle hook Lambda hangs until it
timesout as it tries to drain nodes that fail to evict pods because it
would cause a violation to pod disruption budgets.

Whilst this is sensible most of the time (for example when rolling
nodes) it's not required when destroying a cluster entirely and actually
prevents them being destroyed without intervention.