### PR TITLE
Delete PodDisruptionBudgets when destroying cluster

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -449,7 +449,11 @@ drain_cluster_task: &drain_cluster_task
       export KUBECONFIG=$(pwd)/kubeconfig
 
       export RESOURCE_TYPES=$(kubectl get crd -o json | jq -r '.items[] | select (.spec.group | endswith(".govsvc.uk")) | .spec.names.singular')
+      echo 'deleting govsvc.uk CRDs'
       kubectl delete -A --all $(echo $RESOURCE_TYPES | tr ' ' ',')
+
+      echo 'deleting PodDisruptionBudgets'
+      kubectl delete -A --all poddisruptionbudget
 
       echo "fetching cluster VPC ID..."
       CLUSTER_VPC_ID=$(aws eks describe-cluster --name "${CLUSTER_NAME}" | jq .cluster.resourcesVpcConfig.vpcId -r)


### PR DESCRIPTION
Without this change the termination lifecycle hook Lambda hangs until it
timesout as it tries to drain nodes that fail to evict pods because it
would cause a violation to pod disruption budgets.

Whilst this is sensible most of the time (for example when rolling
nodes) it's not required when destroying a cluster entirely and actually
prevents them being destroyed without intervention.