### PR TITLE
Explicitly set harbor rds root ca

### DIFF
--- a/modules/gsp-cluster/harbor.tf
+++ b/modules/gsp-cluster/harbor.tf
@@ -162,6 +162,7 @@ resource "aws_rds_cluster_instance" "harbor" {
   engine               = "aurora-postgresql"
   engine_version       = "10.7"
   apply_immediately    = true
+  ca_cert_identifier   = "rds-ca-2015"
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.private.name
 

--- a/modules/gsp-cluster/harbor.tf
+++ b/modules/gsp-cluster/harbor.tf
@@ -161,6 +161,7 @@ resource "aws_rds_cluster_instance" "harbor" {
   cluster_identifier   = aws_rds_cluster.harbor.id
   engine               = "aurora-postgresql"
   engine_version       = "10.7"
+  apply_immediately    = true
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.private.name
 


### PR DESCRIPTION
We are currently using `rds-ca-2015`. This root CA will expire soon and
a new root CA has been provided by AWS:

```
The current CA expires on March 5, 2020, requiring updates to client
applications and database instances that have certificates referencing
the current CA. Client applications must add new CA certificates (root
and intermediate where necessary) to their trust stores, and RDS
database instances must separately use new server certificates before
this hard expiration date. However, we strongly recommend you complete
these changes before February 5, 2020. After February 5, 2020, we will
begin scheduling certificate rotations for your RDS database instances
prior to the March 5, 2020 deadline. The automatic update(s) will be
scheduled within your maintenance window.
```

This commit explicitly specifies what we are currently using and
provides a commit to rollback to if things go pear-shaped 🍐.