### PR TITLE
Use latest rds root ca

### DIFF
--- a/modules/gsp-cluster/harbor.tf
+++ b/modules/gsp-cluster/harbor.tf
@@ -162,7 +162,7 @@ resource "aws_rds_cluster_instance" "harbor" {
   engine               = "aurora-postgresql"
   engine_version       = "10.7"
   apply_immediately    = true
-  ca_cert_identifier   = "rds-ca-2015"
+  ca_cert_identifier   = "rds-ca-2019"
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.private.name
 


### PR DESCRIPTION
Merge #868 first.

```
To protect your communications with RDS database instances, a CA
generates time-bound certificates that are checked by your client
applications that connect via SSL/TLS to authenticate RDS databases
before exchanging information. AWS renews the CA and creates new root
certificates every five years to ensure RDS customer connections are
properly protected for years to come.
```