### PR TITLE
Remove IAM role for Concourse workers without any policies attached

### DIFF
--- a/modules/gsp-cluster/concourse.tf
+++ b/modules/gsp-cluster/concourse.tf
@@ -1,7 +1,0 @@
-resource "aws_iam_role" "concourse" {
-  name        = "${var.cluster_name}-concourse"
-  description = "Role the concourse process assumes"
-
-  assume_role_policy = data.aws_iam_policy_document.trust_kiam_server.json
-}
-

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -11,7 +11,6 @@ global:
     name: ${account_name}
   roles:
     harbor: ${harbor_iam_role_name}
-    concourse: ${concourse_iam_role_name}
   cloudHsm:
     enabled: false
     ip: "127.0.0.1"
@@ -57,8 +56,6 @@ concourse:
     replicas: ${concourse_worker_count}
     nodeSelector:
       node-role.kubernetes.io/ci: ""
-    annotations:
-      iam.amazonaws.com/role: ${concourse_iam_role_name}
     tolerations:
       - key: "node-role.kubernetes.io/ci"
         operator: Exists

--- a/modules/gsp-cluster/kiam-system.tf
+++ b/modules/gsp-cluster/kiam-system.tf
@@ -17,7 +17,6 @@ data "aws_iam_policy_document" "kiam_server_policy" {
 
     resources = [
       aws_iam_role.cloudwatch_log_shipping_role.arn,
-      aws_iam_role.concourse.arn,
     ]
   }
 }

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -22,7 +22,6 @@ data "template_file" "values" {
     concourse_teams                  = jsonencode(concat(["main"], var.concourse_teams))
     concourse_main_team_github_teams = jsonencode(var.concourse_main_team_github_teams)
     concourse_worker_count           = var.ci_worker_count
-    concourse_iam_role_name          = aws_iam_role.concourse.name
     github_client_id                 = jsonencode(var.github_client_id)
     github_client_secret             = jsonencode(var.github_client_secret)
     github_ca_cert                   = jsonencode(var.github_ca_cert)
@@ -65,7 +64,6 @@ data "template_file" "values" {
       "|",
       [
         aws_iam_role.cloudwatch_log_shipping_role.name,
-        aws_iam_role.concourse.name,
         aws_iam_role.grafana.name,
         aws_iam_role.gsp-service-operator.name,
         aws_iam_role.harbor.name,


### PR DESCRIPTION
What good is a role without policies?

This used to have CodeCommit stuff attached, until https://github.com/alphagov/gsp/pull/171