### PR TITLE
Fix Grafana IAM role: Annotate ServiceAccount, not Pods

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -171,8 +171,9 @@ gsp-monitoring:
             - "alerts-3.monitoring.gds-reliability.engineering"
           scheme: https
     grafana:
-      podAnnotations:
-        eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/${grafana_iam_role_name}
+      serviceAccount:
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/${grafana_iam_role_name}
       adminPassword: ${grafana_default_admin_password}
       grafana.ini:
         server:


### PR DESCRIPTION
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#service-account-configuration