### PR TITLE
Set CA thumbprint for IAM OIDC provider

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -40,7 +40,12 @@ resource "aws_eks_cluster" "eks-cluster" {
 
 resource "aws_iam_openid_connect_provider" "eks" {
   client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = []
+  # the thumbprint identifies the root CA for the OIDC provider. See
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+  # in this case, this thumbprint is the thumbprint of the root CA
+  # presented by `oidc.eks.eu-west-2.amazonaws.com`; this isn't likely to change
+  # I checked and the same thumbprint applies to eu-west-1
+  thumbprint_list = [ "9E99A48A9960B14926BB7F3B02E22DA2B0AB7280" ]
   url             = aws_eks_cluster.eks-cluster.identity[0].oidc[0].issuer
 }
 


### PR DESCRIPTION
the thumbprint identifies the root CA for the OIDC provider. See
https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
in this case, this thumbprint is the thumbprint of the root CA
presented by `oidc.eks.eu-west-2.amazonaws.com`; this isn't likely to change
I checked and the same thumbprint applies to eu-west-1

This is required for IAM Roles for k8s service accounts to work.  If
you don't have this, you get an error similar to the following:

```
aws sts get-caller-identity
An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation: OpenIDConnect provider's HTTPS certificate doesn't match configured thumbprint
```