### PR TITLE
Update apigroup for concourse operator resources.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
@@ -162,7 +162,7 @@ rules:
   - list
   - watch
 
-- apiGroups: ["concourse.k8s.io"]
+- apiGroups: ["concourse.govsvc.uk"]
   resources:
   - pipelines
   verbs:
@@ -170,7 +170,7 @@ rules:
   - get
   - list
   - watch
-- apiGroups: ["concourse.k8s.io"]
+- apiGroups: ["concourse.govsvc.uk"]
   resources:
   - teams
   verbs:


### PR DESCRIPTION
The API Group for the concourse resources was recently updated to get it
off the "reserved" group suffix of 'k8s.io'. The new roles and permissions
work was done before this migration happened. This change brings the roles
in line.