### PR TITLE
Revert Grafana to use KIAM to deal with IAM roles

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -178,9 +178,8 @@ gsp-monitoring:
             - "alerts-3.monitoring.gds-reliability.engineering"
           scheme: https
     grafana:
-      serviceAccount:
-        annotations:
-          eks.amazonaws.com/role-arn: arn:aws:iam::${account_id}:role/${grafana_iam_role_name}
+      podAnnotations:
+        iam.amazonaws.com/role: ${grafana_iam_role_name}
       adminPassword: ${grafana_default_admin_password}
       grafana.ini:
         server:

--- a/modules/gsp-cluster/grafana.tf
+++ b/modules/gsp-cluster/grafana.tf
@@ -1,25 +1,7 @@
-data "aws_iam_policy_document" "trust_grafana" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-
-    principals {
-      type        = "Federated"
-      identifiers = [module.k8s-cluster.oidc_provider_arn]
-    }
-
-    condition {
-      test = "StringEquals"
-      variable = "${replace(module.k8s-cluster.oidc_provider_url, "https://", "")}:sub"
-      values = ["system:serviceaccount:gsp-system:gsp-grafana"]
-    }
-  }
-}
-
 resource "aws_iam_role" "grafana" {
   name               = "${var.cluster_name}-grafana"
   description        = "Role the Grafana process assumes"
-  assume_role_policy = data.aws_iam_policy_document.trust_grafana.json
+  assume_role_policy = data.aws_iam_policy_document.trust_kiam_server.json
 }
 
 data "aws_iam_policy_document" "grafana_cloudwatch" {


### PR DESCRIPTION
This reverts commit 21aab2202f57de90641f6a38dba09df42e025a99.
This reverts commit cd36603e6d7f382e84eec57d7bc41908141d2fdd.

It turns out that Grafana overrides the default credential provider chain, and so we can't use this right now. https://github.com/grafana/grafana/issues/20473