### PR TITLE
Update external-dns from 0.5.15 to 0.5.18

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
@@ -86,10 +86,11 @@ spec:
       securityContext:
         fsGroup: 1001
         runAsUser: 1001
+        runAsNonRoot: true
       serviceAccountName: {{ $.Release.Name }}-external-dns
       containers:
       - name: external-dns
-        image: "docker.io/bitnami/external-dns:0.5.15-debian-9-r1"
+        image: "docker.io/bitnami/external-dns:0.5.18-debian-9-r4"
         imagePullPolicy: "IfNotPresent"
         args:
         # Generic arguments
@@ -147,6 +148,12 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
+
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
 
         volumeMounts:
         # AWS mountPath(s)


### PR DESCRIPTION
So it uses a new enough version of the AWS SDK to support IAM roles for EKS.
Also includes some additional security rules that've been added to the chart
since our fork. We can probably get away without them.

I think we forked off chart version 2.5.1 or later before, this will be
equivalent to 2.14.3.

Likely conflicts with #857