### PR TITLE
Remove ingressgateway HorizontalPodAutoscaler

### DIFF
--- a/templates/managed-namespaces-gateways.yaml
+++ b/templates/managed-namespaces-gateways.yaml
@@ -30,10 +30,7 @@ istio:
       labels:
         app: istio-ingressgateway
         istio: {{ $namespace.name }}-ingressgateway
-      autoscaleEnabled: true
-      autoscaleMin: 3
-      autoscaleMax: 3
-      # specify replicaCount when autoscaleEnabled: false
+      autoscaleEnabled: false
       replicaCount: 3
       resources:
         requests:


### PR DESCRIPTION
We are causing alert noise in tenant namespace with KubeHpaMaxedOut
alerts.  This is because ingressgateways have a HPA with min = max =
3.

This commit sets `autoscaleEnabled: false` which will remove the HPA
kubeyaml.  We might need to go and manually remove the HPA objects
afterwards.

We already set `replicaCount: 3` so the Deployment should have the
correct number of replicas without `autoscaleEnabled: true`.