### PR TITLE
switch cert-manager role to use IAM roles for EKS service accounts

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -198,5 +198,6 @@ externalDns:
   iamRoleName: ${external_dns_iam_role_name}
 
 cert-manager:
-  podAnnotations:
-    iam.amazonaws.com/role: ${cert_manager_role_name}
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: ${cert_manager_role_arn}

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -66,7 +66,6 @@ data "template_file" "values" {
         aws_iam_role.gsp-service-operator.name,
         aws_iam_role.harbor.name,
         aws_iam_role.external_dns.name,
-        aws_iam_role.cert_manager.name,
       ],
     )})$"
   }

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -57,7 +57,7 @@ data "template_file" "values" {
     external_dns_iam_role_name       = aws_iam_role.external_dns.name
     grafana_default_admin_password   = jsonencode(random_password.grafana_default_admin_password.result)
     eks_version                      = var.eks_version
-    cert_manager_role_name           = aws_iam_role.cert_manager.name
+    cert_manager_role_arn            = aws_iam_role.cert_manager.arn
     permitted_roles_regex = "^(${join(
       "|",
       [


### PR DESCRIPTION
**Why**
To gain the simplicity advantage of EKS service accounts.

**What**
Alter cert-manager role to use IAM roles for EKS service accounts.

With Alex Monk @Krenair 