### PR TITLE
remove unused variable `cluster_number` from users tf

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -596,7 +596,6 @@ resources:
       account_name: ((account-name))
       cluster_name: ((cluster-name))
       cluster_domain: ((cluster-domain))
-      cluster_number: ((cluster-number))
       aws_account_role_arn: ((account-role-arn))
       github_client_id: ((github-client-id))
       github_client_secret: ((github-client-secret))


### PR DESCRIPTION
The concourse output for applying user-state has the warning:

    Warning: Value for undeclared variable

      (...)

    The root module does not declare a variable named "cluster_number". To use
    this value, add a "variable" block to the configuration.

This commit is a simple fix for that problem :)