### PR TITLE
Allow cert-manager to access EKS token

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -898,4 +898,6 @@ gatekeeper:
 cert-manager:
   replicaCount: 2
   securityContext:
+    enabled: true # remove this line when upgrading cert-manager
+                  # chart, it's deprecated on current `master`
     fsGroup: 1001

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -897,3 +897,5 @@ gatekeeper:
 
 cert-manager:
   replicaCount: 2
+  securityContext:
+    fsGroup: 1001


### PR DESCRIPTION
cert-manager runs as a non-root user, which means that it can't access
the volume containing the EKS token used to authenticate as an IAM
Role.

There is an [issue on cert-manager][1] which suggests using `fsGroup`.
From the k8s docs fsGroup is:

> A special supplemental group that applies to all containers in a
> pod. Some volume types allow the Kubelet to change the ownership of
> that volume to be owned by the pod: 1. The owning GID will be the
> FSGroup 2. The setgid bit is set (new files created in the volume
> will be owned by FSGroup) 3. The permission bits are OR'd with
> rw-rw---- If unset, the Kubelet will not modify the ownership and
> permissions of any volume.

I guess this basically means that if you set an fsGroup, your
containers can now see stuff in attached volumes.

Tested by :snowflake:ing the Deployment in sandbox.

[1]: https://github.com/jetstack/cert-manager/issues/2147