### PR TITLE
more de-kiamification of external-dns

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
@@ -1,6 +1,6 @@
 {{- range .Values.namespaces }}
 {{- $defaultedPermittedRolesRegex := .permittedRolesRegex | default "^$" }}
-{{- $permittedRolesRegex := printf "%s|^svcop-%s-%s-.*$|^%s$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name $.Values.externalDns.iamRoleName }}
+{{- $permittedRolesRegex := printf "%s|^svcop-%s-%s-.*$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name }}
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Now that external-dns uses service account IAM roles, we don't need
this hack to edit the kiam permittedRolesRegex to add the
per-namespace external-dns roles