### PR TITLE
Allow managed namespaces to use STS

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/sts-service-entry.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/sts-service-entry.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.global.runningOnAws }}
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: {{ include "gsp-cluster.fullname" . }}-aws-sts
+  labels:
+    app.kubernetes.io/name: {{ include "gsp-cluster.name" . }}-aws-sts
+    helm.sh/chart: {{ include "gsp-cluster.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  hosts:
+  - sts.amazonaws.com
+  ports:
+  - name: https
+    number: 443
+    protocol: TLS
+  location: MESH_EXTERNAL
+  resolution: DNS
+{{- end }}


### PR DESCRIPTION
This is necessary for apps in managed namespaces (such as
external-dns) to use the IAM roles for service accounts functionality.
Without this, the AWS SDK fails to authenticate.