### PR TITLE
Allow all namespaces to assume external-dns role

### DIFF
--- a/modules/gsp-cluster/external-dns.tf
+++ b/modules/gsp-cluster/external-dns.tf
@@ -9,9 +9,9 @@ data "aws_iam_policy_document" "trust_external_dns" {
     }
 
     condition {
-      test = "StringEquals"
+      test = "StringLike"
       variable = "${replace(module.k8s-cluster.oidc_provider_url, "https://", "")}:sub"
-      values = ["system:serviceaccount:gsp-system:gsp-external-dns"]
+      values = ["system:serviceaccount:*:gsp-external-dns"]
     }
   }
 }


### PR DESCRIPTION
So that per-namespace external-dns instances can work