### PR TITLE
Switch fluentd-cloudwatch role to use IAM roles for EKS service accounts

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -154,7 +154,9 @@ fluentd-cloudwatch:
   extraVars:
     - "{ name: CLUSTER_NAME, value: ${cluster_name} }"
   logGroupName: ${cloudwatch_log_group_name}
-  awsRole: ${cloudwatch_log_shipping_role}
+  rbac:
+    serviceAccountAnnotations:
+      eks.amazonaws.com/role-arn: ${cloudwatch_log_shipping_role}
   tolerations:
   - operator: Exists
     effect: NoSchedule

--- a/modules/gsp-cluster/kiam-system.tf
+++ b/modules/gsp-cluster/kiam-system.tf
@@ -10,17 +10,6 @@ data "aws_iam_policy_document" "kiam_server_role" {
   }
 }
 
-data "aws_iam_policy_document" "kiam_server_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    resources = [
-      aws_iam_role.cloudwatch_log_shipping_role.arn,
-    ]
-  }
-}
-
 # a trust relationship policy for roles we want kiam-server to assume
 data "aws_iam_policy_document" "trust_kiam_server" {
   statement {
@@ -39,19 +28,6 @@ resource "aws_iam_role" "kiam_server_role" {
   description = "Role the Kiam Server process assumes"
 
   assume_role_policy = data.aws_iam_policy_document.kiam_server_role.json
-}
-
-resource "aws_iam_policy" "kiam_server_policy" {
-  name        = "${var.cluster_name}_kiam_server_policy"
-  description = "Policy for the Kiam Server process"
-
-  policy = data.aws_iam_policy_document.kiam_server_policy.json
-}
-
-resource "aws_iam_policy_attachment" "kiam_server_policy_attach" {
-  name       = "${var.cluster_name}_kiam-server-attachment"
-  roles      = [aws_iam_role.kiam_server_role.name]
-  policy_arn = aws_iam_policy.kiam_server_policy.arn
 }
 
 resource "tls_private_key" "kiam_ca" {

--- a/modules/gsp-cluster/monitoring-system.tf
+++ b/modules/gsp-cluster/monitoring-system.tf
@@ -27,10 +27,28 @@ data "aws_iam_policy_document" "cloudwatch_log_shipping_policy" {
   }
 }
 
+data "aws_iam_policy_document" "trust_fluentd_cloudwatch" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.k8s-cluster.oidc_provider_arn]
+    }
+
+    condition {
+      test = "StringEquals"
+      variable = "${replace(module.k8s-cluster.oidc_provider_url, "https://", "")}:sub"
+      values = ["system:serviceaccount:gsp-system:gsp-fluentd-cloudwatch"]
+    }
+  }
+}
+
 resource "aws_iam_role" "cloudwatch_log_shipping_role" {
   name = "${var.cluster_name}_cloudwatch_log_shipping_role"
 
-  assume_role_policy = data.aws_iam_policy_document.trust_kiam_server.json
+  assume_role_policy = data.aws_iam_policy_document.trust_fluentd_cloudwatch.json
 }
 
 resource "aws_iam_policy" "cloudwatch_log_shipping_policy" {
@@ -42,10 +60,7 @@ resource "aws_iam_policy" "cloudwatch_log_shipping_policy" {
 
 resource "aws_iam_policy_attachment" "cloudwatch_log_shipping_policy" {
   name = "${var.cluster_name}_cloudwatch_log_shipping_role_policy_attachement"
-  roles = [
-    aws_iam_role.cloudwatch_log_shipping_role.name,
-    module.k8s-cluster.kiam-server-node-instance-role-name,
-  ]
+  roles = [aws_iam_role.cloudwatch_log_shipping_role.name]
   policy_arn = aws_iam_policy.cloudwatch_log_shipping_policy.arn
 }
 

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -48,7 +48,7 @@ data "template_file" "values" {
     kiam_server_key_b64e_pem         = base64encode(tls_private_key.kiam_server.private_key_pem)
     kiam_agent_cert_b64e_pem         = base64encode(tls_locally_signed_cert.kiam_agent.cert_pem)
     kiam_agent_key_b64e_pem          = base64encode(tls_private_key.kiam_agent.private_key_pem)
-    cloudwatch_log_shipping_role     = aws_iam_role.cloudwatch_log_shipping_role.name
+    cloudwatch_log_shipping_role     = aws_iam_role.cloudwatch_log_shipping_role.arn
     cloudwatch_log_group_name        = aws_cloudwatch_log_group.logs.name
     service_operator_boundary_arn    = aws_iam_policy.service-operator-managed-role-permissions-boundary.arn
     service_operator_role_arn        = aws_iam_role.gsp-service-operator.arn
@@ -61,7 +61,6 @@ data "template_file" "values" {
     permitted_roles_regex = "^(${join(
       "|",
       [
-        aws_iam_role.cloudwatch_log_shipping_role.name,
         aws_iam_role.grafana.name,
         aws_iam_role.harbor.name,
       ],


### PR DESCRIPTION
This includes a chart change from https://github.com/helm/charts/pull/18391 -
for some reason we have a fork of this chart?