### PR TITLE
remove unneeded variables from user-state

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -592,13 +592,8 @@ resources:
       region: eu-west-2
       key: users-((cluster-name)).tfstate
     vars:
-      account_id: ((account-id))
-      account_name: ((account-name))
       cluster_name: ((cluster-name))
-      cluster_domain: ((cluster-domain))
       aws_account_role_arn: ((account-role-arn))
-      github_client_id: ((github-client-id))
-      github_client_secret: ((github-client-secret))
 - name: task-toolbox
   type: docker-image
   source:


### PR DESCRIPTION
These aren't needed and are causing warnings in the concourse output.