### PR TITLE
specify a minimum aws provider version

### DIFF
--- a/pipelines/deployer/main.tf
+++ b/pipelines/deployer/main.tf
@@ -10,6 +10,8 @@ variable "aws_account_role_arn" {
 provider "aws" {
   region = "eu-west-2"
 
+  version = "~> 2.37"
+
   assume_role {
     role_arn = var.aws_account_role_arn
   }


### PR DESCRIPTION
[We need minimum 2.37 so we can have ca_cert_identifier in
aws_db_instance][1].  Specifying the minimum version here will force
an upgrade if anyone (say, me) has a cached aws provider of an earlier
version.

[1]: https://github.com/terraform-providers/terraform-provider-aws/issues/10489