### PR TITLE
Remove deprecated log group

### DIFF
--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -153,7 +153,6 @@ kiam:
 fluentd-cloudwatch:
   extraVars:
     - "{ name: CLUSTER_NAME, value: ${cluster_name} }"
-  logGroupName: ${cloudwatch_log_group_name}
   rbac:
     serviceAccountAnnotations:
       eks.amazonaws.com/role-arn: ${cloudwatch_log_shipping_role}

--- a/modules/gsp-cluster/monitoring-system.tf
+++ b/modules/gsp-cluster/monitoring-system.tf
@@ -19,7 +19,6 @@ data "aws_iam_policy_document" "cloudwatch_log_shipping_policy" {
     ]
 
     resources = [
-      aws_cloudwatch_log_group.logs.arn,
       aws_cloudwatch_log_group.application_logs.arn,
       aws_cloudwatch_log_group.dataplane_logs.arn,
       aws_cloudwatch_log_group.host_logs.arn,
@@ -62,11 +61,6 @@ resource "aws_iam_policy_attachment" "cloudwatch_log_shipping_policy" {
   name = "${var.cluster_name}_cloudwatch_log_shipping_role_policy_attachement"
   roles = [aws_iam_role.cloudwatch_log_shipping_role.name]
   policy_arn = aws_iam_policy.cloudwatch_log_shipping_policy.arn
-}
-
-resource "aws_cloudwatch_log_group" "logs" {
-  name              = var.cluster_domain
-  retention_in_days = 30
 }
 
 resource "aws_cloudwatch_log_group" "application_logs" {

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -49,7 +49,6 @@ data "template_file" "values" {
     kiam_agent_cert_b64e_pem         = base64encode(tls_locally_signed_cert.kiam_agent.cert_pem)
     kiam_agent_key_b64e_pem          = base64encode(tls_private_key.kiam_agent.private_key_pem)
     cloudwatch_log_shipping_role     = aws_iam_role.cloudwatch_log_shipping_role.arn
-    cloudwatch_log_group_name        = aws_cloudwatch_log_group.logs.name
     service_operator_boundary_arn    = aws_iam_policy.service-operator-managed-role-permissions-boundary.arn
     service_operator_role_arn        = aws_iam_role.gsp-service-operator.arn
     rds_from_worker_security_group   = aws_security_group.rds-from-worker.id


### PR DESCRIPTION
We have a log group with the same name as the cluster domain.  We no
longer write any logs to it, despite setting the fluentd-cloudwatch
`logGroupName` value to it.

This is because we override the log group name on an output-by-output
basis in the fluentd configuration file, so nothing goes to this
top-level log group.

The default value for `logGroupName` is `kubernetes` which is a log
group which doesn't exist.  Thought: maybe the default should be one
of the log groups which does exist?  In any case, it shouldn't be the
old and deprecated one.