### PR TITLE
allow users to see RDS tags

### DIFF
--- a/modules/gsp-user/iam.tf
+++ b/modules/gsp-user/iam.tf
@@ -69,6 +69,11 @@ resource "aws_iam_role_policy_attachment" "user-defaults-iam" {
   policy_arn = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "user-defaults-rds" {
+  role       = aws_iam_role.user.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "user-defaults-load-balancing-read-only" {
   role       = aws_iam_role.user.name
   policy_arn = "arn:aws:iam::aws:policy/ElasticLoadBalancingReadOnly"


### PR DESCRIPTION
Currently users don't have `rds:ListTagsForResource` permission, so
they can't see tags on an RDS instace.

This grants that permission.

We checked that this won't allow users to extract the master
password.  The [AWS docs][1] say:

> Amazon RDS API actions never return the password, so this action
> provides a way to regain access to a primary instance user if the
> password is lost. This includes restoring privileges that might have
> been accidentally revoked.

[1]: https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-instance.html