### PR TITLE
use set_pipeline step in release/deploy pipelines

### DIFF
--- a/hack/validate-deployer-pipeline.sh
+++ b/hack/validate-deployer-pipeline.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+FLY_BIN=${FLY_BIN:-fly}
+CLUSTER_NAME="validation"
+PIPELINE_NAME="validation-deployer"
+
+$FLY_BIN validate-pipeline \
+	--config "pipelines/deployer/deployer.yaml" \
+	--load-vars-from "pipelines/deployer/deployer.defaults.yaml" \
+	--yaml-var 'config-approvers=[alphagov]' \
+	--yaml-var 'config-approval-count=0' \
+	"$@"
+
+

--- a/hack/validate-release-pipeline.sh
+++ b/hack/validate-release-pipeline.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+FLY_BIN=${FLY_BIN:-fly}
+PIPELINE_NAME="release"
+
+$FLY_BIN validate-pipeline \
+	--config "pipelines/release/release.yaml" \
+	--yaml-var 'config-approvers=[alphagov]' \
+	--yaml-var 'config-approval-count=0' \
+	--var "pipeline-name=${PIPELINE_NAME}" \
+	--var "branch=validating" \
+	--var "github-release-tag-prefix=validating-" \
+	"$@"

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -513,11 +513,6 @@ resource_types:
   source:
     repository: ((github-resource-image))
     tag: ((github-resource-tag))
-- name: concourse-pipeline
-  type: docker-image
-  source:
-    repository: concourse/concourse-pipeline-resource
-    tag: "2.2.0"
 - name: s3-iam
   type: docker-image
   source:
@@ -562,13 +557,6 @@ resources:
     repository: ((users-repository))
     access_token: ((github-api-token))
     release: true
-- name: pipeline
-  type: concourse-pipeline
-  source:
-    teams:
-    - name: gsp
-      username: gsp
-      password: ((readonly_local_user_password))
 - name: cluster-state
   type: terraform
   source:
@@ -646,16 +634,12 @@ jobs:
     params:
       ACCOUNT_NAME: ((account-name))
       CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
-  - put: pipeline
-    params:
-      pipelines:
-      - name: ((concourse-pipeline-name))
-        team: ((concourse-team))
-        config_file: platform/pipelines/deployer/deployer.yaml
-        vars_files:
-        - platform/pipelines/deployer/deployer.defaults.yaml
-        - config/((config-path))
-        - trusted-contributors/github.vars.yaml
+  - set_pipeline: ((concourse-pipeline-name))
+    file: platform/pipelines/deployer/deployer.yaml
+    vars_files:
+    - platform/pipelines/deployer/deployer.defaults.yaml
+    - config/((config-path))
+    - trusted-contributors/github.vars.yaml
 
 - name: deploy
   serial: true

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -28,12 +28,6 @@ resource_types:
     repository: "govsvc/concourse-github-resource"
     tag: "gsp-va191b03"
 
-- name: concourse-pipeline
-  type: docker-image
-  source:
-    repository: concourse/concourse-pipeline-resource
-    tag: "2.2.0"
-
 - name: paas-semver
   type: docker-image
   source:
@@ -189,14 +183,6 @@ resources:
     access_token: ((github-api-token))
     release: true
 
-- name: pipeline
-  type: concourse-pipeline
-  source:
-    teams:
-    - name: gsp
-      username: gsp
-      password: ((readonly_local_user_password))
-
 - name: concourse-github-resource
   type: docker-image
   source:
@@ -293,18 +279,14 @@ jobs:
     file: platform/pipelines/tasks/generate-trusted-contributors.yaml
     params:
       CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
-  - put: pipeline
-    params:
-      pipelines:
-      - name: ((pipeline-name))
-        team: gsp
-        config_file: platform/pipelines/release/release.yaml
-        vars_files:
-        - trusted-contributors/github.vars.yaml
-        vars:
-          branch: ((branch))
-          pipeline-name: ((pipeline-name))
-          github-release-tag-prefix: ((github-release-tag-prefix))
+  - set_pipeline: ((pipeline-name))
+    file: platform/pipelines/release/release.yaml
+    vars_files:
+    - trusted-contributors/github.vars.yaml
+    vars:
+      branch: ((branch))
+      pipeline-name: ((pipeline-name))
+      github-release-tag-prefix: ((github-release-tag-prefix))
 
 - name: build-concourse-task-toolbox
   serial: true


### PR DESCRIPTION
concourse has introduced a [set_pipeline step]( https://concourse-ci.org/set-pipeline-step.html) giving us a canonical way to perform self-updating pipelines without the need for yet another resource-type or fly-based-task.
 
this updates our deployer and release pipelines to use the new set_pipeline step and reduce some boilerplate yaml

also: add hack/validate-$pipeline scripts because I'm bored of remember what vars I need