### PR TITLE
stop trying to steal controller reference

### DIFF
--- a/components/service-operator/internal/aws/cloudformation/controller.go
+++ b/components/service-operator/internal/aws/cloudformation/controller.go
@@ -164,7 +164,7 @@ func (r *Controller) Reconcile(req ctrl.Request) (res ctrl.Result, err error) {
 		// failed to reconcile, requeue as configured
 		res.Requeue = true
 		res.RequeueAfter = r.ReconcileErrorRetryDelay
-	} else if r.RequeueOnSuccess == true {
+	} else if r.RequeueOnSuccess {
 		// reconcile succeeded, requeue as configured
 		res.Requeue = true
 		res.RequeueAfter = r.ReconcileSuccessRetryDelay


### PR DESCRIPTION
the service operator should not attempt to set controller reference for
an object that is already owned by something else, this allows existing
secrets (provisioned by other means) to be the target for populating
with configuration/credentials.