### PR TITLE
default to NOT checking creds on pipeline apply

### DIFF
--- a/components/concourse-operator/pkg/controller/pipeline/pipeline_controller.go
+++ b/components/concourse-operator/pkg/controller/pipeline/pipeline_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcilePipeline) update(teamName string, instance *concoursev1beta1.P
 		return fmt.Errorf("couldn't obtain existing pipeline config: %s", err)
 	}
 	// set pipeline
-	_, _, _, err = concourseClient.Team(teamName).CreateOrUpdatePipelineConfig(pipelineName, existingConfigVersion, pipelineYAML, true)
+	_, _, _, err = concourseClient.Team(teamName).CreateOrUpdatePipelineConfig(pipelineName, existingConfigVersion, pipelineYAML, false)
 	if err != nil {
 		return fmt.Errorf("couldn't CreateOrUpdatePipelineConfig '%s' for team '%s': %s", pipelineName, teamName, err)
 	}


### PR DESCRIPTION
the concourse-operator currently performs set-pipeline with "check
creds" flag set ... this means that an Pipeline resource will fail to
reconcile if it uses secret variables that are not yet defined.

This behaviour is undesirable since nobody can see the reconcile error
unless they inspect the operator's logs or note the Pipeline status.

Instead, just let the operator set the pipeline, and the issues will
become visible in the concourse ui