### PR TITLE
canary: ecr based cd-smoke-test

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -74,6 +74,8 @@ spec:
           - name: src
           outputs:
           - name: image
+          caches:
+          - path: cache
           run:
             path: build
       - put: ecr

--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -46,8 +46,8 @@ spec:
         paths:
         - components/canary
 
-    - name: image
-      type: docker-image
+    - name: ecr
+      type: registry-image
       icon: layers
       source:
         username: ((canary.ImageRegistryUsername))
@@ -61,21 +61,32 @@ spec:
       - get: timer
         trigger: true
       - get: src
-      - put: image
-        get_params: {skip_download: true}
+      - task: build
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: vito/oci-build-task}
+          params:
+            CONTEXT: src/components/canary
+          inputs:
+          - name: src
+          outputs:
+          - name: image
+          run:
+            path: build
+      - put: ecr
         params:
-          build: src/components/canary
-          dockerfile: src/components/canary/Dockerfile
-          tag_file: src/.git/short_ref
-          tag_as_latest: true
-          tag_prefix: v
+          image: image/image.tar
+          additional_tags: src/.git/short_ref
 
     - name: deploy
       serial: true
       plan:
       - get: src
         passed: ["build"]
-      - get: image
+      - get: ecr
         passed: ["build"]
         trigger: true
 
@@ -83,9 +94,11 @@ spec:
         config:
           platform: linux
           image_resource: *task_toolbox
+          params:
+            IMAGE_URI: ((canary.ImageRepositoryURI))
           inputs:
           - name: src
-          - name: image
+          - name: ecr
           outputs:
           - name: chart-values
           run:
@@ -95,13 +108,17 @@ spec:
               - -c
               - |
                 echo "generating helm values for latest image versions..."
+                IMAGE_TAG_TYPE=$(cat ecr/digest | cut -d ':' -f 1)
+                IMAGE_TAG=$(cat ecr/digest | cut -d ':' -f 2)
+                IMAGE_REPOSITORY="${IMAGE_URI}@${IMAGE_TAG_TYPE}"
+                BUILD_TIMESTAMP="$(date +%s)"
                 mkdir -p chart-values
                 cat << EOF > ./overrides.yaml
                 canary:
                   image:
-                    repository: $(cat image/repository)@$(cat image/digest | cut -d ':' -f 1)
-                    tag: $(cat image/digest | cut -d ':' -f 2)
-                  chartCommitTimestamp: $(date +%s)
+                    repository: "${IMAGE_REPOSITORY}"
+                    tag: "${IMAGE_TAG}"
+                  chartCommitTimestamp: ${BUILD_TIMESTAMP}
                 EOF
                 echo "merging with chart values..."
                 spruce merge ./src/components/canary/chart/values.yaml ./overrides.yaml | tee -a chart-values/values.yaml


### PR DESCRIPTION
We have switched to using service-operator provisioned ImageRepositories
(ECR) as the supported image storage.

Unfortunatly the docker-image resource makes some weird assumptions when
the registry uri "looks like" an ECR URI, triggering a code path that
want an AWS access key/id instead of username/password, that is
incompatible with us already knowing the username/password.

The newer builtin registry-image[1] resource does not suffer from the
same issue, but also requires us to seperate out the "build" step to
as registry-image is only responsible for pushing/pulling from
registries.

This change updates the cd-smoke-test pipeline to use the
oci-build-task[2] to build the canary, and the registry-image resource
to store the image.

[1] https://github.com/concourse/registry-image-resource
[2] https://github.com/vito/oci-build-task