### PR TITLE
enforce digest use for all images in account's ecr

### DIFF
--- a/charts/gsp-cluster/policies/digests-on-images/src.rego
+++ b/charts/gsp-cluster/policies/digests-on-images/src.rego
@@ -9,3 +9,14 @@ violation[{"msg": msg}] {
 
   msg := sprintf("images from harbor must use digest (https://github.com/alphagov/gsp/blob/master/docs/gds-supported-platform/internal-images-require-digests.md): %v", [image])
 }
+
+violation[{"msg": msg}] {
+  image := input.review.object.spec.containers[_].image
+  aws_account_id := input.parameters.aws_account_id
+  registry = sprintf("%s.dkr.ecr.eu-west-2.amazonaws.com", [aws_account_id])
+
+  startswith(image, registry)
+  not re_match("^.*@sha256:[a-f,0-9]{64}$", image)
+
+  msg := sprintf("images from ecr must use digest (https://github.com/alphagov/gsp/blob/master/docs/gds-supported-platform/internal-images-require-digests.md): %v", [image])
+}

--- a/charts/gsp-cluster/policies/digests-on-images/src_test.rego
+++ b/charts/gsp-cluster/policies/digests-on-images/src_test.rego
@@ -62,3 +62,45 @@ test_allow_internal_registry_with_digest {
   results := data.digests_on_images.violation with input as input
   count(results) == 0
 }
+
+test_deny_internal_ecr_with_tag {
+  input := {
+    "parameters": {
+      "aws_account_id": "012345678900"
+    },
+    "review": {
+      "object": {
+        "spec": {
+          "containers": [{
+            "image": "nginx"
+          }, {
+            "image": "012345678900.dkr.ecr.eu-west-2.amazonaws.com/example:latest"
+          }]
+        }
+      }
+    }
+  }
+  results := data.digests_on_images.violation with input as input
+  count(results) == 1
+}
+
+test_allow_internal_ecr_with_digest {
+  input := {
+    "parameters": {
+      "aws_account_id": "012345678900"
+    },
+    "review": {
+      "object": {
+        "spec": {
+          "containers": [{
+            "image": "nginx"
+          }, {
+            "image": "012345678900.dkr.ecr.eu-west-2.amazonaws.com/example@sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
+          }]
+        }
+      }
+    }
+  }
+  results := data.digests_on_images.violation with input as input
+  count(results) == 0
+}

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/constraints/digests-on-internal-registry.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/constraints/digests-on-internal-registry.yaml
@@ -12,4 +12,5 @@ spec:
         kinds: ["Pod"]
   parameters:
     registry: "registry.{{ .Values.global.cluster.domain }}"
+    aws_account_id: {{ .Values.global.account.id | quote }}
 {{ end }}

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -9,6 +9,7 @@ global:
     oidcProviderARN: ${cluster_oidc_provider_arn}
   account:
     name: ${account_name}
+    id: ${account_id}
   roles:
     harbor: ${harbor_iam_role_name}
   cloudHsm:


### PR DESCRIPTION
we currently enforce that pods can only reference images from the local
harbor registry if they use a digest. this improves our confidence that
what is running in the cluster is what we think it is, avoiding tag
mutability issues.

this adds the same restriction for images referenced from the account's
ecr registry.