### PR TITLE
Revert "set caches for canary build-task"

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -74,8 +74,6 @@ spec:
           - name: src
           outputs:
           - name: image
-          caches:
-          - path: cache
           run:
             path: build
       - put: ecr


### PR DESCRIPTION
This reverts commit 26f70d69a56e0f8f993fe7c9443e93923a33b3fb.

the cache is so good that it causes builds to not trigger new deploys as
it creates canary images with identical digests.

This could probably be resolved using build-args to pass in the build
timestamp ... but just drop it (like it's hot) for now