### PR TITLE
allow rds access from ci worker nodes

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -233,17 +233,23 @@ resource "aws_security_group" "rds-from-worker" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port       = 3306
-    to_port         = 3306
-    protocol        = "tcp"
-    security_groups = [module.k8s-cluster.worker_security_group_id]
+    from_port = 3306
+    to_port   = 3306
+    protocol  = "tcp"
+    security_groups = [
+      module.k8s-cluster.worker_security_group_id,
+      module.k8s-cluster.ci_security_group_id,
+    ]
   }
 
   ingress {
-    from_port       = 5432
-    to_port         = 5432
-    protocol        = "tcp"
-    security_groups = [module.k8s-cluster.worker_security_group_id]
+    from_port = 5432
+    to_port   = 5432
+    protocol  = "tcp"
+    security_groups = [
+      module.k8s-cluster.worker_security_group_id,
+      module.k8s-cluster.ci_security_group_id,
+    ]
   }
 }
 

--- a/modules/k8s-cluster/outputs.tf
+++ b/modules/k8s-cluster/outputs.tf
@@ -34,6 +34,10 @@ output "worker_security_group_id" {
   value = aws_security_group.worker.id
 }
 
+output "ci_security_group_id" {
+  value = aws_cloudformation_stack.ci-nodes.outputs["NodeSecurityGroup"]
+}
+
 output "oidc_provider_url" {
   value = aws_iam_openid_connect_provider.eks.url
 }


### PR DESCRIPTION
It is desirable to run scripts against provisioned databases from
concourse tasks.

We currently have seperate ci nodes from generic worker nodes (a
distinction we would like to remove at some point).

This change allows rds acesss from ci nodes.