### PR TITLE
let prometheus use the extra disk we gave it

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -18,7 +18,7 @@ prometheus-operator:
         product: local
       replicas: 2
       retention: "60d"
-      retentionSize: "45GB"
+      retentionSize: "190GB"
       walCompression: true
       ruleSelectorNilUsesHelmValues: false
       ruleSelector: {}


### PR DESCRIPTION
In 6c0c240da85edb614 we allocated 200Gb of disk for prometheus to use,
but we forgot to tell prometheus that it was allowed to use it.

This sets the retentionsize to 190Gb so we have space left for WAL and
other stuff.