### PR TITLE
Improve svcop test flakes

### DIFF
--- a/components/service-operator/controllers/postgres_cloudformation_test.go
+++ b/components/service-operator/controllers/postgres_cloudformation_test.go
@@ -19,7 +19,8 @@ import (
 
 var _ = Describe("PostgresCloudFormationController", func() {
 
-	var timeout time.Duration = time.Minute * 30
+	var within30mins time.Duration = time.Minute * 30
+	var within5mins = time.Minute * 5
 	var client client.Client
 	var ctx context.Context = context.Background()
 	var teardown func()
@@ -84,14 +85,14 @@ var _ = Describe("PostgresCloudFormationController", func() {
 			Eventually(func() object.State {
 				_ = client.Get(ctx, resourceNamespacedName, &pg)
 				return pg.GetState()
-			}, timeout).Should(Equal(object.ReadyState))
+			}, within30mins).Should(Equal(object.ReadyState))
 		})
 
 		By("displaying an AWS CREATE_COMPLETE resource status after initial creation", func() {
 			Eventually(func() string {
 				_ = client.Get(ctx, resourceNamespacedName, &pg)
 				return pg.Status.AWS.Status
-			}, timeout).Should(Equal(cloudformation.CreateComplete))
+			}, within5mins).Should(Equal(cloudformation.CreateComplete))
 		})
 
 		By("displaying an AWS stack id in resource status", func() {
@@ -126,7 +127,7 @@ var _ = Describe("PostgresCloudFormationController", func() {
 			Eventually(func() map[string][]byte {
 				_ = client.Get(ctx, secretNamespacedName, &secret)
 				return secret.Data
-			}).Should(And(
+			}, within5mins).Should(And(
 				HaveKey("Username"),
 				HaveKey("Password"),
 				HaveKey("Endpoint"),
@@ -139,7 +140,7 @@ var _ = Describe("PostgresCloudFormationController", func() {
 			Eventually(func() map[string]interface{} {
 				_ = client.Get(ctx, serviceEntryNamespacedName0, &serviceEntry)
 				return serviceEntry.Spec
-			}).Should(And(
+			}, within5mins).Should(And(
 				HaveKey("hosts"),
 				HaveKey("ports"),
 				HaveKey("addresses"),
@@ -154,7 +155,7 @@ var _ = Describe("PostgresCloudFormationController", func() {
 			Eventually(func() map[string]interface{} {
 				_ = client.Get(ctx, serviceEntryNamespacedName1, &serviceEntry)
 				return serviceEntry.Spec
-			}).Should(And(
+			}, within5mins).Should(And(
 				HaveKey("hosts"),
 				HaveKey("ports"),
 				HaveKey("addresses"),
@@ -195,7 +196,7 @@ var _ = Describe("PostgresCloudFormationController", func() {
 				err := client.List(ctx, &list)
 				Expect(err).ToNot(HaveOccurred())
 				return len(list.Items)
-			}, timeout).Should(Equal(0))
+			}, within30mins).Should(Equal(0))
 		})
 
 		// GC will remove this in a real cluster, but we don't have the hooks installed in our tests :(

--- a/components/service-operator/hack/test_integration.sh
+++ b/components/service-operator/hack/test_integration.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 AWS_ACCOUNT_ID="$(aws sts get-caller-identity | jq -r .Account)"
+AWS_RDS_SECURITY_GROUP_ID=$(aws ec2 describe-security-groups | jq -r '.SecurityGroups[] | select(.GroupName == "sandbox_rds_from_worker") | .GroupId')
 
 docker build \
 	--network host \
@@ -8,7 +9,7 @@ docker build \
 	--build-arg AWS_ACCESS_KEY_ID \
 	--build-arg AWS_SECRET_ACCESS_KEY \
 	--build-arg AWS_SESSION_TOKEN \
-	--build-arg AWS_RDS_SECURITY_GROUP_ID=sg-06ea6f076bd39a4f6 \
+	--build-arg AWS_RDS_SECURITY_GROUP_ID=$AWS_RDS_SECURITY_GROUP_ID \
 	--build-arg AWS_RDS_SUBNET_GROUP_NAME=sandbox-private \
 	--build-arg AWS_PRINCIPAL_PERMISSIONS_BOUNDARY_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:policy/sandbox-service-operator-managed-role-permissions-boundary \
 	--build-arg AWS_PRINCIPAL_SERVER_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/sandbox_kiam_server \


### PR DESCRIPTION
it often takes longer than a second after creation of rds resources for
the Secret and/or ServiceEntry resources to appear.

This adds longer timeouts around the tests waiting for them, and makes
the timeout variable more descriptive.

the hack/test_integration script assumed that the security group id
would be static in our sandbox test account... it isn't, so fetch it
from the api by name instead