### PR TITLE
Fix creation of service operator role for serviceaccount access

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/role.yaml
@@ -6,16 +6,6 @@ metadata:
   creationTimestamp: null
   name: {{ .Release.Name }}-service-operator-role
 rules:
-- resources:
-  - serviceaccount
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - access.govsvc.uk
   resources:
@@ -122,6 +112,7 @@ rules:
   - configmaps
   - events
   - secrets
+  - serviceaccounts
   verbs:
   - create
   - delete

--- a/components/service-operator/config/rbac/role-not-patch.yaml
+++ b/components/service-operator/config/rbac/role-not-patch.yaml
@@ -4,6 +4,7 @@
   - configmaps
   - events
   - secrets
+  - serviceaccounts
   verbs:
   - create
   - delete

--- a/components/service-operator/controllers/serviceaccount.go
+++ b/components/service-operator/controllers/serviceaccount.go
@@ -38,8 +38,6 @@ func (r *ServiceAccountController) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// +kubebuilder:rbac:groups=,resources=serviceaccount,verbs=get;list;watch;create;update;patch;delete
-
 // Reconcile synchronises state between the resource and a cloudformation stack
 func (r *ServiceAccountController) Reconcile(req ctrl.Request) (res ctrl.Result, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second * 1)


### PR DESCRIPTION
Do this through role-not-patch.yaml like we do for other empty string apiGroup
things.

rules[0].apiGroups: Required value: resource rules must supply at least one api
group