### PR TITLE
Isolate tenant namespace istio resources

### DIFF
--- a/charts/gsp-cluster/policies/README.md
+++ b/charts/gsp-cluster/policies/README.md
@@ -2,11 +2,24 @@
 
 ## Running Tests
 
+All together:
+
+```
+$ opa test policies
+PASS: 21/21
+```
+
+Or, individually:
+
 ```
 $ opa test policies/digests-on-images
-PASS: 3/3
+PASS: 5/5
 ```
 ```
 $ opa test policies/restrict-special-nodes
 PASS: 11/11
+```
+```
+$ opa test policies/isolate-tenant-istio-resources
+PASS: 5/5
 ```

--- a/charts/gsp-cluster/policies/isolate-tenant-istio-resources/src.rego
+++ b/charts/gsp-cluster/policies/isolate-tenant-istio-resources/src.rego
@@ -1,0 +1,23 @@
+package isolate_tenant_istio_resources
+
+violation[{"msg": msg}] {
+  not input.review.object.spec.exportTo
+  msg := "exportTo should be present"
+}
+
+violation[{"msg": msg}] {
+  not is_array(input.review.object.spec.exportTo)
+  msg := "exportTo should be a list"
+}
+
+violation[{"msg": msg}] {
+  exportToCount := count(input.review.object.spec.exportTo)
+  exportToCount != 1
+  msg := sprintf("exportTo should be a list of size 1: %v", [exportToCount])
+}
+
+violation[{"msg": msg}] {
+  exportToValue := input.review.object.spec.exportTo[0]
+  exportToValue != "."
+  msg := sprintf("exportTo should be set to '.': '%v'", [exportToValue])
+}

--- a/charts/gsp-cluster/policies/isolate-tenant-istio-resources/src_test.rego
+++ b/charts/gsp-cluster/policies/isolate-tenant-istio-resources/src_test.rego
@@ -1,0 +1,87 @@
+package isolate_tenant_istio_resources
+
+test_allow_correct_specification {
+  input := {
+    "review": {
+      "object": {
+        "spec": {
+          "exportTo": ["."]
+        }
+      }
+    }
+  }
+  results := data.isolate_tenant_istio_resources.violation with input as input
+  count(results) == 0
+}
+
+test_deny_exportto_single_value {
+  input := {
+    "review": {
+      "object": {
+        "spec": {
+          "exportTo": "."
+        }
+      }
+    }
+  }
+  results := data.isolate_tenant_istio_resources.violation with input as input
+  count(results) >= 1
+}
+
+test_deny_multiple_exportto_values {
+  input := {
+    "review": {
+      "object": {
+        "spec": {
+          "exportTo": [
+              ".",
+              "*"
+          ]
+        }
+      }
+    }
+  }
+  results := data.isolate_tenant_istio_resources.violation with input as input
+  count(results) >= 1
+}
+
+test_deny_exportto_star {
+  input := {
+    "review": {
+      "object": {
+        "spec": {
+          "exportTo": ["*"]
+        }
+      }
+    }
+  }
+  results := data.isolate_tenant_istio_resources.violation with input as input
+  count(results) >= 1
+}
+
+test_deny_exportto_random_string {
+  input := {
+    "review": {
+      "object": {
+        "spec": {
+          "exportTo": ["slfkjefgl"]
+        }
+      }
+    }
+  }
+  results := data.isolate_tenant_istio_resources.violation with input as input
+  count(results) >= 1
+}
+
+test_deny_exportto_unset {
+  input := {
+    "review": {
+      "object": {
+        "spec": {
+        }
+      }
+    }
+  }
+  results := data.isolate_tenant_istio_resources.violation with input as input
+  count(results) >= 1
+}

--- a/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
@@ -87,7 +87,7 @@ rules:
   verbs:
   - get
   - list
-  - watch  
+  - watch
 - apiGroups: ["apps"]
   resources:
   - deployments
@@ -238,6 +238,16 @@ rules:
   - tracespans
   verbs:
   - delete
+  - get
+  - list
+  - watch
+
+- apiGroups: ["constraints.gatekeeper.sh/v1beta1"]
+  resources:
+  - isolatetenantistioresources
+  - requireimagedigests
+  - toleratespecialnodes
+  verbs:
   - get
   - list
   - watch

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/constraints/isolate-tenant-istio-resources.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/constraints/isolate-tenant-istio-resources.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.gatekeeper.enabled }}
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: IsolateTenantIstioResources
+metadata:
+  name: isolate-tenant-istio-resources
+spec:
+  enforcementAction: deny
+  match:
+    excludedNamespaces:
+      - "kube-system"
+      - "gsp-system"
+      - "istio-system"
+    kinds:
+    - apiGroups:
+      - "networking.istio.io"
+      kinds:
+      - "DestinationRule"
+      - "ServiceEntry"
+      - "VirtualService"
+{{ end }}

--- a/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/templates/isolate-tenant-istio-resources.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/gatekeeper/templates/isolate-tenant-istio-resources.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.gatekeeper.enabled }}
+---
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: isolatetenantistioresources
+spec:
+  crd:
+    spec:
+      names:
+        kind: IsolateTenantIstioResources
+        listKind: IsolateTenantIstioResourcesList
+        plural: isolatetenantistioresources
+        singular: isolatetenantistioresources
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+{{ .Files.Get "policies/isolate-tenant-istio-resources/src.rego" | indent 8 }}
+{{ end }}

--- a/components/canary/chart/templates/virtual-service.yaml
+++ b/components/canary/chart/templates/virtual-service.yaml
@@ -18,3 +18,5 @@ spec:
           host: {{ include "gsp-canary.fullname" . }}
           port:
             number: {{ .Values.service.port }}
+  exportTo:
+  - "."


### PR DESCRIPTION
Istio violates the cluster-scoped vs namespace-scoped separation with
resources such as ServiceEntry that could allow a resource created in
one namespace to affect the state of the whole cluster. This uses
gatekeeper to enforce namespace isolation for these offending istio
resource types.

Some namespaces (kube-system, gsp-system, istio-system) are excluded as
some entries need to be global (such as the egress safelist configured
in *-cluster-config).