### PR TITLE
Fix external dns

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ $.Release.Name }}-external-dns-{{ .namespace }}
   labels:


### PR DESCRIPTION
A bug was introduced whereby newly-deployed external-dns instances will
fail to start up (discovered on an on-demand cluster). The problem seems
to be related to the way the RoleBinding is set up. Currently the
RoleBinding is in the wrong namespace (it's being created in gsp-system
instead of the tenant namespace). It makes sense that breaks it.

However, adding an equivalent RoleBinding to the correct namespace with
the same values otherwise doesn't fix external-dns. It has to be a
ClusterRoleBinding. Why this is is unclear to me at this stage.

Fixing it in this way doesn't break dev-namespace isolation and, as far
as I can tell, doesn't introduce any security problems. A user of a
namespace (including in-cluster concourse) cannot create cluster-wide
resources. These ClusterRoleBindings are being created by the
multi-tenant concourse.