### PR TITLE
release: Use digests for tags in more places

### DIFF
--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -612,18 +612,15 @@ jobs:
               task:
                 image:
                   repository: $(cat concourse-task-toolbox/repository)
-                  tag: $(cat concourse-task-toolbox/tag)
-                  digest: $(cat concourse-task-toolbox/digest | cut -d ':' -f 2)
+                  tag: $(cat concourse-task-toolbox/digest | cut -d ':' -f 2)
               github:
                 image:
                   repository: $(cat concourse-github-resource/repository)
-                  tag: $(cat concourse-github-resource/tag)
-                  digest: $(cat concourse-github-resource/digest | cut -d ':' -f 2)
+                  tag: $(cat concourse-github-resource/digest | cut -d ':' -f 2)
               harbor:
                 image:
                   repository: $(cat concourse-harbor-resource/repository)
-                  tag: $(cat concourse-harbor-resource/tag)
-                  digest: $(cat concourse-harbor-resource/digest | cut -d ':' -f 2)
+                  tag: $(cat concourse-harbor-resource/digest | cut -d ':' -f 2)
             EOF
             echo "merging with cluster values..."
             spruce merge ./platform/charts/gsp-cluster/values.yaml ./overrides.yaml | tee -a cluster-values/values.yaml
@@ -747,9 +744,9 @@ jobs:
           cp platform/pipelines/deployer/* deployer-package/pipelines/deployer/
           cat << EOF > ./overrides.yaml
           task-toolbox-image: $(cat concourse-task-toolbox/repository)
-          task-toolbox-tag: $(cat concourse-task-toolbox/tag)
+          task-toolbox-tag: $(cat concourse-task-toolbox/digest | cut -d ':' -f 2)
           github-resource-image: $(cat concourse-github-resource/repository)
-          github-resource-tag: $(cat concourse-github-resource/tag)
+          github-resource-tag: $(cat concourse-github-resource/digest | cut -d ':' -f 2)
           EOF
           cat overrides.yaml
           echo "merging with default values..."


### PR DESCRIPTION
Phil noticed that in some cases it just came out as 'latest' which is not what
we want.

We already do this for pipelineOperator, serviceOperator, and AWSSSMAgent.