### PR TITLE
Copy Principals IAM credentials into their Secret

### DIFF
--- a/components/service-operator/controllers/principal_cloudformation_test.go
+++ b/components/service-operator/controllers/principal_cloudformation_test.go
@@ -118,16 +118,46 @@ var _ = Describe("PrincipalCloudFormationController", func() {
 				HaveKeyWithValue("ImageRegistryUsername", BeEquivalentTo("AWS")),
 				HaveKey("ImageRegistryPassword"),
 				HaveKeyWithValue("ImageRegistryEndpoint", BeEquivalentTo("https://011571571136.dkr.ecr.eu-west-2.amazonaws.com")),
+				HaveKey("AccessKeyID"),
+				HaveKey("SecretAccessKey"),
+				HaveKey("SessionToken"),
 			))
 		})
 
-		By("ensuring the secret is updated on credentials renewal", func() {
-			originalPassword := secret.Data["ImageRegistryPassword"]
+		originalPassword := secret.Data["ImageRegistryPassword"]
+		originalAccessKeyId := secret.Data["AccessKeyID"]
+		originalSecretAccessKey := secret.Data["SecretAccessKey"]
+		originalSessionToken := secret.Data["SessionToken"]
+		By("ensuring the ECR secret is updated on credentials renewal", func() {
 			Eventually(func() []byte {
 				_ = client.Get(ctx, secretNamespacedName, &secret)
 				Expect(secret.Data["ImageRegistryPassword"]).ToNot(BeEmpty())
 				return secret.Data["ImageRegistryPassword"]
 			}, time.Minute*5).ShouldNot(BeEquivalentTo(originalPassword))
+		})
+
+		By("ensuring the STS AccessKeyID secret is updated on credentials renewal", func() {
+			Eventually(func() []byte {
+				_ = client.Get(ctx, secretNamespacedName, &secret)
+				Expect(secret.Data["AccessKeyID"]).ToNot(BeEmpty())
+				return secret.Data["AccessKeyID"]
+			}, time.Minute*5).ShouldNot(BeEquivalentTo(originalAccessKeyId))
+		})
+
+		By("ensuring the STS SecretAccessKey secret is updated on credentials renewal", func() {
+			Eventually(func() []byte {
+				_ = client.Get(ctx, secretNamespacedName, &secret)
+				Expect(secret.Data["SecretAccessKey"]).ToNot(BeEmpty())
+				return secret.Data["SecretAccessKey"]
+			}, time.Minute*5).ShouldNot(BeEquivalentTo(originalSecretAccessKey))
+		})
+
+		By("ensuring the STS SessionToken secret is updated on credentials renewal", func() {
+			Eventually(func() []byte {
+				_ = client.Get(ctx, secretNamespacedName, &secret)
+				Expect(secret.Data["SessionToken"]).ToNot(BeEmpty())
+				return secret.Data["SessionToken"]
+			}, time.Minute*5).ShouldNot(BeEquivalentTo(originalSessionToken))
 		})
 
 		By("deleting resource with kubernetes api", func() {

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -65,6 +65,7 @@ func SetupControllerEnv() (client.Client, func()) {
 	os.Setenv("CLOUD_PROVIDER", "aws")
 	os.Setenv("CLUSTER_NAME", "xxx")
 	os.Setenv("IMAGE_REGISTRY_CREDENTIALS_RENEWAL_INTERVAL", "30s")
+	os.Setenv("PRINCIPAL_CREDENTIALS_SESSION_DURATION", "1h")
 	ctx := context.Background()
 
 	log := zap.LoggerTo(GinkgoWriter, false)

--- a/components/service-operator/internal/aws/sdk/sdkfakes/fake_client.go
+++ b/components/service-operator/internal/aws/sdk/sdkfakes/fake_client.go
@@ -4,8 +4,10 @@ package sdkfakes
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/alphagov/gsp/components/service-operator/internal/aws/sdk"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -98,6 +100,18 @@ type FakeClient struct {
 	getAuthorizationTokenWithContextReturnsOnCall map[int]struct {
 		result1 *ecr.GetAuthorizationTokenOutput
 		result2 error
+	}
+	GetRoleCredentialsStub        func(string, time.Duration) *credentials.Credentials
+	getRoleCredentialsMutex       sync.RWMutex
+	getRoleCredentialsArgsForCall []struct {
+		arg1 string
+		arg2 time.Duration
+	}
+	getRoleCredentialsReturns struct {
+		result1 *credentials.Credentials
+	}
+	getRoleCredentialsReturnsOnCall map[int]struct {
+		result1 *credentials.Credentials
 	}
 	GetSecretValueWithContextStub        func(context.Context, *secretsmanager.GetSecretValueInput, ...request.Option) (*secretsmanager.GetSecretValueOutput, error)
 	getSecretValueWithContextMutex       sync.RWMutex
@@ -518,6 +532,67 @@ func (fake *FakeClient) GetAuthorizationTokenWithContextReturnsOnCall(i int, res
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GetRoleCredentials(arg1 string, arg2 time.Duration) *credentials.Credentials {
+	fake.getRoleCredentialsMutex.Lock()
+	ret, specificReturn := fake.getRoleCredentialsReturnsOnCall[len(fake.getRoleCredentialsArgsForCall)]
+	fake.getRoleCredentialsArgsForCall = append(fake.getRoleCredentialsArgsForCall, struct {
+		arg1 string
+		arg2 time.Duration
+	}{arg1, arg2})
+	fake.recordInvocation("GetRoleCredentials", []interface{}{arg1, arg2})
+	fake.getRoleCredentialsMutex.Unlock()
+	if fake.GetRoleCredentialsStub != nil {
+		return fake.GetRoleCredentialsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getRoleCredentialsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) GetRoleCredentialsCallCount() int {
+	fake.getRoleCredentialsMutex.RLock()
+	defer fake.getRoleCredentialsMutex.RUnlock()
+	return len(fake.getRoleCredentialsArgsForCall)
+}
+
+func (fake *FakeClient) GetRoleCredentialsCalls(stub func(string, time.Duration) *credentials.Credentials) {
+	fake.getRoleCredentialsMutex.Lock()
+	defer fake.getRoleCredentialsMutex.Unlock()
+	fake.GetRoleCredentialsStub = stub
+}
+
+func (fake *FakeClient) GetRoleCredentialsArgsForCall(i int) (string, time.Duration) {
+	fake.getRoleCredentialsMutex.RLock()
+	defer fake.getRoleCredentialsMutex.RUnlock()
+	argsForCall := fake.getRoleCredentialsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) GetRoleCredentialsReturns(result1 *credentials.Credentials) {
+	fake.getRoleCredentialsMutex.Lock()
+	defer fake.getRoleCredentialsMutex.Unlock()
+	fake.GetRoleCredentialsStub = nil
+	fake.getRoleCredentialsReturns = struct {
+		result1 *credentials.Credentials
+	}{result1}
+}
+
+func (fake *FakeClient) GetRoleCredentialsReturnsOnCall(i int, result1 *credentials.Credentials) {
+	fake.getRoleCredentialsMutex.Lock()
+	defer fake.getRoleCredentialsMutex.Unlock()
+	fake.GetRoleCredentialsStub = nil
+	if fake.getRoleCredentialsReturnsOnCall == nil {
+		fake.getRoleCredentialsReturnsOnCall = make(map[int]struct {
+			result1 *credentials.Credentials
+		})
+	}
+	fake.getRoleCredentialsReturnsOnCall[i] = struct {
+		result1 *credentials.Credentials
+	}{result1}
+}
+
 func (fake *FakeClient) GetSecretValueWithContext(arg1 context.Context, arg2 *secretsmanager.GetSecretValueInput, arg3 ...request.Option) (*secretsmanager.GetSecretValueOutput, error) {
 	fake.getSecretValueWithContextMutex.Lock()
 	ret, specificReturn := fake.getSecretValueWithContextReturnsOnCall[len(fake.getSecretValueWithContextArgsForCall)]
@@ -663,6 +738,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.describeStacksWithContextMutex.RUnlock()
 	fake.getAuthorizationTokenWithContextMutex.RLock()
 	defer fake.getAuthorizationTokenWithContextMutex.RUnlock()
+	fake.getRoleCredentialsMutex.RLock()
+	defer fake.getRoleCredentialsMutex.RUnlock()
 	fake.getSecretValueWithContextMutex.RLock()
 	defer fake.getSecretValueWithContextMutex.RUnlock()
 	fake.updateStackWithContextMutex.RLock()

--- a/components/service-operator/internal/env/environment.go
+++ b/components/service-operator/internal/env/environment.go
@@ -67,6 +67,22 @@ func ImageRegistryCredentialsRenewalInterval() time.Duration {
 	return renewalInterval
 }
 
+func PrincipalCredentialsSessionDuration() time.Duration {
+	envVarName := "PRINCIPAL_CREDENTIALS_SESSION_DURATION"
+	envVarValue := os.Getenv(envVarName)
+	duration := time.Hour * 12
+
+	if envVarValue != "" {
+		var err error
+		duration, err = time.ParseDuration(envVarValue)
+		if err != nil {
+			panic(fmt.Errorf("failed to parse duration from %s (%s)", envVarName, envVarValue))
+		}
+	}
+
+	return duration
+}
+
 // MustGet is a panicy version of os.Getenv
 func MustGet(key string) string {
 	v := os.Getenv(key)


### PR DESCRIPTION
This is so we can have tenants request S3 Buckets for their pipelines that can be accessed by Concourse, which can only deal with k8s Secrets and can't handle IMDS/IRSA etc. for tenants.