### PR TITLE
svcop ServiceAccount controller: Add missing hyphen to generated names

### DIFF
--- a/components/service-operator/controllers/serviceaccount.go
+++ b/components/service-operator/controllers/serviceaccount.go
@@ -110,7 +110,7 @@ func (r *ServiceAccountController) updatePrincipal(ctx context.Context, o *core.
 		// if none are found, make a new one with GenerateName
 		principal = &access.Principal{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: o.GetName(),
+				GenerateName: fmt.Sprintf("%s-", o.GetName()),
 				Namespace:    o.GetNamespace(),
 			},
 		}


### PR DESCRIPTION
This was generating names such as:
`svcop-verify-verify-doc-checking-build-doc-checking-build-svcacc7q2hp`

May need to think about how we roll this out carefully.