### PR TITLE
svcop: only lookup Principal based on access group label

### DIFF
--- a/components/service-operator/controllers/serviceaccount_test.go
+++ b/components/service-operator/controllers/serviceaccount_test.go
@@ -44,6 +44,7 @@ var _ = Describe("ServiceAccountController", func() {
 					Name:      name,
 					Namespace: namespace,
 					Labels: map[string]string{
+						"ignored-label":                 "should-be-ignored",
 						cloudformation.AccessGroupLabel: "test.access.group",
 					},
 					Annotations: map[string]string{


### PR DESCRIPTION
previously:

A Principal would be linked to a ServiceAccount based on ALL the
metadata.labels matching

now:

A Principal will be linked to a ServiceAccount based only on the blessed
access-group label and we ignore any ServiceAccounts that do not have
this label.

also: 

...aprently a bunch of go fmt things :woman_shrugging: 