### PR TITLE
svcop: don't steal Principal or ServiceEntry owner

### DIFF
--- a/components/service-operator/internal/aws/cloudformation/controller.go
+++ b/components/service-operator/internal/aws/cloudformation/controller.go
@@ -315,8 +315,10 @@ func (r *Controller) updateServiceEntry(ctx context.Context, o ServiceEntryCreat
 	op, err := controllerutil.CreateOrUpdate(ctx, r.KubernetesClient, serviceEntry, func() error {
 		serviceEntry.Spec = spec
 		// mark the serviceEntry as owned by the o resource so it gets gc'd
-		if err := controllerutil.SetControllerReference(o, serviceEntry, r.Scheme); err != nil {
-			return err
+		if !isAlreadyOwned(serviceEntry) {
+			if err := controllerutil.SetControllerReference(o, serviceEntry, r.Scheme); err != nil {
+				return err
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
the controllers can target Principals, Secrets and ServiceEntries which
may be owned by other controllers ... for Secrets we check that the
resource is not already owned before claiming ownership, this does the
same for Principals and ServiceAccounts allowing other controllers to
manage the resources without error