### PR TITLE
Use modern github-resource in configure-namespace

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -295,7 +295,7 @@ spec:
       type: registry-image
       source:
         repository: "govsvc/concourse-github-resource"
-        tag: "v0.0.2"
+        tag: "gsp-va191b03"
     resources:
     - name: src
       type: github


### PR DESCRIPTION
We are using an ancient version of concourse-github-resource that predates the GraphQL implementation.  This either caused or made much harder to investigate a broken build yesterday.