### PR TITLE
Auditors can view all gatekeeper constraint resources.

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
@@ -244,9 +244,7 @@ rules:
 
 - apiGroups: ["constraints.gatekeeper.sh/v1beta1"]
   resources:
-  - isolatetenantistioresources
-  - requireimagedigests
-  - toleratespecialnodes
+  - "*"
   verbs:
   - get
   - list


### PR DESCRIPTION
There's no need for the maintenance overhead of listing individual
gatekeeper constraint resources as will always want auditors to view all
of them.