### PR TITLE
Remove cluster artefact signing key from tenant namespaces.

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -181,8 +181,6 @@ data:
   name: {{ $.Values.global.cluster.name | b64enc }}
   domain: {{ $.Values.global.cluster.domain | b64enc }}
   cloudHsmIp: {{ $.Values.global.cloudHsm.ip | b64enc }}
-  privateKey: {{ $.Values.global.cluster.privateKey | b64enc }}
-  publicKey: {{ $.Values.global.cluster.publicKey | b64enc }}
   releaseVersion: {{ $.Values.global.cluster.releaseVersion | b64enc }}
 ---
 apiVersion: v1

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -155,7 +155,6 @@ apply_cluster_chart: &apply_cluster_chart
     DEFAULT_NAMESPACE:
     CHART_RELEASE_NAME:
     GITHUB_API_TOKEN:
-    CLUSTER_PRIVATE_KEY:
     CLUSTER_PUBLIC_KEY:
     CONFIG_VALUES_PATH:
     GOOGLE_OAUTH_CLIENT_ID:
@@ -215,8 +214,6 @@ apply_cluster_chart: &apply_cluster_chart
         --set "githubAPIToken=${GITHUB_API_TOKEN}" \
         --set "googleOauthClientId=${GOOGLE_OAUTH_CLIENT_ID}" \
         --set "googleOauthClientSecret=${GOOGLE_OAUTH_CLIENT_SECRET}" \
-        --set "global.cluster.privateKey=${CLUSTER_PRIVATE_KEY}" \
-        --set "global.cluster.publicKey=${CLUSTER_PUBLIC_KEY}" \
         --set "global.cluster.releaseVersion=${RELEASE_TAG}" \
         --output-dir manifests \
         $GSP_CLUSTER_CHARTS_SOURCE
@@ -852,7 +849,6 @@ jobs:
       DEFAULT_NAMESPACE: gsp-system
       CHART_RELEASE_NAME: gsp
       GITHUB_API_TOKEN: ((github-api-token))
-      CLUSTER_PRIVATE_KEY: ((ci-system-gpg-private))
       CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
       CONFIG_VALUES_PATH: ((config-values-path))
       GOOGLE_OAUTH_CLIENT_ID: ((google-oauth-client-id))


### PR DESCRIPTION
We no longer wish to share this key among namespaces. Preferring instead
to have it tenant-controlled. This ensures a user in one namespace cannot
impersonate a person or agent from another namespace.

Before merging:

- [x] https://github.com/alphagov/doc-checking/pull/1074
- [x] https://github.com/alphagov/verify-proxy-node/pull/484
- [x] https://github.com/alphagov/verify-proxy-node/pull/485
- [x] https://github.com/alphagov/verify-metadata-controller/pull/71
- [x] https://github.com/alphagov/verify-metadata-controller/pull/72