### PR TITLE
svcop: Remove KIAM support for managed namespaces

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/managed-namespaces.yaml
@@ -1,6 +1,4 @@
 {{- range .Values.namespaces }}
-{{- $defaultedPermittedRolesRegex := .permittedRolesRegex | default "^$" }}
-{{- $permittedRolesRegex := printf "%s|^svcop-%s-%s-.*$" $defaultedPermittedRolesRegex $.Values.global.cluster.name .name }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -14,6 +12,4 @@ metadata:
 {{- if .talksToPsn }}
     talksToPsn: "true"
 {{- end }}
-  annotations:
-    iam.amazonaws.com/permitted: {{ $permittedRolesRegex | quote }}
 {{- end }}

--- a/hack/lint-terraform-values-output.sh
+++ b/hack/lint-terraform-values-output.sh
@@ -53,7 +53,6 @@ namespaces:
   repository: verify-metadata-controller
   branch: master
   path: ci
-  permittedRolesRegex: "^$"
   requiredApprovalCount: 2
   scope: cluster
 - name: verify-proxy-node-build


### PR DESCRIPTION
While we're here also remove the unused ability to configure permittedRolesRegex.

(technically it's used in verify-cluster-config but set to the default value anyway - see https://github.com/alphagov/verify-cluster-config/pull/118)