### PR TITLE
Expose github-resource and task-toolbox digests for use by tenants

### DIFF
--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -165,8 +165,10 @@ metadata:
 data:
   github-resource-image: {{ $.Values.concourseResources.github.image.repository | b64enc }}
   github-resource-tag: {{ $.Values.concourseResources.github.image.tag | b64enc }}
+  github-resource-digest: {{ $.Values.concourseResources.github.image.digest | b64enc }}
   task-toolbox-image: {{ $.Values.concourseResources.task.image.repository | b64enc }}
   task-toolbox-tag: {{ $.Values.concourseResources.task.image.tag | b64enc }}
+  task-toolbox-digest: {{ $.Values.concourseResources.task.image.digest | b64enc }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -298,6 +300,10 @@ spec:
             source:
               repository: {{ $.Values.concourseResources.task.image.repository | quote }}
               tag: {{ $.Values.concourseResources.task.image.tag | quote }}
+            {{ if $.Values.concourseResources.task.image.digest != '' }}
+            version:
+              digest: {{ $.Values.concourseResources.task.image.digest | quote }}
+            {{ end }}
           inputs:
           - name: src
           params:

--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -15,6 +15,8 @@ spec:
       source:
         repository: ((concourse.task-toolbox-image))
         tag: ((concourse.task-toolbox-tag))
+      version:
+        digest: ((concourse.task-toolbox-digest))
 
     resource_types:
     - name: github
@@ -22,6 +24,8 @@ spec:
       source:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
+      version:
+        digest: ((concourse.github-resource-digest))
 
     resources:
     - name: timer

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -851,10 +851,12 @@ concourseResources:
     image:
       repository: govsvc/concourse-github-resource
       tag: latest
+      digest: ''
   task:
     image:
       repository: govsvc/task-toolbox
       tag: latest
+      digest: ''
 
 # externalDns:
 # - namespace: verify-metadata-controller

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -29,9 +29,11 @@ maximum-workers-per-az-count: 5
 
 task-toolbox-image: govsvc/task-toolbox
 task-toolbox-tag: latest
+task-toolbox-digest: ''
 
 github-resource-image: govsvc/concourse-github-resource
 github-resource-tag: latest
+github-resource-digest: ''
 
 terraform-resource-image: govsvc/terraform-resource
 terraform-resource-tag: latest

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -510,6 +510,8 @@ resource_types:
   source:
     repository: ((github-resource-image))
     tag: ((github-resource-tag))
+  version:
+    digest: ((github-resource-digest))
 - name: concourse-pipeline
   type: docker-image
   source:

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -567,12 +567,12 @@ jobs:
                 image:
                   repository: $(cat concourse-task-toolbox/repository)
                   tag: $(cat concourse-task-toolbox/tag)
-                  digest: $(cat concourse-task-toolbox/digest | cut -d ':' -f 2)
+                  digest: $(cat concourse-task-toolbox/digest)
               github:
                 image:
                   repository: $(cat concourse-github-resource/repository)
                   tag: $(cat concourse-github-resource/tag)
-                  digest: $(cat concourse-github-resource/digest | cut -d ':' -f 2)
+                  digest: $(cat concourse-github-resource/digest)
             EOF
             echo "merging with cluster values..."
             spruce merge ./platform/charts/gsp-cluster/values.yaml ./overrides.yaml | tee -a cluster-values/values.yaml
@@ -696,8 +696,10 @@ jobs:
           cat << EOF > ./overrides.yaml
           task-toolbox-image: $(cat concourse-task-toolbox/repository)
           task-toolbox-tag: $(cat concourse-task-toolbox/tag)
+          task-toolbox-digest: $(cat concourse-task-toolbox/digest)
           github-resource-image: $(cat concourse-github-resource/repository)
           github-resource-tag: $(cat concourse-github-resource/tag)
+          github-resource-digest: $(cat concourse-github-resource/digest)
           EOF
           cat overrides.yaml
           echo "merging with default values..."


### PR DESCRIPTION
... and pin task-toolbox used in configure-namespace

So people with write access to DockerHub can't change code running in the live clusters.