### PR TITLE
svcop: Follow-up #965: Allow updating of roles too

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -98,6 +98,7 @@ data "aws_iam_policy_document" "service-operator" {
       "iam:PutRolePolicy",
       "iam:TagRole",
       "iam:UntagRole",
+      "iam:UpdateRole",
     ]
 
     resources = [


### PR DESCRIPTION
Didn't get caught in the integration tests presumably because that will only
create fresh roles rather than try to update existing ones. Has blown up in
sandbox however.