### PR TITLE
Seems iam:UpdateRole doesnt have anything to do with permissions boundaries

### DIFF
--- a/modules/gsp-cluster/service-operator.tf
+++ b/modules/gsp-cluster/service-operator.tf
@@ -98,7 +98,6 @@ data "aws_iam_policy_document" "service-operator" {
       "iam:PutRolePolicy",
       "iam:TagRole",
       "iam:UntagRole",
-      "iam:UpdateRole",
     ]
 
     resources = [
@@ -120,6 +119,7 @@ data "aws_iam_policy_document" "service-operator" {
       "iam:DeleteRolePolicy",
       "iam:GetRolePolicy",
       "iam:UpdateAssumeRolePolicy",
+      "iam:UpdateRole",
     ]
 
     resources = [


### PR DESCRIPTION
So we were still seeing things like this:
`API: iam:UpdateRole User: arn:aws:sts::011571571136:assumed-role/sandbox-service-operator/1581603874295411240 is not authorized to perform: iam:UpdateRole on resource: role svcop-sandbox-sandbox-main-testsvcacc`