### PR TITLE
svcop: Principal credentials in Secrets: use shorter session duration

### DIFF
--- a/components/service-operator/apis/access/v1beta1/principal_types.go
+++ b/components/service-operator/apis/access/v1beta1/principal_types.go
@@ -142,7 +142,6 @@ func (s *Principal) GetStackTemplate() (*cloudformation.Template, error) {
 		RoleName:                 s.GetRoleName(),
 		AssumeRolePolicyDocument: cloudformation.Sub(subbableHack),
 		PermissionsBoundary:      cloudformation.Ref(IAMPermissionsBoundaryParameterName),
-		MaxSessionDuration:       43200, // 12 hours
 	}
 
 	template.Resources[SharedPolicyResourceName] = &cloudformation.AWSIAMPolicy{
@@ -206,7 +205,7 @@ func (s *Principal) GetTemplateSecrets(ctx context.Context, client sdk.Client, o
 	templateSecrets["ImageRegistryPassword"] = ecrCredentials.Password
 	templateSecrets["ImageRegistryEndpoint"] = ecrCredentials.Endpoint
 
-	assumedRoleCredentials, err := client.GetRoleCredentials(roleArn, env.PrincipalCredentialsSessionDuration()).Get()
+	assumedRoleCredentials, err := client.GetRoleCredentials(roleArn).Get()
 	if err != nil {
 		return nil, err
 	}

--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -65,7 +65,6 @@ func SetupControllerEnv() (client.Client, func()) {
 	os.Setenv("CLOUD_PROVIDER", "aws")
 	os.Setenv("CLUSTER_NAME", "xxx")
 	os.Setenv("IMAGE_REGISTRY_CREDENTIALS_RENEWAL_INTERVAL", "30s")
-	os.Setenv("PRINCIPAL_CREDENTIALS_SESSION_DURATION", "1h")
 	ctx := context.Background()
 
 	log := zap.LoggerTo(GinkgoWriter, false)

--- a/components/service-operator/go.mod
+++ b/components/service-operator/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	sigs.k8s.io/controller-runtime v0.2.0-beta.4
+	sigs.k8s.io/controller-tools v0.2.0-beta.4 // indirect
 )
 
 // avoid jsonpatch v2.0.0 which was yanked and republished and so has

--- a/components/service-operator/go.sum
+++ b/components/service-operator/go.sum
@@ -111,6 +111,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/stackerr v0.0.0-20150612192056-c2fcf88613f4/go.mod h1:SBHk9aNQtiw4R4bEuzHjVmZikkUKCnO1v3lPQ21HZGk=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fluent/fluent-logger-golang v1.3.0/go.mod h1:2/HCT/jTy78yGyeNGQLGQsjF3zzzAuy6Xlk6FCMV5eU=
 github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
@@ -139,6 +141,8 @@ github.com/go-redis/redis v6.10.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8w
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobuffalo/flect v0.1.5 h1:xpKq9ap8MbYfhuPCF0dBH854Gp9CxZjr/IocxELFflo=
+github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gocql/gocql v0.0.0-20190423091413-b99afaf3b163/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
@@ -274,6 +278,10 @@ github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190403194419-1ea4449da983/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2 h1:g+4J5sZg6osfvEfkRZxJ1em0VT95/UOZgi/l7zi1/oE=
@@ -468,6 +476,7 @@ golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -498,7 +507,9 @@ golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190429190828-d89cdac9e872/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -524,6 +535,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190501045030-23463209683d/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db h1:9hRk1xeL9LTT3yX/941DqeBz87XgHAQuj+TbimYJuiw=
@@ -616,6 +628,7 @@ k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyod
 k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible h1:U5Bt+dab9K8qaUmXINrkXO135kA11/i5Kg1RUydgaMQ=
 k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/helm v2.13.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
+k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1 h1:RVgyDHY/kFKtLqh67NvEWIgkMneNoIrdkN0CxDSQc68=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -629,6 +642,8 @@ k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/controller-runtime v0.2.0-beta.4 h1:S1XVfRWR1MuIXZdkYx3jN8JDw+bbQxmWZroy0i87z/A=
 sigs.k8s.io/controller-runtime v0.2.0-beta.4/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
+sigs.k8s.io/controller-tools v0.2.0-beta.4 h1:W+coTe+nkVNclQrikwlRp6GJKwgcrHzvIQZ9kCaak5A=
+sigs.k8s.io/controller-tools v0.2.0-beta.4/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GMtvyBKX30SGl4em6Y=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/components/service-operator/internal/aws/sdk/client.go
+++ b/components/service-operator/internal/aws/sdk/client.go
@@ -1,8 +1,6 @@
 package sdk
 
 import (
-	"time"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -29,7 +27,7 @@ type Client interface {
 	GetSecretValueWithContext(aws.Context, *secretsmanager.GetSecretValueInput, ...request.Option) (*secretsmanager.GetSecretValueOutput, error)
 	GetAuthorizationTokenWithContext(aws.Context, *ecr.GetAuthorizationTokenInput, ...request.Option) (*ecr.GetAuthorizationTokenOutput, error)
 	AssumeRole(roleArn string) Client
-	GetRoleCredentials(roleARN string, sessionDuration time.Duration) *credentials.Credentials
+	GetRoleCredentials(roleARN string) *credentials.Credentials
 }
 
 // NewClient creates a new AWS client that implements the Client interface.
@@ -59,7 +57,7 @@ type client struct {
 	*ecr.ECR
 }
 
-func (c *client) GetRoleCredentials(roleARN string, sessionDuration time.Duration) *credentials.Credentials {
+func (c *client) GetRoleCredentials(roleARN string) *credentials.Credentials {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
@@ -67,10 +65,10 @@ func (c *client) GetRoleCredentials(roleARN string, sessionDuration time.Duratio
 	return credentials.NewCredentials(&stscreds.AssumeRoleProvider{
 		Client:   sts.New(sess),
 		RoleARN:  roleARN,
-		Duration: sessionDuration,
+		Duration: stscreds.DefaultDuration,
 	})
 }
 
 func (c *client) AssumeRole(roleARN string) Client {
-	return NewClient(&aws.Config{Credentials: c.GetRoleCredentials(roleARN, stscreds.DefaultDuration)})
+	return NewClient(&aws.Config{Credentials: c.GetRoleCredentials(roleARN)})
 }

--- a/components/service-operator/internal/aws/sdk/sdkfakes/fake_client.go
+++ b/components/service-operator/internal/aws/sdk/sdkfakes/fake_client.go
@@ -4,7 +4,6 @@ package sdkfakes
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/alphagov/gsp/components/service-operator/internal/aws/sdk"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -101,11 +100,10 @@ type FakeClient struct {
 		result1 *ecr.GetAuthorizationTokenOutput
 		result2 error
 	}
-	GetRoleCredentialsStub        func(string, time.Duration) *credentials.Credentials
+	GetRoleCredentialsStub        func(string) *credentials.Credentials
 	getRoleCredentialsMutex       sync.RWMutex
 	getRoleCredentialsArgsForCall []struct {
 		arg1 string
-		arg2 time.Duration
 	}
 	getRoleCredentialsReturns struct {
 		result1 *credentials.Credentials
@@ -532,17 +530,16 @@ func (fake *FakeClient) GetAuthorizationTokenWithContextReturnsOnCall(i int, res
 	}{result1, result2}
 }
 
-func (fake *FakeClient) GetRoleCredentials(arg1 string, arg2 time.Duration) *credentials.Credentials {
+func (fake *FakeClient) GetRoleCredentials(arg1 string) *credentials.Credentials {
 	fake.getRoleCredentialsMutex.Lock()
 	ret, specificReturn := fake.getRoleCredentialsReturnsOnCall[len(fake.getRoleCredentialsArgsForCall)]
 	fake.getRoleCredentialsArgsForCall = append(fake.getRoleCredentialsArgsForCall, struct {
 		arg1 string
-		arg2 time.Duration
-	}{arg1, arg2})
-	fake.recordInvocation("GetRoleCredentials", []interface{}{arg1, arg2})
+	}{arg1})
+	fake.recordInvocation("GetRoleCredentials", []interface{}{arg1})
 	fake.getRoleCredentialsMutex.Unlock()
 	if fake.GetRoleCredentialsStub != nil {
-		return fake.GetRoleCredentialsStub(arg1, arg2)
+		return fake.GetRoleCredentialsStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -557,17 +554,17 @@ func (fake *FakeClient) GetRoleCredentialsCallCount() int {
 	return len(fake.getRoleCredentialsArgsForCall)
 }
 
-func (fake *FakeClient) GetRoleCredentialsCalls(stub func(string, time.Duration) *credentials.Credentials) {
+func (fake *FakeClient) GetRoleCredentialsCalls(stub func(string) *credentials.Credentials) {
 	fake.getRoleCredentialsMutex.Lock()
 	defer fake.getRoleCredentialsMutex.Unlock()
 	fake.GetRoleCredentialsStub = stub
 }
 
-func (fake *FakeClient) GetRoleCredentialsArgsForCall(i int) (string, time.Duration) {
+func (fake *FakeClient) GetRoleCredentialsArgsForCall(i int) string {
 	fake.getRoleCredentialsMutex.RLock()
 	defer fake.getRoleCredentialsMutex.RUnlock()
 	argsForCall := fake.getRoleCredentialsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) GetRoleCredentialsReturns(result1 *credentials.Credentials) {

--- a/components/service-operator/internal/aws/sdk/sdkfakes/fake_client_happy.go
+++ b/components/service-operator/internal/aws/sdk/sdkfakes/fake_client_happy.go
@@ -131,7 +131,7 @@ func NewHappyClient(outputs map[string]string) *FakeClient {
 	client.AssumeRoleReturns(client)
 
 	getRoleCredsLater := time.After(time.Second * 60)
-	client.GetRoleCredentialsStub = func(string, time.Duration) *credentials.Credentials {
+	client.GetRoleCredentialsStub = func(string) *credentials.Credentials {
 		select {
 		case <-getRoleCredsLater:
 			return credentials.NewStaticCredentialsFromCreds(credentials.Value{

--- a/components/service-operator/internal/env/environment.go
+++ b/components/service-operator/internal/env/environment.go
@@ -54,7 +54,7 @@ func AWSRoleArn() string {
 func ImageRegistryCredentialsRenewalInterval() time.Duration {
 	envVarName := "IMAGE_REGISTRY_CREDENTIALS_RENEWAL_INTERVAL"
 	envVarValue := os.Getenv(envVarName)
-	renewalInterval := time.Hour * 6
+	renewalInterval := time.Minute * 30
 
 	if envVarValue != "" {
 		var err error
@@ -65,22 +65,6 @@ func ImageRegistryCredentialsRenewalInterval() time.Duration {
 	}
 
 	return renewalInterval
-}
-
-func PrincipalCredentialsSessionDuration() time.Duration {
-	envVarName := "PRINCIPAL_CREDENTIALS_SESSION_DURATION"
-	envVarValue := os.Getenv(envVarName)
-	duration := time.Hour * 12
-
-	if envVarValue != "" {
-		var err error
-		duration, err = time.ParseDuration(envVarValue)
-		if err != nil {
-			panic(fmt.Errorf("failed to parse duration from %s (%s)", envVarName, envVarValue))
-		}
-	}
-
-	return duration
 }
 
 // MustGet is a panicy version of os.Getenv


### PR DESCRIPTION
Can't use 12h due to this constraint:
The requested DurationSeconds exceeds the 1 hour session limit for roles assumed by role chaining.