### PR TITLE
svcop: RDS: Set CACertificateIdentifier for 2019 CA change

### DIFF
--- a/components/service-operator/apis/database/v1beta1/postgres_types.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types.go
@@ -177,14 +177,15 @@ func (p *Postgres) GetStackTemplate() (*cloudformation.Template, error) {
 	}
 	for i := 0; i < instanceCount; i++ {
 		template.Resources[fmt.Sprintf("%s%d", PostgresResourceInstance, i)] = &cloudformation.AWSRDSDBInstance{
-			DBClusterIdentifier:    cloudformation.Ref(PostgresResourceCluster),
-			DBInstanceClass:        coalesce(p.Spec.AWS.InstanceType, DefaultClass),
-			Engine:                 Engine,
-			PubliclyAccessible:     false,
-			DBParameterGroupName:   cloudformation.Ref(PostgresResourceParameterGroup),
-			Tags:                   tags,
-			DBSubnetGroupName:      cloudformation.Ref(DBSubnetGroupNameParameterName),
-			DeleteAutomatedBackups: false,
+			DBClusterIdentifier:     cloudformation.Ref(PostgresResourceCluster),
+			DBInstanceClass:         coalesce(p.Spec.AWS.InstanceType, DefaultClass),
+			Engine:                  Engine,
+			PubliclyAccessible:      false,
+			DBParameterGroupName:    cloudformation.Ref(PostgresResourceParameterGroup),
+			Tags:                    tags,
+			DBSubnetGroupName:       cloudformation.Ref(DBSubnetGroupNameParameterName),
+			DeleteAutomatedBackups:  false,
+			CACertificateIdentifier: "rds-ca-2019",
 		}
 	}
 

--- a/components/service-operator/apis/database/v1beta1/postgres_types_test.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types_test.go
@@ -249,6 +249,7 @@ var _ = Describe("Postgres", func() {
 					Expect(instance.Engine).To(Equal("aurora-postgresql"))
 					Expect(instance.Tags).To(Equal(tags))
 					Expect(instance.DeleteAutomatedBackups).To(Equal(false))
+					Expect(instance.CACertificateIdentifier).To(Equal("rds-ca-2019"))
 				}
 			})
 

--- a/components/service-operator/apis/queue/v1beta1/sqs_types.go
+++ b/components/service-operator/apis/queue/v1beta1/sqs_types.go
@@ -22,7 +22,6 @@ import (
 	"github.com/alphagov/gsp/components/service-operator/internal/env"
 	"github.com/alphagov/gsp/components/service-operator/internal/object"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/awslabs/goformation/cloudformation/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -105,7 +104,7 @@ func (s *SQS) GetStackTemplate() (*cloudformation.Template, error) {
 		"Type": "String",
 	}
 
-	tags := []resources.Tag{
+	tags := []cloudformation.Tag{
 		{
 			Key:   "Cluster",
 			Value: env.ClusterName(),
@@ -139,9 +138,9 @@ func (s *SQS) GetStackTemplate() (*cloudformation.Template, error) {
 		redrivePolicy = ""
 	}
 
-	template.Resources[SQSResourceName] = &resources.AWSSQSQueue{
+	template.Resources[SQSResourceName] = &cloudformation.AWSSQSQueue{
 		QueueName:                     queueName,
-		Tags:                          append(tags, resources.Tag{Key: "QueueType", Value: "Main"}),
+		Tags:                          append(tags, cloudformation.Tag{Key: "QueueType", Value: "Main"}),
 		ContentBasedDeduplication:     s.Spec.AWS.ContentBasedDeduplication,
 		DelaySeconds:                  s.Spec.AWS.DelaySeconds,
 		FifoQueue:                     s.Spec.AWS.FifoQueue,
@@ -153,9 +152,9 @@ func (s *SQS) GetStackTemplate() (*cloudformation.Template, error) {
 	}
 
 	dlQueueName := fmt.Sprintf("%s-dl", queueName)
-	template.Resources[SQSDLQResourceName] = &resources.AWSSQSQueue{
+	template.Resources[SQSDLQResourceName] = &cloudformation.AWSSQSQueue{
 		QueueName:              dlQueueName,
-		Tags:                   append(tags, resources.Tag{Key: "QueueType", Value: "Dead-Letter"}),
+		Tags:                   append(tags, cloudformation.Tag{Key: "QueueType", Value: "Dead-Letter"}),
 		FifoQueue:              s.Spec.AWS.FifoQueue,
 		MessageRetentionPeriod: s.Spec.AWS.MessageRetentionPeriod,
 
@@ -189,7 +188,7 @@ func (s *SQS) GetStackTemplate() (*cloudformation.Template, error) {
 		},
 	}
 
-	template.Resources[SQSResourceIAMPolicy] = &resources.AWSIAMPolicy{
+	template.Resources[SQSResourceIAMPolicy] = &cloudformation.AWSIAMPolicy{
 		PolicyName:     cloudformation.Join("-", []string{"sqs", "access", cloudformation.GetAtt(SQSResourceName, "QueueName")}),
 		PolicyDocument: policy,
 		Roles: []string{

--- a/components/service-operator/go.mod
+++ b/components/service-operator/go.mod
@@ -4,8 +4,9 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.29.4
-	github.com/awslabs/goformation v0.0.0-20190320125420-ac0a17860cf1
+	github.com/awslabs/goformation/v4 v4.5.1
 	github.com/go-logr/logr v0.1.0
+	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0

--- a/components/service-operator/go.sum
+++ b/components/service-operator/go.sum
@@ -52,8 +52,9 @@ github.com/aws/aws-sdk-go v1.29.3 h1:yvEwt1IvgiWpWWayQBQHCK0knTmHKyI7FCrliOV5Pd8
 github.com/aws/aws-sdk-go v1.29.3/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.29.4 h1:w3O/LGvLCliVFJ2fGrpaWDGbRHj1f+aipB1MMfInN24=
 github.com/aws/aws-sdk-go v1.29.4/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
-github.com/awslabs/goformation v0.0.0-20190320125420-ac0a17860cf1 h1:GDeRTDZbIgIUYKXNCyevPCZBSKpPP4Mi57dHE67VjM4=
-github.com/awslabs/goformation v0.0.0-20190320125420-ac0a17860cf1/go.mod h1:HezUyH08DSwwGn3GioVXWZYUhkdvC+oGJ7ya7vBRm7k=
+github.com/awslabs/goformation/v3 v3.1.0/go.mod h1:hQ5RXo3GNm2laHWKizDzU5DsDy+yNcenSca2UxN0850=
+github.com/awslabs/goformation/v4 v4.5.1 h1:pvn5ORAiJiA6348xK+wj9Gz4c63GBPK4fAw7zUMkvAA=
+github.com/awslabs/goformation/v4 v4.5.1/go.mod h1:MBDN7u1lMNDoehbFuO4uPvgwPeolTMA2TzX1yO6KlxI=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -246,6 +247,8 @@ github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
+github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jefferai/jsonx v1.0.0/go.mod h1:OGmqmi2tTeI/PS+qQfBDToLHHJIy/RMp24fPo8vFvoQ=
@@ -300,6 +303,7 @@ github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747/go.mod h1:Sfy
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
@@ -429,8 +433,10 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/xeipuuv/gojsonpointer v0.0.0-20170225233418-6fe8760cad35 h1:0TnXeVP6mx+A4CBf8cQVkQfkhyGBQCmJcT4g6zKzm7M=
 github.com/xeipuuv/gojsonpointer v0.0.0-20170225233418-6fe8760cad35/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c h1:XZWnr3bsDQWAZg4Ne+cPoXRPILrNlPNQfxBuwLl43is=
 github.com/xeipuuv/gojsonreference v0.0.0-20150808065054-e02fc20de94c/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20181112162635-ac52e6811b56 h1:yhqBHs09SmmUoNOHc9jgK4a60T3XFRtPAkYxVnqgY50=
 github.com/xeipuuv/gojsonschema v0.0.0-20181112162635-ac52e6811b56/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
@@ -488,6 +494,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/components/service-operator/internal/aws/cloudformation/client.go
+++ b/components/service-operator/internal/aws/cloudformation/client.go
@@ -14,8 +14,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	goformation "github.com/awslabs/goformation/cloudformation"
-	goresources "github.com/awslabs/goformation/cloudformation/resources"
+	goformation "github.com/awslabs/goformation/v4/cloudformation"
+	goformationtags "github.com/awslabs/goformation/v4/cloudformation/tags"
+	goformationrds "github.com/awslabs/goformation/v4/cloudformation/rds"
+	goformationiam "github.com/awslabs/goformation/v4/cloudformation/iam"
+	goformations3 "github.com/awslabs/goformation/v4/cloudformation/s3"
+	goformationsqs "github.com/awslabs/goformation/v4/cloudformation/sqs"
+	goformationecr "github.com/awslabs/goformation/v4/cloudformation/ecr"
+	goformationsecretsmanager "github.com/awslabs/goformation/v4/cloudformation/secretsmanager"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,20 +39,20 @@ type DescribeStacksOutput = cloudformation.DescribeStacksOutput
 type GetSecretValueInput = secretsmanager.GetSecretValueInput
 type Parameter = cloudformation.Parameter
 type Template = goformation.Template
-type Tag = goresources.Tag
-type AWSRDSDBCluster = goresources.AWSRDSDBCluster
-type AWSRDSDBInstance = goresources.AWSRDSDBInstance
-type AWSRDSDBClusterParameterGroup = goresources.AWSRDSDBClusterParameterGroup
-type AWSRDSDBParameterGroup = goresources.AWSRDSDBParameterGroup
-type AWSIAMPolicy = goresources.AWSIAMPolicy
-type AWSIAMRole = goresources.AWSIAMRole
-type AWSS3Bucket = goresources.AWSS3Bucket
-type AWSSecretsManagerSecret = goresources.AWSSecretsManagerSecret
-type AWSSecretsManagerSecretTargetAttachment = goresources.AWSSecretsManagerSecretTargetAttachment
-type AWSSQSQueue = goresources.AWSSQSQueue
-type GenerateSecretString = goresources.AWSSecretsManagerSecret_GenerateSecretString
-type AWSECRRepository = goresources.AWSECRRepository
-type AWSECRRepository_LifecyclePolicy = goresources.AWSECRRepository_LifecyclePolicy
+type Tag = goformationtags.Tag
+type AWSRDSDBCluster = goformationrds.DBCluster
+type AWSRDSDBInstance = goformationrds.DBInstance
+type AWSRDSDBClusterParameterGroup = goformationrds.DBClusterParameterGroup
+type AWSRDSDBParameterGroup = goformationrds.DBParameterGroup
+type AWSIAMPolicy = goformationiam.Policy
+type AWSIAMRole = goformationiam.Role
+type AWSS3Bucket = goformations3.Bucket
+type AWSSecretsManagerSecret = goformationsecretsmanager.Secret
+type AWSSecretsManagerSecretTargetAttachment = goformationsecretsmanager.SecretTargetAttachment
+type AWSSQSQueue = goformationsqs.Queue
+type GenerateSecretString = goformationsecretsmanager.Secret_GenerateSecretString
+type AWSECRRepository = goformationecr.Repository
+type AWSECRRepository_LifecyclePolicy = goformationecr.Repository_LifecyclePolicy
 
 var NewTemplate = goformation.NewTemplate
 var Join = goformation.Join

--- a/components/service-operator/internal/aws/cloudformation/client.go
+++ b/components/service-operator/internal/aws/cloudformation/client.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Alias types from the various cloudformation packages so we can access
-// relevant parts via this package for convinience
+// relevant parts via this package for convenience
 type State = cloudformation.Stack
 type StateEvent = cloudformation.StackEvent
 type Output = cloudformation.Output

--- a/components/service-operator/internal/aws/cloudformation/cloudformationfakes/fake_stack.go
+++ b/components/service-operator/internal/aws/cloudformation/cloudformationfakes/fake_stack.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/alphagov/gsp/components/service-operator/internal/aws/cloudformation"
 	"github.com/alphagov/gsp/components/service-operator/internal/object"
-	cloudformationa "github.com/awslabs/goformation/cloudformation"
+	cloudformationa "github.com/awslabs/goformation/v4/cloudformation"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"


### PR DESCRIPTION
Do the goformation version update yak shave to get access to the new parameter. Also fix a typo and make sqs_types use our aliases.