### PR TITLE
set resource requests/limits for prometheus

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -25,6 +25,13 @@ prometheus-operator:
       secrets: [ istio.gsp-prometheus-operator-prometheus ]
       serviceMonitorSelectorNilUsesHelmValues: false
       serviceMonitorSelector: {}
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 8Gi
+        requests:
+          cpu: 1000m
+          memory: 8Gi
       storageSpec:
         volumeClaimTemplate:
           spec:


### PR DESCRIPTION
### What

allocate requests and limits to prometheus container 

### Why

so that we can reduce chance of it getting evicted as this will give it a qosClass of `Guaranteed`.

### Notes

pods with lower Quality of Service[1] scores will be evicted first if a node
is under memory pressure[2]

in production clusters appears to desire ~7Gi based on current usage.... so setting limit at 8Gi

### Links

[1] https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
[2] https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/#node-oom-behavior

### Related

https://github.com/alphagov/tech-ops-cluster-config/pull/292