### PR TITLE
Follow-up #609: Remove now-duplicate LaunchTemplate from nodegroup-v2

### DIFF
--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -178,9 +178,6 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       DesiredCapacity: !Ref NodeAutoScalingGroupDesiredCapacity
-      LaunchTemplate:
-        LaunchTemplateId: !Ref NodeLaunchTemplate
-        Version: !GetAtt NodeLaunchTemplate.LatestVersionNumber
       MinSize: !Ref NodeAutoScalingGroupMinSize
       MaxSize: !Ref NodeAutoScalingGroupMaxSize
       VPCZoneIdentifier: !Ref Subnets


### PR DESCRIPTION
UPDATE_ROLLBACK_COMPLETE: ["Exactly one of [LaunchConfigurationName,InstanceId,LaunchTemplate,MixedInstancesPolicy] needs to be specified"]