### PR TITLE
Work around broken CloudFormation

### DIFF
--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -194,11 +194,9 @@ Resources:
             - InstanceType: m5.xlarge
             - InstanceType: m5d.xlarge
             - InstanceType: m5a.xlarge
-            - InstanceType: m5ad.xlarge
             - InstanceType: r5.xlarge
             - InstanceType: r5d.xlarge
             - InstanceType: r5a.xlarge
-            - InstanceType: r5ad.xlarge
       Tags:
         - Key: Name
           Value: !Sub ${ClusterName}-${NodeGroupName}


### PR DESCRIPTION
News apparently hasn't reached the CloudFormation team that m5ad and
r5ad instances exist.  They were only launched in March last year, we
can't expect them to be on the bleeding edge. 🙄