### PR TITLE
Allow cluster autoscaler to evict pods with local storage

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -62,6 +62,7 @@ cluster-autoscaler:
     talksToAWSMetadataService: "true"
   extraArgs:
     balance-similar-node-groups: true
+    skip-nodes-with-local-storage: false
   image:
     tag: v1.14.5 # upgrade this when upgrading kubernetes
   rbac:


### PR DESCRIPTION
By default, the cluster autoscaler won't evict a pod with local
storage - ie an EmptyDir or HostPath volume.  The reasoning is that
the pod depends on that particular node for its behaviour I guess.

This is a major problem for us because the injected istio sidecars all
have an EmptyDir volume, which means we can basically never evict any
of our pods, so we can never scale the cluster down.

I don't think it's a big deal to evict pods with HostPath or
EmptyDir.  (Most pods with HostPath will be DaemonSets anyway, so will
be unsuitable for eviction for that reason; EmptyDirs should IMO be
considered ephemeral).