### PR TITLE
remove unused variable worker-instance-type

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -6,7 +6,6 @@ module "k8s-cluster" {
   public_subnet_ids  = var.public_subnet_ids
   cluster_name       = var.cluster_name
 
-  worker_instance_type                   = var.worker_instance_type
   minimum_workers_per_az_count           = var.minimum_workers_per_az_count
   desired_workers_per_az_map             = var.desired_workers_per_az_map
   maximum_workers_per_az_count           = var.maximum_workers_per_az_count

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -36,11 +36,6 @@ variable "dev_user_arns" {
   default     = []
 }
 
-variable "worker_instance_type" {
-  type    = string
-  default = "t3.medium"
-}
-
 variable "minimum_workers_per_az_count" {
   type    = string
   default = "1"

--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -8,73 +8,6 @@ Parameters:
     Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
     Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
 
-  NodeInstanceType:
-    Description: EC2 instance type for the node instances
-    Type: String
-    Default: t3.medium
-    ConstraintDescription: Must be a valid EC2 instance type
-    AllowedValues:
-      - t3.nano
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
-      - m5.large
-      - m5.xlarge
-      - m5.2xlarge
-      - m5.4xlarge
-      - m5.12xlarge
-      - m5.24xlarge
-      - m5a.large
-      - m5a.xlarge
-      - m5a.2xlarge
-      - m5a.4xlarge
-      - m5a.12xlarge
-      - m5a.24xlarge
-      - m5d.large
-      - m5d.xlarge
-      - c5.large
-      - c5.xlarge
-      - c5.2xlarge
-      - c5.4xlarge
-      - c5.9xlarge
-      - c5.18xlarge
-      - i3.large
-      - i3.xlarge
-      - i3.2xlarge
-      - i3.4xlarge
-      - i3.8xlarge
-      - i3.16xlarge
-      - x1.16xlarge
-      - x1.32xlarge
-      - p2.xlarge
-      - p2.8xlarge
-      - p2.16xlarge
-      - p3.2xlarge
-      - p3.8xlarge
-      - p3.16xlarge
-      - p3dn.24xlarge
-      - r5.large
-      - r5.xlarge
-      - r5.2xlarge
-      - r5.4xlarge
-      - r5.12xlarge
-      - r5.24xlarge
-      - r5d.large
-      - r5d.xlarge
-      - r5d.2xlarge
-      - r5d.4xlarge
-      - r5d.12xlarge
-      - r5d.24xlarge
-      - z1d.large
-      - z1d.xlarge
-      - z1d.2xlarge
-      - z1d.3xlarge
-      - z1d.6xlarge
-      - z1d.12xlarge
-
   NodeAutoScalingGroupMinSize:
     Description: Minimum size of Node Group ASG.
     Type: Number
@@ -159,7 +92,6 @@ Metadata:
           - NodeAutoScalingGroupDesiredCapacity
           - NodeAutoScalingGroupMaxSize
           - NodeAutoScalingGroupOnDemandPercentageAboveBase
-          - NodeInstanceType
           - NodeInstanceProfile
           - NodeImageId
           - NodeVolumeSize
@@ -224,7 +156,6 @@ Resources:
         IamInstanceProfile:
           Arn: !Ref NodeInstanceProfile
         ImageId: !Ref NodeImageId
-        InstanceType: !Ref NodeInstanceType
         SecurityGroupIds: !Ref NodeSecurityGroups
 
         BlockDeviceMappings:

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -72,7 +72,7 @@ resource "aws_cloudformation_stack" "worker-nodes" {
     NodeAutoScalingGroupMinSize         = "0"
     NodeAutoScalingGroupDesiredCapacity = "0"
     NodeAutoScalingGroupMaxSize         = "0"
-    NodeInstanceType                    = var.worker_instance_type
+    NodeInstanceType                    = "t3.medium"
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""
     VpcId                               = var.vpc_id
@@ -131,7 +131,6 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
 
     NodeAutoScalingGroupOnDemandPercentageAboveBase = var.worker_on_demand_percentage_above_base
 
-    NodeInstanceType    = var.worker_instance_type
     NodeInstanceProfile = aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceProfile"]
     NodeVolumeSize      = "40"
     BootstrapArguments  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -26,11 +26,6 @@ variable "worker_eks_version" {
   type = string
 }
 
-variable "worker_instance_type" {
-  type    = string
-  default = "t3.medium"
-}
-
 variable "minimum_workers_per_az_count" {
   type    = string
   default = "1"

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -48,11 +48,6 @@ variable "hsm_splunk_index" {
   type = string
 }
 
-variable "worker_instance_type" {
-  type    = string
-  default = "m5.large"
-}
-
 variable "minimum_workers_per_az_count" {
   type = string
 }
@@ -161,7 +156,6 @@ module "gsp-cluster" {
 
   eks_version                  = var.eks_version
   worker_eks_version           = var.worker_eks_version
-  worker_instance_type         = var.worker_instance_type
   minimum_workers_per_az_count = var.minimum_workers_per_az_count
   desired_workers_per_az_map   = var.desired_workers_per_az_map
   maximum_workers_per_az_count = var.maximum_workers_per_az_count

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -591,7 +591,6 @@ resources:
       hsm_splunk_index: ((hsm-splunk-index))
       eks_version: ((eks-version))
       worker_eks_version: ((worker-eks-version))
-      worker_instance_type: ((worker-instance-type))
       minimum_workers_per_az_count: ((minimum-workers-per-az-count))
       maximum_workers_per_az_count: ((maximum-workers-per-az-count))
       worker_on_demand_percentage_above_base: ((worker-on-demand-percentage-above-base))


### PR DESCRIPTION
Now that we use a MixedInstancesPolicy it's no longer possible to
specify a worker instance type.  So this should be removed.

Created as draft while I first remove usages from the cluster-config repos