### PR TITLE
big little prometheus 

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -27,21 +27,23 @@ prometheus-operator:
       serviceMonitorSelector: {}
       resources:
         limits:
-          cpu: 1000m
-          memory: 8Gi
+          cpu: 2000m
+          memory: 12Gi
         requests:
-          cpu: 1000m
-          memory: 8Gi
+          cpu: 2000m
+          memory: 12Gi
       storageSpec:
         volumeClaimTemplate:
           spec:
             accessModes: ["ReadWriteOnce"]
             resources:
               requests:
-                storage: 200Gi
+                storage: 500Gi
             storageClassName: gp2
       query:
-        timeout: 30s
+        maxConcurrency: 2
+        maxSamples: 1000000
+        timeout: 10s
       additionalScrapeConfigs:
       - job_name: 'istio-mesh'
         kubernetes_sd_configs:


### PR DESCRIPTION
### What

prometheus ran out of disk space, and got very unhappy about it. a large
number of WriteAheadLog files were required to repair/replay and the situation
got worse as prometheus continued to use up the disk. while we tell
prometheus to only retain 180Gi of metrics on disk, this limit does not
apply to the WAL files, and it seems 20Gi was not enough for it to do it's job and 
recover after a crash.

* increases disk to 500Gi
* leave retention at 180Gi (we can come back to this later)

prometheus is very memory hungry after an out-of-disk crash, prometheus
appears to need to spike memory by at least 2GB during it's WAL log
replay/recover... when combined with the initial flood of queries that
go out when prometheus gets running, this pushes it into OOMKill land

* allocate 12Gi of guarenteed memory to prometheus pods this effectivly
  gives prometheus it's own node.
* Since it has it's effectly has it's own node, there is no reason to
  throlle cpu to a single core's worth, give it 2000m.

large promQL queries operating on a large number of samples cause memory
to spike and can push prometheus over it's limit into the OOMKill zone.
These queries are not necasarily from "users" but are also complex rules
configured by things like kube-prometheus and other things bundled with
the kubernetes integration/operator.

* set maxSamples to 1000000 (5x less than the default) so that each
  query is limited in the amount of memory it will allocate
* set maxConcurrency to 2 (same as number of cpu allocated) so that the
  number of goroutines/query workers are capped limiting the number of
  in-flight queries
* set query timeout to 10s to reduce number of slow performing/large
  in-flight queries

## Note

* Lowering the number of maxSamples has helped me get prometheus stable while it was consuming lots of memory after the WAL replay issues, however some queries are now failing with "would require too many samples", including some large time range queries on DCS dashboard.... we may want to look at this again in the future as I think it can probably handle being raised to at least 2.5m, I just wanted to get it stable for now.
* I have already done the dance to resize the disks of both instances in verify-cluster my hand so this will be mostly a no-op there
* I have NOT done the manual work in sandbox ... so after deploy, someone (probably me) will have to do the resize jig