### PR TITLE
add "generation" label to ci worker nodes

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -20,5 +20,6 @@ module "k8s-cluster" {
     formatlist("%s/32", var.egress_ips),
     var.gds_external_cidrs,
   )
+  worker_generation_timestamp = var.worker_generation_timestamp
 }
 

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -66,6 +66,11 @@ variable "ci_worker_instance_type" {
   default = "m5.large"
 }
 
+variable "worker_generation_timestamp" {
+  type    = string
+  default = "none"
+}
+
 variable "addons" {
   type = map(string)
 

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -204,7 +204,7 @@ resource "aws_cloudformation_stack" "ci-nodes" {
     NodeAutoScalingGroupMaxSize         = var.ci_worker_count + 1
     NodeInstanceType                    = var.ci_worker_instance_type
     NodeVolumeSize                      = "75"
-    BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/ci --register-with-taints=node-role.kubernetes.io/ci=:NoSchedule --event-qps=0\""
+    BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/ci,generation=${var.worker_generation_timestamp} --register-with-taints=node-role.kubernetes.io/ci=:NoSchedule --event-qps=0\""
     VpcId                               = var.vpc_id
     Subnets                             = join(",", var.private_subnet_ids)
   }

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -26,6 +26,11 @@ variable "worker_eks_version" {
   type = string
 }
 
+variable "worker_generation_timestamp" {
+  type    = string
+  default = "none"
+}
+
 variable "minimum_workers_per_az_count" {
   type    = string
   default = "1"

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -65,6 +65,11 @@ variable "worker_on_demand_percentage_above_base" {
   type = "string"
 }
 
+variable "worker_generation_timestamp" {
+  type    = string
+  default = "none"
+}
+
 variable "ci_worker_instance_type" {
   type    = string
   default = "m5.large"
@@ -74,6 +79,7 @@ variable "ci_worker_count" {
   type    = string
   default = "3"
 }
+
 
 variable "eks_version" {
   description = "EKS platform version (https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html)"
@@ -159,6 +165,7 @@ module "gsp-cluster" {
   minimum_workers_per_az_count = var.minimum_workers_per_az_count
   desired_workers_per_az_map   = var.desired_workers_per_az_map
   maximum_workers_per_az_count = var.maximum_workers_per_az_count
+  worker_generation_timestamp  = var.worker_generation_timestamp
 
   worker_on_demand_percentage_above_base = var.worker_on_demand_percentage_above_base
 

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -616,6 +616,13 @@ resources:
   source:
     repository: ((task-toolbox-image))
     tag: ((task-toolbox-tag))
+- name: daily
+  type: time
+  icon: update
+  source:
+    start: 6:00 AM
+    stop: 7:00 PM
+    location: Europe/London
 
 jobs:
 - name: update
@@ -664,6 +671,8 @@ jobs:
       trigger: true
       params:
         include_source_tarball: true
+    - get: daily
+      trigger: true
     - get: aws-node-lifecycle-hook
     - get: config
       passed: [update]
@@ -756,16 +765,28 @@ jobs:
           echo "assuming aws deployer role..."
           AWS_CREDS="$(aws-assume-role $ACCOUNT_ROLE_ARN)"
           eval "${AWS_CREDS}"
-          # Look for worker node ASGs for this cluster and make a map of their AZs to desired counts
-          export JQ_FILTER=$(echo '{desired_workers_per_az_map: [' \
+          echo "Looking for worker node ASGs for this cluster and make a map of their AZs to desired counts..."
+          JQ_FILTER=$(echo '{desired_workers_per_az_map: [' \
             '.AutoScalingGroups[] | ' \
              "select (.Tags | from_entries .Name | startswith(\"$CLUSTER_NAME-worker-\")) | " \
             '{key: .AvailabilityZones[0], value: .DesiredCapacity}' \
           '] | from_entries}')
-          export DESIRED_MAP=$(aws autoscaling describe-auto-scaling-groups | jq "$JQ_FILTER")
+          aws autoscaling describe-auto-scaling-groups \
+            | jq "$JQ_FILTER" \
+            > desired_map.json
+          echo "add worker generation timestamp var (ensures nodes are rolled periodically)..."
+          jq "{worker_generation_timestamp: .version.time}" daily/input \
+            > worker_generation_timestamp.json
+          echo "merging into tfvars.json..."
           mkdir -p terraform-var-overrides
-          echo $DESIRED_MAP
-          echo $DESIRED_MAP > terraform-var-overrides/overrides.tfvars.json
+          jq -s '.[0] * .[1]' \
+            desired_map.json \
+            worker_generation_timestamp.json \
+            > terraform-var-overrides/overrides.tfvars.json
+          cat terraform-var-overrides/overrides.tfvars.json
+          echo "OK!"
+      inputs:
+      - name: daily
       outputs:
       - name: terraform-var-overrides
   - task: generate-managed-namespaces-zones


### PR DESCRIPTION
## What

this adds a "generation" label to ci (concourse) worker nodes that gets
populated with a timestamp from the deployment pipeline.

## Why

becuase we would like something to cause regular rolling of ci nodes

## How

a timer in the deployment pipeline will trigger daily, causing the
generation label to be updated in the nodegroup configuration and cause
cloudformation to roll the nodes via the same mechanism that occurs with
any other node modification.

## More

if useful, this could easily be added to other node groups, but right
now we just want the concourse workers to get kicked at least once a
day to avoid them getting a case of bloaty-cache