### PR TITLE
re-add [mr]5ad spot instance types

### DIFF
--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -126,9 +126,11 @@ Resources:
             - InstanceType: m5.xlarge
             - InstanceType: m5d.xlarge
             - InstanceType: m5a.xlarge
+            - InstanceType: m5ad.xlarge
             - InstanceType: r5.xlarge
             - InstanceType: r5d.xlarge
             - InstanceType: r5a.xlarge
+            - InstanceType: r5ad.xlarge
       Tags:
         - Key: Name
           Value: !Sub ${ClusterName}-${NodeGroupName}


### PR DESCRIPTION
Amazon support say they've fixed this and this should work now.