### PR TITLE
hide generated file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+zz_generated.deepcopy.go linguist-generated=true


### PR DESCRIPTION
To make PRs less noisy, we can mark files as generated in order to
suppress diffs on github.

This adds a single file which we definitely want to exclude.  I wasn't
100% sure about any others, feel free to add to this PR.

https://help.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github