### PR TITLE
Make on-demand base capacity configurable

### DIFF
--- a/modules/gsp-cluster/main.tf
+++ b/modules/gsp-cluster/main.tf
@@ -9,6 +9,7 @@ module "k8s-cluster" {
   minimum_workers_per_az_count           = var.minimum_workers_per_az_count
   desired_workers_per_az_map             = var.desired_workers_per_az_map
   maximum_workers_per_az_count           = var.maximum_workers_per_az_count
+  worker_on_demand_base_capacity         = var.worker_on_demand_base_capacity
   worker_on_demand_percentage_above_base = var.worker_on_demand_percentage_above_base
 
   ci_worker_count         = var.ci_worker_count

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -51,6 +51,11 @@ variable "maximum_workers_per_az_count" {
   default = "5"
 }
 
+variable "worker_on_demand_base_capacity" {
+  type    = "string"
+  default = "1"
+}
+
 variable "worker_on_demand_percentage_above_base" {
   type    = "string"
   default = "100"

--- a/modules/k8s-cluster/data/nodegroup-v2.yaml
+++ b/modules/k8s-cluster/data/nodegroup-v2.yaml
@@ -28,8 +28,13 @@ Parameters:
     Type: Number
     Default: 1
 
+  NodeAutoScalingGroupOnDemandBaseCapacity:
+    Description: Number of nodes which must be provisioned as on-demand (rather than spot)
+    Type: Number
+    Default: 1
+
   NodeAutoScalingGroupOnDemandPercentageAboveBase:
-    Description: Percentage of nodes above the base capacity (minimum size) to launch as on-demand (rather than spot instances)
+    Description: Percentage of nodes above the base capacity to launch as on-demand (rather than spot instances)
     Type: Number
     Default: 100
 
@@ -116,7 +121,7 @@ Resources:
       TargetGroupARNs: !Ref NodeTargetGroups
       MixedInstancesPolicy:
         InstancesDistribution:
-          OnDemandBaseCapacity: !Ref NodeAutoScalingGroupMinSize
+          OnDemandBaseCapacity: !Ref NodeAutoScalingGroupOnDemandBaseCapacity
           OnDemandPercentageAboveBaseCapacity: !Ref NodeAutoScalingGroupOnDemandPercentageAboveBase
         LaunchTemplate:
           LaunchTemplateSpecification:

--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -129,6 +129,7 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
     ))
     NodeAutoScalingGroupMaxSize = var.maximum_workers_per_az_count
 
+    NodeAutoScalingGroupOnDemandBaseCapacity        = var.worker_on_demand_base_capacity
     NodeAutoScalingGroupOnDemandPercentageAboveBase = var.worker_on_demand_percentage_above_base
 
     NodeInstanceProfile = aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceProfile"]

--- a/modules/k8s-cluster/variables.tf
+++ b/modules/k8s-cluster/variables.tf
@@ -46,6 +46,11 @@ variable "maximum_workers_per_az_count" {
   default = "5"
 }
 
+variable "worker_on_demand_base_capacity" {
+  type    = "string"
+  default = "1"
+}
+
 variable "worker_on_demand_percentage_above_base" {
   type    = "string"
   default = "100"

--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -26,6 +26,7 @@ config-approval-count: 2
 
 minimum-workers-per-az-count: 1
 maximum-workers-per-az-count: 5
+worker-on-demand-base-capacity: 1
 worker-on-demand-percentage-above-base: 100
 
 task-toolbox-image: govsvc/task-toolbox

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -61,6 +61,10 @@ variable "maximum_workers_per_az_count" {
   type = string
 }
 
+variable "worker_on_demand_base_capacity" {
+  type = "string"
+}
+
 variable "worker_on_demand_percentage_above_base" {
   type = "string"
 }

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -593,6 +593,7 @@ resources:
       worker_eks_version: ((worker-eks-version))
       minimum_workers_per_az_count: ((minimum-workers-per-az-count))
       maximum_workers_per_az_count: ((maximum-workers-per-az-count))
+      worker_on_demand_base_capacity: ((worker-on-demand-base-capacity))
       worker_on_demand_percentage_above_base: ((worker-on-demand-percentage-above-base))
       enable_nlb: ((enable-nlb))
       ci_worker_instance_type: ((ci-worker-instance-type))


### PR DESCRIPTION
Currently, we set the on-demand base capacity to the same value as the
minimum-workers-per-az-count.  But in sandbox I want to set the base
capacity to 0 (so we can have 100% spot instances).

This makes the on-demand base capacity separately configurable, with a
default value of 1 (which matches the current value everywhere).

:warning: I think this will respin all the worker nodes because it
edits the launch template in the cloudformation template.