### PR TITLE
let concourse workers live on main node group

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -730,8 +730,8 @@ concourse:
     emptyDirSize: 60Gi
     resources:
       requests:
-        cpu: 150m
-        memory: 2Gi
+        cpu: 2000m
+        memory: 12Gi
     env:
     - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE
       value: "false"

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -38,14 +38,6 @@ concourse:
     githubClientId: ${github_client_id}
     githubClientSecret: ${github_client_secret}
     githubCaCert: ${github_ca_cert}
-  worker:
-    replicas: ${concourse_worker_count}
-    nodeSelector:
-      node-role.kubernetes.io/ci: ""
-    tolerations:
-      - key: "node-role.kubernetes.io/ci"
-        operator: Exists
-        effect: NoSchedule
   concourse:
     web:
       externalUrl: https://ci.${cluster_domain}


### PR DESCRIPTION
## What

This removes the toleration/targeting to the special "ci" node group allowing concourse workers to run on the main node group.

It raises the min ram request to a point that will cause worker pods to likely get their own node. 

## Why

Because we don't want to maintain multiple node groups

## Context / Notes

* We want to maintain the status-quo that concourse workers get their own VM.
* This will leave a bunch of empty ci nodes doing nothing that we can then remove in a follow-up PR... but we don't do it all at once to minimise disruption.

## Before merge

Discuss

