### PR TITLE
Remove more litter when deleting clusters

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -470,6 +470,12 @@ drain_cluster_task: &drain_cluster_task
       echo 'deleting PodDisruptionBudgets'
       kubectl delete -A --all poddisruptionbudget
 
+      echo 'deleting deployments and statefulsets'
+      kubectl delete -A --all deployment,statefulset
+
+      echo 'deleting volumes and claims'
+      kubectl delete -A --all pv,pvc
+
       echo "fetching cluster VPC ID..."
       CLUSTER_VPC_ID=$(aws eks describe-cluster --name "${CLUSTER_NAME}" | jq .cluster.resourcesVpcConfig.vpcId -r)
       echo "deleting any LoadBalancer services..."

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -463,6 +463,9 @@ drain_cluster_task: &drain_cluster_task
       aws eks update-kubeconfig --name "${CLUSTER_NAME}" --kubeconfig ./kubeconfig
       export KUBECONFIG=$(pwd)/kubeconfig
 
+      echo 'deleting concourse pipelines'
+      kubectl delete -A --all pipelines
+
       export RESOURCE_TYPES=$(kubectl get crd -o json | jq -r '.items[] | select (.spec.group | endswith(".govsvc.uk")) | .spec.names.singular')
       echo 'deleting govsvc.uk CRDs'
       kubectl delete -A --all $(echo $RESOURCE_TYPES | tr ' ' ',')


### PR DESCRIPTION
## Don't leave EBS volumes lying around when draining

Currently, when we drain a cluster, we leave a bunch of EBS volumes
lying around.  This is because we don't delete the persistentvolumes
correctly.  This is expensive, because each time we do this we leak
~600GB worth of EBS space (of which 500GB is prometheus).  EBS costs
$0.116 per GB-month in eu-west-2, so 600GB works out around $70/month
worth of unused EBS leaked each time we drain a cluster.

In order to do delete EBS properly, we need to delete any pod that has
a bound persistentvolume first.

Therefore, this commit:

 - deletes all deployments and statefulsets (in order to delete the
   pods)
 - deletes all persistentvolumes and persistentvolumeclaims

This should hopefully delete the underlying EBS volumes.

## Delete concourse pipelines when we drain clusters

I'm not sure why this is important but @chrisfarms said it
was... :shrug:
