### PR TITLE
suppress the diff of go.sum in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+go.sum linguist-generated=true
 zz_generated.deepcopy.go linguist-generated=true


### PR DESCRIPTION
You can still view it if you want but we shouldn't show it by default.