### PR TITLE
upgrade vpc-cni to v1.5.5

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
@@ -82,20 +82,12 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.5
           imagePullPolicy: Always
           ports:
             - containerPort: 61678
               name: metrics
           name: aws-node
-          #readinessProbe:
-          #  exec:
-          #    command: ["/app/grpc_health_probe", "-addr=:50051"]
-          #  initialDelaySeconds: 25
-          #livenessProbe:
-          #  exec:
-          #    command: ["/app/grpc_health_probe", "-addr=:50051"]
-          #  initialDelaySeconds: 25
           env:
             - name: AWS_VPC_K8S_CNI_EXTERNALSNAT
               value: "true"


### PR DESCRIPTION
updates the vpc-cni to match aws eks recormendations

https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.5.5