### PR TITLE
manually remove any volumes owned by cluster

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -505,6 +505,11 @@ drain_cluster_task: &drain_cluster_task
           aws ec2 wait instance-terminated --instance-ids $INSTANCES
         fi
       done
+      echo "tidying up any orphaned volumes...."
+      VOLUME_IDS=$(aws ec2 describe-volumes --filters "Name=tag:kubernetes.io/cluster/${CLUSTER_NAME},Values=owned" --max-items 1000 | jq '.Volumes[].VolumeId' -r)
+      for VOLUME_ID in $VOLUME_IDS; do
+        aws ec2 delete-volume --volume-id "${VOLUME_ID}"
+      done
   inputs:
   - name: platform
 


### PR DESCRIPTION
## What

this adds a second attempt to destroy any volumes owned by the cluster
during drain by calling out to aws directly

## Why

to avoid the buildup of litter and cost

volumes _should_ be removed after PersistVolumeClaim, PersistVolume and
 Pods are deleted for storage classes reclaimPolicy Delete (as we have). however we are still seeing some volumes left over are on-demand cluster destroys.

## Note

I'm not crazy about adding more to this drain script ... but I can't see a reason why this wouldn't be working already and I just want the volumes gone :woman_shrugging: 