### PR TITLE
allow read-only users read rds logs

### DIFF
--- a/modules/gsp-user/iam.tf
+++ b/modules/gsp-user/iam.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "user-defaults" {
 
     actions = [
       "eks:DescribeCluster*",
+      "rds:DownloadDBLogFilePortion",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
we don't ship rds logs to cloudwatch, but we still want to be able to
read the short term ones available from the rds console without assuming
an admin role.