### PR TITLE
Add permissions for people/Concourse to interact with Redis objects

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/auditor-cluster-role.yaml
@@ -296,6 +296,7 @@ rules:
 - apiGroups: ["database.govsvc.uk"]
   resources:
   - postgres
+  - redis
   verbs:
   - delete
   - get

--- a/charts/gsp-cluster/templates/00-aws-auth/operator-cluster-role.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/operator-cluster-role.yaml
@@ -165,6 +165,7 @@ rules:
 - apiGroups: ["database.govsvc.uk"]
   resources:
   - postgres
+  - redis
   verbs:
   - create
   - patch


### PR DESCRIPTION
Seems our service-operator Makefile doesn't generate these files.