### PR TITLE
Re-enable sandbox CloudHSM ingress

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/cloudhsm-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.cloudHSMExpose }}
+{{ if .Values.global.cloudHsm.public }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -11,6 +11,7 @@ global:
   roles:
     canary: ""
   cloudHsm:
+    public: false
     enabled: false
     ip: "127.0.0.1"
   kubeApiService:

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -11,6 +11,7 @@ global:
     name: ${account_name}
     id: ${account_id}
   cloudHsm:
+    public: false
     enabled: false
     ip: "127.0.0.1"
   # move these to gsp-namespace terraform output


### PR DESCRIPTION
At some point we accidentally deleted the `Service` that provides the
"public" ingress _and_ broke the toggle to generate the YAML (see
`alphagov/techops-cluster-config@e2b980874c27383b8891d86be7a7d88d3658eda1`).

This commit turns this back on.