### PR TITLE
support spot termination events in lifecycle hook

### DIFF
--- a/components/aws-node-lifecycle-hook/pkg/lifecycle/heartbeat.go
+++ b/components/aws-node-lifecycle-hook/pkg/lifecycle/heartbeat.go
@@ -28,8 +28,6 @@ func heartbeat(ctx context.Context, asgClient awsclient.Client, asgEvent ASGLife
 			})
 			if err != nil {
 				log.Printf("heartbeat failed for %s: %s", asgEvent.EC2InstanceId, err)
-			} else {
-				log.Printf("heartbeat ok for %s", asgEvent.EC2InstanceId)
 			}
 		}
 	}

--- a/modules/k8s-cluster/aws-node-lifecycle-hook.tf
+++ b/modules/k8s-cluster/aws-node-lifecycle-hook.tf
@@ -125,3 +125,24 @@ resource "aws_cloudwatch_event_target" "aws-node-lifecycle-hook" {
   arn       = aws_lambda_function.aws-node-lifecycle-hook.arn
 }
 
+resource "aws_cloudwatch_event_rule" "aws-node-spot-termination-hook" {
+  name        = "${var.cluster_name}-spot-termination-hook"
+  description = "Execute Spot Termination Lifecycle Logic"
+
+  event_pattern = <<PATTERN
+{
+  "detail-type": [
+    "EC2 Spot Instance Interruption Warning"
+  ],
+  "source": [
+    "aws.ec2"
+  ]
+}
+PATTERN
+}
+
+resource "aws_cloudwatch_event_target" "aws-node-spot-termination-hook" {
+  rule      = aws_cloudwatch_event_rule.aws-node-spot-termination-hook.name
+  target_id = "SpotLifecycleLambda"
+  arn       = aws_lambda_function.aws-node-lifecycle-hook.arn
+}


### PR DESCRIPTION
we use spot instances in some clusters, but spot instances do not obey the rules of lifecycle hooks.

to ensure more graceful handling of spot termination we extend the lifecycle hook to perform the same drain functionality currently executed for ASG termination events for the spot termination warning events.

In additional to wiring up the events, we also slightly modify the drain logic to not error if node cannot be found (this is because we cannot scope the spot termination warning events to the correct asg easily, so we need to gracefully handle the case where the hook is called for a node in a different cluster - not ideal, but not so bad)