### PR TITLE
svcop: Try checking whitelisted output key is set instead of hackery

### DIFF
--- a/components/service-operator/internal/aws/cloudformation/client.go
+++ b/components/service-operator/internal/aws/cloudformation/client.go
@@ -110,13 +110,9 @@ type Client struct {
 // Calls should be retried if DeadlineExceeded errors are hit
 // Returns any outputs on successful apply.
 // Will update stack with current status
-func (r *Client) Apply(ctx context.Context, stack Stack, params ...*Parameter) (out Outputs, err error) {
+func (r *Client) Apply(ctx context.Context, stack Stack, params ...*Parameter) (Outputs, error) {
 	// always update stack status
-	defer func () {
-		if err == nil {
-			err = r.updateStatus(stack)
-		}
-	}()
+	defer r.updateStatus(stack)
 	// check if exists
 	exists, err := r.exists(ctx, stack)
 	if err != nil {
@@ -246,13 +242,9 @@ func (r *Client) update(ctx context.Context, stack Stack, params ...*Parameter) 
 // Destroy will attempt to deprovision the cloudformation stack and block until complete or the ctx Deadline expires
 // Calls should be retried if DeadlineExceeded errors are hit
 // Will update stack with current status
-func (r *Client) Destroy(ctx context.Context, stack Stack) (err error) {
+func (r *Client) Destroy(ctx context.Context, stack Stack) error {
 	// always update stack status
-	defer func () {
-		if err == nil {
-			err = r.updateStatus(stack)
-		}
-	}()
+	defer r.updateStatus(stack)
 	// fetch current state
 	state, err := r.get(ctx, stack)
 	if err == ErrStackNotFound {
@@ -376,7 +368,7 @@ func (r *Client) get(ctx context.Context, stack Stack) (*State, error) {
 // whitelisted outputs. ignores any errors encountered and just updates
 // whatever it can with the intension of getting as much info visible as
 // possible even under error conditions.
-func (r *Client) updateStatus(stack Stack) error {
+func (r *Client) updateStatus(stack Stack) {
 	// use a fresh context or we might not be able to update status after
 	// deadline is hit, but this feels a little wrong
 	ctx := context.Background()
@@ -429,16 +421,12 @@ func (r *Client) updateStatus(stack Stack) error {
 		if s.AWS.Info == nil {
 			s.AWS.Info = map[string]string{}
 		}
-		outputs, err := r.Outputs(ctx, stack)
-		if err != nil {
-			return err
-		}
+		outputs, _ := r.Outputs(ctx, stack)
 		for _, whitelistedKey := range w.GetStackOutputWhitelist() {
 			s.AWS.Info[whitelistedKey] = outputs[whitelistedKey]
 		}
 	}
 	stack.SetStatus(s)
-	return nil
 }
 
 func (r *Client) events(ctx context.Context, stack Stack) ([]*StateEvent, error) {

--- a/components/service-operator/internal/aws/cloudformation/client.go
+++ b/components/service-operator/internal/aws/cloudformation/client.go
@@ -423,7 +423,9 @@ func (r *Client) updateStatus(stack Stack) {
 		}
 		outputs, _ := r.Outputs(ctx, stack)
 		for _, whitelistedKey := range w.GetStackOutputWhitelist() {
-			s.AWS.Info[whitelistedKey] = outputs[whitelistedKey]
+			if val, ok := outputs[whitelistedKey]; ok {
+				s.AWS.Info[whitelistedKey] = val
+			}
 		}
 	}
 	stack.SetStatus(s)


### PR DESCRIPTION
Undoes #1062. It was horribly hacky and also started failing with this error:
```
      should create on Apply() [It]

      /workspace/internal/aws/cloudformation/client_test.go:65


      Expected

          <int>: 0

      to be >

          <int>: 0


      /workspace/internal/aws/cloudformation/client_test.go:67
```