### PR TITLE
Upgrade fluentd-cloudwatch from v1.7.3 to v1.9.3 to avoid some trivy critical warnings

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -80,6 +80,8 @@ cluster-autoscaler:
   replicaCount: 2
 
 fluentd-cloudwatch:
+  image:
+    tag: v1.9.3-debian-cloudwatch-1.0
   resources:
     limits:
       memory: 512Mi

--- a/components/concourse-task-toolbox/bin/findCVEs.py
+++ b/components/concourse-task-toolbox/bin/findCVEs.py
@@ -18,21 +18,9 @@ GLOBAL_IMAGE_SOURCE_WHITELIST = [
 ]
 
 # whitelists against vulnerabilities we've considered for various reasons
-FLUENTD_1_7_3_VULNERABILITIES_WHITELIST = [
-    'CVE-2019-10220',
-    'CVE-2019-14896',
-    'CVE-2019-14901',
-    'CVE-2019-15505',
-    'CVE-2019-20636',
-]
 
 
 def whitelisted(vulnerability):
-    if vulnerability['image_name'] == 'fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0' and \
-       vulnerability['vulnerability']['VulnerabilityID'] in FLUENTD_1_7_3_VULNERABILITIES_WHITELIST:
-        # these should be be fixed in:
-        # fluent/fluentd-kubernetes-daemonset:v1.9.3-debian-cloudwatch-1.0
-        return True
     if vulnerability['image_name'].startswith('fluent/fluentd-kubernetes-daemonset:v1.') and \
        vulnerability['vulnerability']['VulnerabilityID'] == 'CVE-2020-8130':
         # this shows up in usr/local/bundle/gems/async-http-0.50.0/examples/fetch/Gemfile.lock -


### PR DESCRIPTION
Compare:
trivy --ignore-unfixed -s CRITICAL fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0
with:
trivy --ignore-unfixed -s CRITICAL fluent/fluentd-kubernetes-daemonset:v1.9.3-debian-cloudwatch-1.0

Difference appears to be:
```
+----------------+------------------+----------+-------------------+---------------+---------------------------------------------+
|    LIBRARY     | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                    TITLE                    |
+----------------+------------------+----------+-------------------+---------------+---------------------------------------------+
| linux-libc-dev | CVE-2019-10220   | CRITICAL | 4.9.189-3+deb9u1  | 4.9.210-1     | kernel: CIFS: Relative paths                |
|                |                  |          |                   |               | injection in directory entry                |
|                |                  |          |                   |               | lists                                       |
+                +------------------+          +                   +               +---------------------------------------------+
|                | CVE-2019-14896   |          |                   |               | kernel: heap-based buffer overflow          |
|                |                  |          |                   |               | in lbs_ibss_join_existing function in       |
|                |                  |          |                   |               | drivers/net/wireless/marvell/libertas/cfg.c |
+                +------------------+          +                   +               +---------------------------------------------+
|                | CVE-2019-14901   |          |                   |               | kernel: heap overflow in                    |
|                |                  |          |                   |               | marvell/mwifiex/tdls.c                      |
+                +------------------+          +                   +               +---------------------------------------------+
|                | CVE-2019-15505   |          |                   |               | kernel: out of bounds read in               |
|                |                  |          |                   |               | drivers/media/usb/dvb-usb/technisat-usb2.c  |
+----------------+------------------+----------+-------------------+---------------+---------------------------------------------+
```