### PR TITLE
Triple the EBS volume size for the cluster workers

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -133,7 +133,7 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
     NodeAutoScalingGroupOnDemandPercentageAboveBase = var.worker_on_demand_percentage_above_base
 
     NodeInstanceProfile          = aws_cloudformation_stack.worker-nodes.outputs["NodeInstanceProfile"]
-    NodeVolumeSize               = "40"
+    NodeVolumeSize               = "120"
     BootstrapArguments           = "--kubelet-extra-args \"--node-labels=node-role.kubernetes.io/worker --event-qps=0\""
     NodeGroupGenerationTimestamp = var.worker_generation_timestamp
     VpcId                        = var.vpc_id


### PR DESCRIPTION
Hopefully this gives us more time between having to roll the nodes in
order to deal with Concourse cruft.