### PR TITLE
enable 14days of vpc flow logs

### DIFF
--- a/modules/gsp-cluster/vpc-flow-logs.tf
+++ b/modules/gsp-cluster/vpc-flow-logs.tf
@@ -1,0 +1,58 @@
+resource "aws_flow_log" "vpc_flow_log" {
+  iam_role_arn         = aws_iam_role.cloudwatch_vpc_flow_log_shipping.arn
+  log_destination      = aws_cloudwatch_log_group.vpc_flow_log.arn
+  log_destination_type = "cloud-watch-logs"
+  traffic_type         = "ALL"
+  vpc_id               = var.vpc_id
+}
+
+resource "aws_cloudwatch_log_group" "vpc_flow_log" {
+  name              = "/aws/vpc/${var.cluster_domain}/flow"
+  retention_in_days = 14
+}
+
+resource "aws_iam_role" "cloudwatch_vpc_flow_log_shipping" {
+  name = "${var.cluster_name}_cloudwatch_vpc_flow_log_shipping"
+
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_vpc_flow_log_assume_role.json
+}
+
+resource "aws_iam_policy" "cloudwatch_vpc_flow_log_shipping" {
+  name        = "${var.cluster_name}_cloudwatch_vpc_flow_log_shipping"
+  description = "Send logs to Clouwatch"
+
+  policy = data.aws_iam_policy_document.cloudwatch_vpc_flow_log.json
+}
+
+resource "aws_iam_policy_attachment" "cloudwatch_vpc_flow_log_shipping" {
+  name       = "${var.cluster_name}_cloudwatch_vpc_flow_log_shipping"
+  roles      = [aws_iam_role.cloudwatch_vpc_flow_log_shipping.name]
+  policy_arn = aws_iam_policy.cloudwatch_vpc_flow_log_shipping.arn
+}
+
+data "aws_iam_policy_document" "cloudwatch_vpc_flow_log_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_vpc_flow_log" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}


### PR DESCRIPTION
## What

This enables collection of the VPC network traffic flow logs with 14 day
retention so that we can identify which service(s), if any, are
disproportionally responsible for the network transfer costs through the
gateways.

## Why

we are seeing some higher than expected costs due to traffic through our
NAT gateways, but have not been able to work out why.

The aim is to create VPC endpoints for any services that may be
responsible to improve routing.
