### PR TITLE
Add rpm to concourse-task-toolbox container

### DIFF
--- a/components/concourse-task-toolbox/Dockerfile
+++ b/components/concourse-task-toolbox/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --update \
 	py3-pip \
 	mailcap \
 	ncurses \
+	rpm \
 	&& pip3 install awscli s3cmd yq PyYAML kubernetes \
 	&& apk -v --purge del py3-pip \
 	&& rm /var/cache/apk/*


### PR DESCRIPTION
Follows-up #1098

When running trivy against:
govsvc/amazon-ssm-agent@sha256:733b9eccee53fcf96bf3ab62953eda2dc5798c4f9725679b86c941a812e164ab
we were getting:
error in image scan: failed analysis: analyze error: failed to analyze layer:
sha256:17282fad1a5eb72a6f1f7a05102a1e3474fd2193cd013d44845d43c013cd594b :
failed to get packages: failed to get packages: failed to parse the pkg info: no rpm command

This seems to make it possible to run against govsvc/amazon-ssm-agent.