### PR TITLE
Increase check-vulnerabilities timeout from 3m to 10m

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -1060,7 +1060,7 @@ jobs:
     trigger: true
   - task: check-vulnerabilities
     image: task-toolbox
-    timeout: 180s
+    timeout: 600s
     params:
       CLUSTER_NAME: ((cluster-name))
       ACCOUNT_ROLE_ARN: ((account-role-arn))


### PR DESCRIPTION
Sometimes it's timed out in sandbox and it's always timing out in verify.
verify is something like 3-4x the size of sandbox in terms of number of pods.