### PR TITLE
concourse-github-resource: Fix check for pr_author

### DIFF
--- a/components/concourse-github-resource/assets/in
+++ b/components/concourse-github-resource/assets/in
@@ -106,7 +106,7 @@ api_response=$( \
         "https://api.github.com/graphql" \
 )
 
-pr_author=$(echo $api_response | jq ".data.repository.object.associatedPullRequests.nodes[].author.login")
+pr_author=$(echo $api_response | jq --raw-output ".data.repository.object.associatedPullRequests.nodes[].author.login")
 echo PR author: $pr_author
 commit_signature_author=$(echo $api_response | jq --raw-output ".data.repository.object.associatedPullRequests.nodes[].commits.nodes[0].commit.signature.signer.login")
 echo Commit signature author: $commit_signature_author


### PR DESCRIPTION
If you miss --raw-output when outputting a string from jq, it'll get quoted
which can break the grep below.