### PR TITLE
enable all the concourse audit logs

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -759,8 +759,15 @@ concourse:
         type: ClusterIP
       prometheus:
         enabled: true
+      enableBuildAuditing: true
+      enableContainerAuditing: true
+      enableJobAuditing: true
       enablePipelineAuditing: true
+      enableResourceAuditing: true
+      enableSystemAuditing: true
       enableTeamAuditing: true
+      enableWorkerAuditing: true
+      enableVolumeAuditing: true
   persistence:
     enabled: false
   postgresql:


### PR DESCRIPTION
There is a poltergeist in the concourse triggering builds and
scaring the locals, we are enabling our best ghost detection system
(concourse audit logs) to try and catch it in the act.