### PR TITLE
Reduce service API throttling errors

### DIFF
--- a/components/service-operator/controllers/serviceaccount.go
+++ b/components/service-operator/controllers/serviceaccount.go
@@ -48,7 +48,7 @@ func (r *ServiceAccountController) Reconcile(req ctrl.Request) (res ctrl.Result,
 		// ran out of time, most likely waiting on
 		// a long running provisioning, come back a bit later
 		res.Requeue = true
-		res.RequeueAfter = time.Second * 1
+		res.RequeueAfter = cloudformation.DefaultRequeueTimeout
 		err = nil
 	}
 	r.Log.Info("reconciled",

--- a/components/service-operator/internal/aws/cloudformation/controller.go
+++ b/components/service-operator/internal/aws/cloudformation/controller.go
@@ -33,10 +33,10 @@ var (
 	DefaultReconcileDeadline = time.Minute * 1
 	// DefaultRequeueTimeout is the default time when a reconcile needs
 	// requeuing after deadline is hit
-	DefaultRequeueTimeout = time.Second * 1
+	DefaultRequeueTimeout = time.Second * 10
 	// DefaultPollingInterval is the frequency that cloudformation client
 	// polls for state changes
-	DefaultPollingInterval = time.Second * 5
+	DefaultPollingInterval = time.Second * 20
 	// DefaultReconcileSuccessRetryDelay is the default delay after a successful
 	// Reconcile that Reconcile will be called again if RequeueOnSuccess is true
 	DefaultReconcileSuccessRetryDelay = time.Hour * 1


### PR DESCRIPTION
## What

increase time between reconcile retries


This will slow the time between cloudformation stack changes being
reflected in kubernetes objects by around ~15s but will result in an
order of magnitude fewer API requests.

## Why

Because we are seeing regular throttling errors from the service operator