### PR TITLE
do not update role annotation unless present

### DIFF
--- a/components/service-operator/controllers/serviceaccount.go
+++ b/components/service-operator/controllers/serviceaccount.go
@@ -183,8 +183,11 @@ func (r *ServiceAccountController) reconcileServiceAccountWithContext(ctx contex
 	if sa.Annotations == nil {
 		sa.Annotations = map[string]string{}
 	}
-	sa.Annotations["eks.amazonaws.com/role-arn"] = principal.Status.AWS.Info[access.IAMRoleArnOutputName]
-
+	arn := principal.Status.AWS.Info[access.IAMRoleArnOutputName]
+	if arn == "" {
+		return fmt.Errorf("role name unavailable")
+	}
+	sa.Annotations["eks.amazonaws.com/role-arn"] = arn
 	return nil
 }
 


### PR DESCRIPTION
## What

there is an edge case where an error in the cloudformation status update
can mark the status as "ready" but have failed to update the info fields
that the service account controller relies on.

It's not obvious if this should be fixed in the status update code, as
the intention of that code is to reflect as much of the cloudformation
state in the resource as possible within each reconciliation loop.

It _is_ clear however that the service account annotation should always
be expected to be present, so if it is blank, then that is an error and
it should fail to reconcile

## Why

There was an incident where the role field was set to the blank state during changes to an IAM role which was not expected to be possible and we would like to avoid this.