### PR TITLE
fix missing fake output for svcop unit tests

### DIFF
--- a/components/service-operator/controllers/suite_test.go
+++ b/components/service-operator/controllers/suite_test.go
@@ -123,7 +123,9 @@ func SetupControllerEnv() (client.Client, func()) {
 			"IAMRoleName":    "testrole",
 		})),
 		controllers.SQSCloudFormationController(newAWSClient(nil)),
-		controllers.PrincipalCloudFormationController(newAWSClient(nil)),
+		controllers.PrincipalCloudFormationController(newAWSClient(map[string]string{
+			"IAMRoleArn": "test-role-arn",
+		})),
 		controllers.PostgresCloudFormationController(newAWSClient(map[string]string{
 			"Endpoint":     "something.local.govsandbox.uk",
 			"ReadEndpoint": "something-ro.local.govsandbox.uk",


### PR DESCRIPTION
follow up from https://github.com/alphagov/gsp/pull/1123 to fix unit
tests with the fake client