### PR TITLE
check-vulnerabilities: Stop whitelisting quay.io

### DIFF
--- a/components/concourse-task-toolbox/bin/findCVEs.py
+++ b/components/concourse-task-toolbox/bin/findCVEs.py
@@ -10,11 +10,20 @@ GLOBAL_IMAGE_WHITELIST = [
     'jaegertracing/all-in-one:1.16', # error in image scan: scan failed: failed to apply layers: unknown OS - no shell, no ls - possibly scratch
     'k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1', # error in image scan: scan failed: failed to apply layers: unknown OS - no shell, no ls - possibly scratch
     'k8s.gcr.io/metrics-server-amd64:v0.3.0', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/calico/typha:v3.8.1', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/coreos/configmap-reload:v0.0.1', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/coreos/prometheus-config-reloader:v0.37.0', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/coreos/prometheus-operator:v0.37.0', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/kiali/kiali:v1.9', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
+    'quay.io/prometheus/node-exporter:v0.18.1', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/prometheus/prometheus:v2.15.2', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/bitnami/sealed-secrets-controller:v0.7.0', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
+    'quay.io/calico/node:v3.8.1', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
+    'quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.1', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
 ]
 GLOBAL_IMAGE_SOURCE_WHITELIST = [
     '.dkr.ecr.eu-west-2.amazonaws.com/', # ECR
     '.dkr.ecr.us-west-2.amazonaws.com/', # ECR - for EKS upstream
-    'quay.io/', # https://github.com/aquasecurity/trivy/issues/401
 ]
 
 # whitelists against vulnerabilities we've considered for various reasons


### PR DESCRIPTION
Instead only whitelist specific images that fail.

This introduces checking on the following things currently running in sandbox:
quay.io/coreos/kube-state-metrics:v1.9.4
quay.io/jetstack/cert-manager-cainjector:v0.11.0
quay.io/jetstack/cert-manager-controller:v0.11.0
quay.io/jetstack/cert-manager-webhook:v0.11.0