### PR TITLE
only fire canary alert if consistant for 15mins

### DIFF
--- a/components/canary/chart/templates/prometheus-rules.yaml
+++ b/components/canary/chart/templates/prometheus-rules.yaml
@@ -15,6 +15,7 @@ spec:
       annotations:
         message: The Canary rotation is overdue. Check in-cluster concourse.
       expr: time() - max(canary_chart_commit_timestamp{namespace="{{ .Release.Namespace }}"}) without (pod) > 600
+      for: 15m
       labels:
         severity: critical
         layer: cicd


### PR DESCRIPTION
we are ignoring the flakes of the canary rotation alert at the moment as
it recovers quickly within 10m, this means we are not paying attension
when something is really wrong.

this reduces the setitivity of the alert so that a single failure should
not fire the alert .