### PR TITLE
check-vulnerabilities: Stop whitelisting some images that just need pulling down first

### DIFF
--- a/components/concourse-task-toolbox/Dockerfile
+++ b/components/concourse-task-toolbox/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --update \
 	mailcap \
 	ncurses \
 	rpm \
+	docker \
 	&& pip3 install awscli s3cmd yq PyYAML kubernetes \
 	&& apk -v --purge del py3-pip \
 	&& rm /var/cache/apk/*

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -1066,6 +1066,7 @@ jobs:
       ACCOUNT_ROLE_ARN: ((account-role-arn))
       AWS_REGION: eu-west-2
       AWS_DEFAULT_REGION: eu-west-2
+    privileged: true
     config:
       platform: linux
       run:
@@ -1084,6 +1085,7 @@ jobs:
               --kubeconfig ./kubeconfig
           echo "done, looking for CVEs"
           export KUBECONFIG=$(pwd)/kubeconfig
+          /usr/bin/dockerd &
           python3 /usr/local/bin/findCVEs.py
 
 - name: destroy


### PR DESCRIPTION
This is to work around trivy being unwilling to work with their seemingly
broken responses, see https://github.com/aquasecurity/trivy/issues/401#issuecomment-611454832

This begins vulnerability checking on the following containers:
quay.io/bitnami/sealed-secrets-controller:v0.7.0
quay.io/calico/node:v3.8.1
quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.1
quay.io/kiali/kiali:v1.9

This involves making the container privileged and running dockerd. This sounds scary so someone should check all the implications of this.