### PR TITLE
bump EKS worker nodes to 1.15

### DIFF
--- a/pipelines/deployer/deployer.defaults.yaml
+++ b/pipelines/deployer/deployer.defaults.yaml
@@ -1,5 +1,5 @@
 eks-version: "1.15"
-worker-eks-version: "1.14"
+worker-eks-version: "1.15"
 
 config-trigger: true
 config-version: "master"


### PR DESCRIPTION
Following on from EKS control plane upgrade to 1.15