### PR TITLE
Revert "check-vulnerabilities: Stop whitelisting some images that jus…

### DIFF
--- a/components/concourse-task-toolbox/Dockerfile
+++ b/components/concourse-task-toolbox/Dockerfile
@@ -20,7 +20,6 @@ RUN apk add --update \
 	mailcap \
 	ncurses \
 	rpm \
-	docker \
 	&& pip3 install awscli s3cmd yq PyYAML kubernetes \
 	&& apk -v --purge del py3-pip \
 	&& rm /var/cache/apk/*

--- a/components/concourse-task-toolbox/bin/findCVEs.py
+++ b/components/concourse-task-toolbox/bin/findCVEs.py
@@ -14,20 +14,16 @@ GLOBAL_IMAGE_WHITELIST = [
     'quay.io/coreos/configmap-reload:v0.0.1', # error in image scan: scan failed: failed to apply layers: unknown OS
     'quay.io/coreos/prometheus-config-reloader:v0.38.1', # error in image scan: scan failed: failed to apply layers: unknown OS
     'quay.io/coreos/prometheus-operator:v0.38.1', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/kiali/kiali:v1.9', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
     'quay.io/prometheus/node-exporter:v0.18.1', # error in image scan: scan failed: failed to apply layers: unknown OS
     'quay.io/prometheus/prometheus:v2.17.2', # error in image scan: scan failed: failed to apply layers: unknown OS
+    'quay.io/bitnami/sealed-secrets-controller:v0.7.0', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
+    'quay.io/calico/node:v3.8.1', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
+    'quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.1', # error in image scan: failed analysis: analyze error: unable to analyze config: json marshal error: unexpected end of JSON input
 ]
 GLOBAL_IMAGE_SOURCE_WHITELIST = [
     '.dkr.ecr.eu-west-2.amazonaws.com/', # ECR
     '.dkr.ecr.us-west-2.amazonaws.com/', # ECR - for EKS upstream
-]
-
-# This is to work around trivy being unwilling to work with their seemingly broken responses, see https://github.com/aquasecurity/trivy/issues/401#issuecomment-611454832
-PULL_FIRST = [
-    'quay.io/bitnami/sealed-secrets-controller:v0.7.0',
-    'quay.io/calico/node:v3.8.1',
-    'quay.io/open-policy-agent/gatekeeper:v3.0.4-beta.1',
-    'quay.io/kiali/kiali:v1.9',
 ]
 
 # whitelists against vulnerabilities we've considered for various reasons
@@ -62,8 +58,6 @@ for pod in client.CoreV1Api().list_pod_for_all_namespaces(watch=False).items:
             continue
         if image_name not in trivy_cache:
             trivy_cache[image_name] = []
-            if image_name in PULL_FIRST:
-                subprocess.check_call(['/usr/bin/docker', 'pull', image_name])
             try:
                 output = subprocess.check_output([
                     'trivy',

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -1066,7 +1066,6 @@ jobs:
       ACCOUNT_ROLE_ARN: ((account-role-arn))
       AWS_REGION: eu-west-2
       AWS_DEFAULT_REGION: eu-west-2
-    privileged: true
     config:
       platform: linux
       run:
@@ -1085,7 +1084,6 @@ jobs:
               --kubeconfig ./kubeconfig
           echo "done, looking for CVEs"
           export KUBECONFIG=$(pwd)/kubeconfig
-          /usr/bin/dockerd &
           python3 /usr/local/bin/findCVEs.py
 
 - name: destroy


### PR DESCRIPTION
…t need pulling down first"

This reverts commit 9931bfc1b275d029efadf067799170dc5024c760.

dockerd doesn't start because:
ERRO[2020-05-11T15:33:01.063878712Z] 'overlay2' is not supported over overlayfs    storage-driver=overlay2
ERRO[2020-05-11T15:33:01.072752664Z] AUFS was not found in /proc/filesystems       storage-driver=aufs
ERRO[2020-05-11T15:33:01.073519646Z] 'overlay' is not supported over overlayfs     storage-driver=overlay

It probably needs some work and that's not prioritised right now.