### PR TITLE
Update the Updating EKS doc

### DIFF
--- a/docs/gds-supported-platform/updating-EKS.md
+++ b/docs/gds-supported-platform/updating-EKS.md
@@ -61,7 +61,7 @@ An [AutoScaling lifecycle hook](https://github.com/alphagov/gsp/tree/master/comp
 helps ensure that instances are drained before retirement as the rolling
 deployment takes place.
 
-* See [PR1134: Bump worker nodes AMI](https://github.com/alphagov/gsp/pull/1134/files) for an example of changing the worker node AMI ID
+* See [PR1134: Bump worker nodes AMI](https://github.com/alphagov/gsp/pull/1134/files) for an example of changing the worker node EKS version.
 
 ## Final touches
 

--- a/docs/gds-supported-platform/updating-EKS.md
+++ b/docs/gds-supported-platform/updating-EKS.md
@@ -61,7 +61,7 @@ An [AutoScaling lifecycle hook](https://github.com/alphagov/gsp/tree/master/comp
 helps ensure that instances are drained before retirement as the rolling
 deployment takes place.
 
-* See [PR207: Bump worker nodes AMI](https://github.com/alphagov/gsp/pull/207/files) for an example of changing the worker node AMI ID
+* See [PR1134: Bump worker nodes AMI](https://github.com/alphagov/gsp/pull/1134/files) for an example of changing the worker node AMI ID
 
 ## Final touches
 


### PR DESCRIPTION

# Why
The existing document provides an example of updating via AWS AMI versioning. We no longer do this but update the worker EKS version inline with the EKS control plane version.

# What
Update the example to reference the current method of updating worker nodes EKS version.
