### PR TITLE
Ignore changes to current running worker counts

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -146,6 +146,13 @@ resource "aws_cloudformation_stack" "worker-nodes-per-az" {
     aws_eks_cluster.eks-cluster,
     aws_cloudformation_stack.worker-nodes,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      parameters["NodeAutoScalingGroupDesiredCapacity"],
+      parameters["NodeAutoScalingGroupMinInstancesInService"],
+    ]
+  }
 }
 
 resource "aws_autoscaling_lifecycle_hook" "worker-nodes-per-az-lifecycle-hook" {


### PR DESCRIPTION
We have seen issues where, during a terraform apply, not all the nodes
will roll. This appeared to be tied to availability zone - all nodes in
an AZ worker group would roll but none of the others would. We're
working on the hypothesis that the trigger is the change in the
"desired" count that is caused by the cluster autoscaler. By ignoring
this value we hope to avoid unnecessary node rolls.