### PR TITLE
Use set_pipeline step instead of concourse-pipeline resource

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -553,11 +553,6 @@ resource_types:
   source:
     repository: ((github-resource-image))
     tag: ((github-resource-tag))
-- name: concourse-pipeline
-  type: docker-image
-  source:
-    repository: concourse/concourse-pipeline-resource
-    tag: "2.2.0"
 - name: s3-iam
   type: docker-image
   source:
@@ -602,13 +597,6 @@ resources:
     repository: ((users-repository))
     access_token: ((github-api-token))
     release: true
-- name: pipeline
-  type: concourse-pipeline
-  source:
-    teams:
-    - name: gsp
-      username: gsp
-      password: ((readonly_local_user_password))
 - name: cluster-state
   type: terraform
   source:
@@ -699,16 +687,12 @@ jobs:
     params:
       ACCOUNT_NAME: ((account-name))
       CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
-  - put: pipeline
-    params:
-      pipelines:
-      - name: ((concourse-pipeline-name))
-        team: ((concourse-team))
-        config_file: platform/pipelines/deployer/deployer.yaml
-        vars_files:
-        - platform/pipelines/deployer/deployer.defaults.yaml
-        - config/((config-path))
-        - trusted-contributors/github.vars.yaml
+  - set_pipeline: ((concourse-pipeline-name))
+    file: platform/pipelines/deployer/deployer.yaml
+    var_files:
+    - platform/pipelines/deployer/deployer.defaults.yaml
+    - config/((config-path))
+    - trusted-contributors/github.vars.yaml
 
 - name: deploy
   serial: true

--- a/pipelines/release/release.yaml
+++ b/pipelines/release/release.yaml
@@ -27,12 +27,6 @@ resource_types:
     repository: "govsvc/concourse-github-resource"
     tag: "gsp-va191b03"
 
-- name: concourse-pipeline
-  type: docker-image
-  source:
-    repository: concourse/concourse-pipeline-resource
-    tag: "2.2.0"
-
 - name: paas-semver
   type: docker-image
   source:
@@ -175,14 +169,6 @@ resources:
     access_token: ((github-api-token))
     release: true
 
-- name: pipeline
-  type: concourse-pipeline
-  source:
-    teams:
-    - name: gsp
-      username: gsp
-      password: ((readonly_local_user_password))
-
 - name: concourse-github-resource
   type: docker-image
   source:
@@ -272,18 +258,14 @@ jobs:
     file: platform/pipelines/tasks/generate-trusted-contributors.yaml
     params:
       CLUSTER_PUBLIC_KEY: ((ci-system-gpg-public))
-  - put: pipeline
-    params:
-      pipelines:
-      - name: ((pipeline-name))
-        team: gsp
-        config_file: platform/pipelines/release/release.yaml
-        vars_files:
-        - trusted-contributors/github.vars.yaml
-        vars:
-          branch: ((branch))
-          pipeline-name: ((pipeline-name))
-          github-release-tag-prefix: ((github-release-tag-prefix))
+  - set_pipeline: ((pipeline-name))
+    file: platform/pipelines/release/release.yaml
+    var_files:
+    - trusted-contributors/github.vars.yaml
+    vars:
+      branch: ((branch))
+      pipeline-name: ((pipeline-name))
+      github-release-tag-prefix: ((github-release-tag-prefix))
 
 - name: build-concourse-task-toolbox
   serial: true


### PR DESCRIPTION
The concourse upgrade to 6.3 has broken the GSP pipelines. Time to move off deprecated things...