### PR TITLE
[untested] work around concourse volume problem in deployer pipeline

### DIFF
--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -37,7 +37,8 @@ unpack_release: &unpack_release
   inputs:
   - name: platform
   outputs:
-  - name: platform
+  - name: platform-unpacked
+    path: platform
 
 generate_cluster_values: &generate_cluster_values
   platform: linux
@@ -96,10 +97,12 @@ generate_managed_namespaces_zones: &generate_managed_namespaces_zones
       echo "generating external dns config for managed namespaces..."
       gomplate -d config=config/${CONFIG_VALUES_PATH} -f platform/templates/managed-namespaces-zones.tf > platform/pipelines/deployer/managed-namespaces-zones.tf
   inputs:
-  - name: platform
+  - name: platform-unpacked-with-hook
+    path: platform
   - name: config
   outputs:
-  - name: platform
+  - name: platform-unpacked-with-hook-and-managed-zones
+    path: platform
 
 generate_managed_namespaces_values: &generate_managed_namespaces_values
   platform: linux
@@ -741,10 +744,12 @@ jobs:
             cp aws-node-lifecycle-hook/aws-node-lifecycle-hook.zip ./platform/modules/k8s-cluster/
           fi
       inputs:
-      - name: platform
+      - name: platform-unpacked
+        path: platform
       - name: aws-node-lifecycle-hook
       outputs:
-      - name: platform
+      - name: platform-unpacked-with-hook
+        path: platform
   - task: scale-autoscaler-down
     image: task-toolbox
     timeout: 40s
@@ -833,7 +838,7 @@ jobs:
   - put: cluster-state
     params:
       env_name: ((account-name))
-      terraform_source: platform/pipelines/deployer
+      terraform_source: platform-unpacked-with-hook-and-managed-zones/pipelines/deployer
       var_files:
       - terraform-var-overrides/overrides.tfvars.json
   - task: generate-user-terraform


### PR DESCRIPTION
I think we've hit a concourse bug when we upgraded from concourse
6.0.0 to 6.3.0.  I've filed concourse/concourse#5799 upstream to
capture this.  In the meantime, I think we can work around this by
forcing each task to use a different volume.

I'm hoping that, by using the `path:` parameter on `output`
configuration blocks, I can leave the actual task steps untouched; I'm
outputting the same directory, but to a different volume.

I don't know how this interacts with `put` steps (in particular, when
we `put: cluster-state`).

Let's merge and see if it fixes things?  It can't break them more than
they are already...