### PR TITLE
concourse-github-resource: Ignore case when sorting lists of approvers

### DIFF
--- a/components/concourse-github-resource/assets/in
+++ b/components/concourse-github-resource/assets/in
@@ -11,7 +11,7 @@ organization=$(jq --raw-output '.source.organization // ""' < ${payload})
 repository=$(jq --raw-output '.source.repository // ""' < ${payload})
 github_api_token=$(jq --raw-output '.source.github_api_token // ""' < ${payload})
 required_approval_count=$(jq --raw-output '(.source.required_approval_count // 0)' < ${payload})
-approvers=$(jq --raw-output '(.source.approvers // [])[]' < ${payload} | sort -d)
+approvers=$(jq --raw-output '(.source.approvers // [])[]' < ${payload} | sort -df)
 
 if [ -z "${organization}" ]; then
   echo "invalid source configuration: missing required 'organization'" >&2
@@ -122,7 +122,7 @@ if [ "${commit_signature_valid_string}" != "true" ] ; then
   exit 1
 fi
 
-approvals=$(echo "${api_response}" | jq --raw-output .data.repository.object.associatedPullRequests.nodes[].reviews.nodes[].author.login | grep -v "${commit_signature_author}" | sort -d)
+approvals=$(echo "${api_response}" | jq --raw-output .data.repository.object.associatedPullRequests.nodes[].reviews.nodes[].author.login | grep -v "${commit_signature_author}" | sort -df)
 echo Approvals: $approvals
 
 


### PR DESCRIPTION
`comm` relies on the input lists being sorted.

GNU coreutils and BusyBox it turns out have different behaviour for `sort -d`.

I believe this was causing certain combinations of approvers to be treated as
invalid.