### PR TITLE
Attempt to improve concourse worker performance

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -733,7 +733,7 @@ concourse:
     emptyDirSize: 60Gi
     resources:
       requests:
-        cpu: 2000m
+        cpu: 3750m
         memory: 12Gi
     env:
     - name: CONCOURSE_GARDEN_DNS_PROXY_ENABLE


### PR DESCRIPTION
This is a hack to attempt to encourage the kube scheduler to put the
concourse worker pods onto otherwise quieter nodes.