### PR TITLE
Add "buddyinfo" collector for the prometheus node exporter

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -276,3 +276,11 @@ prometheus-operator:
     enabled: false
   alertmanager:
     enabled: false
+
+  prometheus-node-exporter:
+    # extraArgs is a manual merge with the upstream chart's values
+    # so may fall out of sync in the future.
+    extraArgs:
+    - --collector.buddyinfo
+    - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+    - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$


### PR DESCRIPTION
To aid with tracking and diagnosing a concourse issue relating to the
allocation of memory it would be easier to be able to see into the kernel's
memory fragmentation over time.