### PR TITLE
task-toolbox: don't purge pip from image

### DIFF
--- a/components/concourse-task-toolbox/Dockerfile
+++ b/components/concourse-task-toolbox/Dockerfile
@@ -21,7 +21,6 @@ RUN apk add --update \
 	ncurses \
 	rpm \
 	&& pip3 install awscli s3cmd yq PyYAML kubernetes \
-	&& apk -v --purge del py3-pip \
 	&& rm /var/cache/apk/*
 
 # install kubeseal


### PR DESCRIPTION
## What

update task-toolbox so that it leaves `pip` in the image.

## Why

purging python pip appears to remove a whole bunch of deps required by other
libraries/scripts so it does not seem sensible to remove it.

This was causing the `aws` cli to fail to execute complaining about missing deps.