### PR TITLE
sealed secrets controller: Use apps/v1 instead of apps/v1beta1

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/sealed-secrets-controller.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/sealed-secrets-controller.yaml
@@ -4,11 +4,14 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-sealed-secrets-controller
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-sealed-secrets-controller
 spec:
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-sealed-secrets-controller
   template:
     metadata:
       labels:


### PR DESCRIPTION
To prepare for EKS 1.16 support.