### PR TITLE
Update AWS VPC CNI and KubeProxy for EKS 1.16

### DIFF
--- a/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/aws-vpc-cni.yaml
@@ -100,7 +100,7 @@ spec:
       tolerations:
         - operator: Exists
       containers:
-        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.1
+        - image: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.6.3
           imagePullPolicy: Always
           ports:
             - containerPort: 61678

--- a/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-proxy.yaml
@@ -37,7 +37,7 @@ spec:
         - /bin/sh
         - -c
         - kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config
-        image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.15.11
+        image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.16.12
         imagePullPolicy: IfNotPresent
         name: kube-proxy
         resources:

--- a/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/calico.yaml
@@ -38,7 +38,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.13.0
+          image: quay.io/calico/node:v3.13.4
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -377,12 +377,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
-  # The CNI plugin needs to get pods, nodes, and namespaces.
+  # The CNI plugin needs to get pods, nodes, configmaps, and namespaces.
   - apiGroups: [""]
     resources:
       - pods
       - nodes
       - namespaces
+      - configmaps
     verbs:
       - get
   - apiGroups: [""]
@@ -553,7 +554,7 @@ spec:
       securityContext:
         fsGroup: 65534
       containers:
-        - image: quay.io/calico/typha:v3.13.0
+        - image: quay.io/calico/typha:v3.13.4
           name: calico-typha
           ports:
             - containerPort: 5473


### PR DESCRIPTION
https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html recommends:
* AWS VPC CNI 1.6.3 (note they've also updated the 1.15 recommendation to this
  as well)
* CoreDNS 1.6.6 (which we have)
* KubeProxy 1.16.12

Don't do this until after https://github.com/alphagov/gsp/pull/1171