### PR TITLE
Remove unwanted prometheus rules

### DIFF
--- a/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
+++ b/charts/gsp-cluster/charts/gsp-monitoring/values.yaml
@@ -4,6 +4,8 @@ prometheus-operator:
       general: false # see templates/rules-general.yaml for replacement
       kubernetesSystem: false # see templates/rules-kubernetes-system.yaml for replacement
       alertmanager: false
+  kubeApiServer:
+    enabled: false
   kubeControllerManager:
     enabled: false
   kubeScheduler:

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -209,6 +209,12 @@ apply_cluster_chart: &apply_cluster_chart
       echo "RELEASE_TAG=${RELEASE_TAG}"
       echo "Removing EKS-provided pod security policy clusterrolebinding (if it exists)"
       kubectl delete --ignore-not-found=true clusterrolebinding eks:podsecuritypolicy:authenticated
+      ### Start of temporary tidyup code ###
+      kubectl delete --ignore-not-found=true --namespace gsp-system servicemonitor gsp-prometheus-operator-apiserver
+      kubectl delete --ignore-not-found=true --namespace gsp-system configmap gsp-prometheus-operator-apiserver
+      kubectl delete --ignore-not-found=true --namespace gsp-system prometheusrule gsp-prometheus-operator-kube-apiserver-slos
+      kubectl delete --ignore-not-found=true --namespace gsp-system prometheusrule gsp-prometheus-operator-kube-apiserver.rules
+      ### End of temporary tidyup code ###
       echo "rendering ${CHART_NAME} chart..."
       mkdir -p manifests
       mkdir -p kube-system-manifests


### PR DESCRIPTION
The kube-apiserver is part of the EKS control plane, so, from a metrics
and alerting point of view we aren't interested. So remove the associated
rules.