### PR TITLE
canary: trigger deploy from timer

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -28,7 +28,7 @@ spec:
       type: time
       icon: update
       source:
-        interval: 2m
+        interval: 4m
 
     - name: src
       type: github
@@ -87,6 +87,8 @@ spec:
       - get: src
         passed: ["build"]
       - get: ecr
+        passed: ["build"]
+      - get: timer
         passed: ["build"]
         trigger: true
 


### PR DESCRIPTION
we are seeing the "build" job run more often than the "deploy" job in
the smoke test pipeline.

Sometimes the "deploy" job waits around for some time (~10mins) before triggering,
resulting in the CanaryOverdue alert firing.

It's not 100% clear why this is happening, and an investigation could be
yak shavey at this point, but as a quick experiement this changes the
job to be triggered on the timer resource rather than the ecr repository
in case the issue is with the check loop of the ecr resource and
increases the interval a little in case the issue is with some kind of
locking while the deploy job is "putting" to the ECR resource (total
guess work).