### PR TITLE
canary: trigger on every version

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -88,8 +88,7 @@ spec:
         passed: ["build"]
       - get: ecr
         passed: ["build"]
-      - get: timer
-        passed: ["build"]
+        version: every
         trigger: true
 
       - task: generate-chart-values


### PR DESCRIPTION
we are still seeing the canary's "deploy" job stall.

try triggering on "every" ECR image built, rather than the latest.