### PR TITLE
concourse: limit retained builds to 500 - 5000

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -771,6 +771,8 @@ concourse:
       enableTeamAuditing: true
       enableWorkerAuditing: true
       enableVolumeAuditing: true
+      defaultBuildLogsToRetain: 500
+      maxBuildLogsToRetain: 5000
   persistence:
     enabled: false
   postgresql:


### PR DESCRIPTION
we see issues in long lived pipelines with large numbers of build logs
retained ... this defaults retained logs to 500 (which can be manually
overriden in pipelines) and caps a max at 5000