### PR TITLE
Lock the engine version of RDS aurora-postgres

### DIFF
--- a/components/service-operator/Makefile
+++ b/components/service-operator/Makefile
@@ -74,7 +74,7 @@ internal/aws/cloudformation/cloudformationfakes/fake_stack.go: internal/aws/clou
 	go generate ./internal/aws/cloudformation
 
 # Build the docker image
-docker-build: test
+docker-build:
 	docker build . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml

--- a/components/service-operator/apis/database/v1beta1/postgres_types.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types.go
@@ -34,6 +34,7 @@ func init() {
 
 const (
 	Engine                       = "aurora-postgresql"
+	EngineVersion                = "10.13"
 	Family                       = "aurora-postgresql10"
 	DefaultClass                 = "db.r5.large"
 	DefaultInstanceCount         = 2
@@ -154,6 +155,7 @@ func (p *Postgres) GetStackTemplate() (*cloudformation.Template, error) {
 
 	template.Resources[PostgresResourceCluster] = &cloudformation.AWSRDSDBCluster{
 		Engine:                      Engine,
+		EngineVersion:               EngineVersion,
 		MasterUsername:              masterUsernameSecretRef,
 		MasterUserPassword:          masterPasswordSecretRef,
 		DBClusterParameterGroupName: cloudformation.Ref(PostgresResourceClusterParameterGroup),
@@ -180,6 +182,7 @@ func (p *Postgres) GetStackTemplate() (*cloudformation.Template, error) {
 			DBClusterIdentifier:     cloudformation.Ref(PostgresResourceCluster),
 			DBInstanceClass:         coalesce(p.Spec.AWS.InstanceType, DefaultClass),
 			Engine:                  Engine,
+			EngineVersion:           EngineVersion,
 			PubliclyAccessible:      false,
 			DBParameterGroupName:    cloudformation.Ref(PostgresResourceParameterGroup),
 			Tags:                    tags,

--- a/components/service-operator/apis/database/v1beta1/postgres_types_test.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types_test.go
@@ -211,6 +211,7 @@ var _ = Describe("Postgres", func() {
 
 			It("should have an RDS cluster resource with sensible defaults", func() {
 				Expect(cluster.Engine).To(Equal("aurora-postgresql"))
+				Expect(cluster.EngineVersion).To(HavePrefix("10"))
 				Expect(cluster.DBClusterParameterGroupName).ToNot(BeEmpty())
 				Expect(cluster.VpcSecurityGroupIds).ToNot(BeNil())
 				Expect(cluster.MasterUsername).ToNot(BeEmpty())
@@ -247,6 +248,7 @@ var _ = Describe("Postgres", func() {
 					Expect(instance.PubliclyAccessible).To(BeFalse())
 					Expect(instance.DBInstanceClass).To(Equal("db.r5.large"))
 					Expect(instance.Engine).To(Equal("aurora-postgresql"))
+					Expect(instance.EngineVersion).To(HavePrefix("10"))
 					Expect(instance.Tags).To(Equal(tags))
 					Expect(instance.DeleteAutomatedBackups).To(Equal(false))
 					Expect(instance.CACertificateIdentifier).To(Equal("rds-ca-2019"))


### PR DESCRIPTION
Without setting the version RDS defaults to "latest", which isn't in line
with our parameter group family, which does lock in the version. So,
explicitly lock the engine version to keep it consistent with the parameter
group.

An alternative would be to expose some sort of parameter through the yaml
and align accordingly, but given the EOL mode of GSP this is the simplest
change that will work.