### PR TITLE
Keep the RDS version consistent with existing RDS instances

### DIFF
--- a/components/service-operator/apis/database/v1beta1/postgres_types.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types.go
@@ -34,7 +34,7 @@ func init() {
 
 const (
 	Engine                       = "aurora-postgresql"
-	EngineVersion                = "10.13"
+	EngineVersion                = "10.11"
 	Family                       = "aurora-postgresql10"
 	DefaultClass                 = "db.r5.large"
 	DefaultInstanceCount         = 2


### PR DESCRIPTION
This will prevent the controller and CloudFormation from trying to replace
existing instances.