### PR TITLE
Remove engine version from RDS cluster

### DIFF
--- a/components/service-operator/apis/database/v1beta1/postgres_types.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types.go
@@ -155,7 +155,6 @@ func (p *Postgres) GetStackTemplate() (*cloudformation.Template, error) {
 
 	template.Resources[PostgresResourceCluster] = &cloudformation.AWSRDSDBCluster{
 		Engine:                      Engine,
-		EngineVersion:               EngineVersion,
 		MasterUsername:              masterUsernameSecretRef,
 		MasterUserPassword:          masterPasswordSecretRef,
 		DBClusterParameterGroupName: cloudformation.Ref(PostgresResourceClusterParameterGroup),

--- a/components/service-operator/apis/database/v1beta1/postgres_types_test.go
+++ b/components/service-operator/apis/database/v1beta1/postgres_types_test.go
@@ -211,7 +211,6 @@ var _ = Describe("Postgres", func() {
 
 			It("should have an RDS cluster resource with sensible defaults", func() {
 				Expect(cluster.Engine).To(Equal("aurora-postgresql"))
-				Expect(cluster.EngineVersion).To(HavePrefix("10"))
 				Expect(cluster.DBClusterParameterGroupName).ToNot(BeEmpty())
 				Expect(cluster.VpcSecurityGroupIds).ToNot(BeNil())
 				Expect(cluster.MasterUsername).ToNot(BeEmpty())


### PR DESCRIPTION
The instances seem to "update" fine, but the "cluster" update keeps failing
so revert the change to the cluster.