### PR TITLE
Allow engine version to be specified and align parameter group family

### DIFF
--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/crd/database.govsvc.uk_postgres.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/crd/database.govsvc.uk_postgres.yaml
@@ -37,6 +37,11 @@ spec:
             aws:
               description: AWS specific subsection of the resource.
               properties:
+                engineVersion:
+                  description: EngineVersion is the version of RDS postgresql to use
+                    (it is only optional to cater for existing databases; this should
+                    be specified on anything new)
+                  type: string
                 instanceCount:
                   description: InstanceCount is the number of database instances in
                     the cluster (defaults to 2 if not set)


### PR DESCRIPTION
The change in "default" AWS aurora postgresql versions is causing
nightmares. So allow a version to be specified in the resource yaml and
ensure the parameter group family is updated accordingly.

bit more context:

This is the continued work from: https://github.com/alphagov/gsp/pull/1183 which is attempting to solve the issues causes by the service-operator not specifying the exact version (resulting in each instance being provisioned with the version that is latest at time of creation).

To make things worse, specifying an EngineVersion in the cloudformation (where previously it was using the default value) still counts as a "change" and requires recreating the instances ... so this is a workaround to avoid that edge case and allow all the existing DBs to stay as they are