### PR TITLE
arbitrary formatting fixes to re-sign some commits

### DIFF
--- a/components/aws-ssm-agent/Dockerfile
+++ b/components/aws-ssm-agent/Dockerfile
@@ -5,4 +5,5 @@ RUN yum update -y && \
     yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
 
 WORKDIR /opt/amazon/ssm/
+
 CMD ["amazon-ssm-agent", "start"]

--- a/components/concourse-operator/README.md
+++ b/components/concourse-operator/README.md
@@ -83,16 +83,19 @@ The operator is deployed as part of https://github.com/alphagov/gsp-ci-system.
 ## Developing
 
 Driven by `make`. To build the docker image:
+
 ```
 make docker-build
 ```
 
 To tag and publish the built docker image:
+
 ```
 make docker-push
 ```
 
 It was originally built using [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) with:
+
 ```
 kubebuilder init --domain k8s.io
 kubebuilder create api --group concourse --version v1beta1 --kind Pipeline


### PR DESCRIPTION
## What

Add fresh signatures for top commits in aws-ssm-agent and concourse-operator components by making arbitrary formatting fixes.

## Why

Because daniel rotated his signing key in github and so the API doesn't consider his signatures valid any more.