### PR TITLE
add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/terraform.tfstate*
 manifests/
 
+local.nix
+
 # ignore vendor dirs
 components/concourse-operator/vendor
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,50 @@
+argsOuter@{...}:
+let
+  # specifying args defaults in this slightly non-standard way to allow us to include the default values in `args`
+  args = rec {
+    pkgs = import <nixpkgs> {};
+    localOverridesPath = ./local.nix;
+  } // argsOuter;
+  ourTerraform = let
+    pkgs = args.pkgs;
+    version = "0.12.12";  # when changing, MUST also update the srcSha256 at the same time
+    srcSha256 = "04qvzbm33ngkbkh45jbcv06c9s1lkgjk39sxvfxw7y6ygxzsrqq5";
+  in if
+    (pkgs.lib.fileContents ./.terraform-version) != version then throw "requested terraform version doesn't match that in .terraform-version. please update it here."
+  else pkgs.terraform_0_12.overrideAttrs (oldAttrs: {
+    name = "terraform-${version}";
+    src = pkgs.fetchFromGitHub {
+      owner = "hashicorp";
+      repo = "terraform";
+      rev = "v${version}";
+      sha256 = srcSha256;
+    };
+  });
+in (with args; {
+
+  gspEnv = (pkgs.stdenv.mkDerivation rec {
+    name = "gsp-env";
+    shortName = "gsp";
+    buildInputs = with pkgs; [
+      gitFull
+      cacert
+      ourTerraform
+
+      kubectl
+      minikube
+      kubernetes-helm
+      open-policy-agent
+      awscli
+
+      # provide gds-cli yourself (perhaps through local.nix?)
+    ];
+
+    LD_LIBRARY_PATH = "${pkgs.stdenv.lib.makeLibraryPath buildInputs}";
+    LANG="en_GB.UTF-8";
+
+    shellHook = ''
+      export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
+    '';
+  }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
+})
+

--- a/local.example.nix
+++ b/local.example.nix
@@ -1,0 +1,22 @@
+# default.nix calls out to the file local.nix if it exists, expecting a function which it will call, applying first
+# the args passed to the original default.nix and then `oldAttrs`, the attrset originally applied to mkDerivation.
+#
+# the function should return an attrset altered to the local user's desires, as they would wish to be applied to
+# mkDerivation to produce the env
+
+args: oldAttrs: oldAttrs // {
+  # here we add some of our favourite packages to the environment which aren't necessarily to everyone's tastes
+  buildInputs = oldAttrs.buildInputs ++ [
+    args.pkgs.vim
+    args.pythonPackages.ipython
+  ];
+
+  shellHook =  oldAttrs.shellHook + ''
+    # PS1 can't be set as a normal derivation attr as it gets clobbered early on in the upstream shellHook script
+    export PS1="⚡$PS1⚡"
+
+    # inject some whimsy into our session - note here we access a package which we don't actually end up
+    # explicitly exposing to the final environment
+    ${args.pkgs.fortune}/bin/fortune
+  '';
+}


### PR DESCRIPTION
This `default.nix` provides an environment with everything (?) needed to work with this repository. It's suggested the user provide `gds-cli` and `fly` through `local.nix` as they are so frequently updated.