### PR TITLE
cd-smoke-test pipeline: merge build & deploy jobs

### DIFF
--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -55,7 +55,7 @@ spec:
         repository: ((canary.ImageRepositoryURI))
 
     jobs:
-    - name: build
+    - name: build-deploy
       serial: true
       plan:
       - get: timer
@@ -80,17 +80,6 @@ spec:
         params:
           image: image/image.tar
           additional_tags: src/.git/short_ref
-
-    - name: deploy
-      serial: true
-      plan:
-      - get: src
-        passed: ["build"]
-      - get: ecr
-        passed: ["build"]
-        version: every
-        trigger: true
-
       - task: generate-chart-values
         config:
           platform: linux


### PR DESCRIPTION
https://trello.com/c/UPQiRxS1

Concourse has an odd quirk that will result in the deploy job occasionally getting delayed by up to half an hour, which causes the canary check to fail. This only seems to happen if we're expecting to be triggered by the finish of a previous job, so just merge these jobs to stop this happening.

Thanks to all for showing me the way here.