### PR TITLE
Bump Concourse chart to app version 6.6.0

### DIFF
--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -718,6 +718,7 @@ fluentd-cloudwatch:
       </label>
 
 concourse:
+  imageTag: 6.6.0
   web:
     nameOverride: concourse-web
     replicas: 2


### PR DESCRIPTION
We can't bump the chart to 14.x as that requires Helm v3.