### PR TITLE
concourse-op: fix unmarshaling of atc.Config from Pipeline resources

### DIFF
--- a/components/concourse-operator/Gopkg.lock
+++ b/components/concourse-operator/Gopkg.lock
@@ -1105,7 +1105,6 @@
     "github.com/onsi/gomega",
     "golang.org/x/net/context",
     "golang.org/x/oauth2",
-    "gopkg.in/yaml.v2",
     "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/errors",
@@ -1136,6 +1135,7 @@
     "sigs.k8s.io/controller-runtime/pkg/webhook/admission/types",
     "sigs.k8s.io/controller-tools/cmd/controller-gen",
     "sigs.k8s.io/testing_frameworks/integration",
+    "sigs.k8s.io/yaml",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/components/concourse-operator/pkg/apis/concourse/v1beta1/pipeline_types.go
+++ b/components/concourse-operator/pkg/apis/concourse/v1beta1/pipeline_types.go
@@ -23,14 +23,22 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+type PipelineConfig struct {
+	atc.Config
+}
+
+func (cfg *PipelineConfig) UnmarshalJSON(data []byte) error {
+	return atc.UnmarshalConfig(data, &cfg.Config)
+}
+
 // PipelineSpec defines the desired state of Pipeline
 type PipelineSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Config         atc.Config `json:"config,omitempty"`
-	PipelineString string     `json:"pipelineString,omitempty"`
-	Paused         bool       `json:"paused,omitempty"`
-	Exposed        bool       `json:"exposed,omitempty"`
+	Config         PipelineConfig `json:"config,omitempty"`
+	PipelineString string         `json:"pipelineString,omitempty"`
+	Paused         bool           `json:"paused,omitempty"`
+	Exposed        bool           `json:"exposed,omitempty"`
 }
 
 // PipelineStatus defines the observed state of Pipeline

--- a/components/concourse-operator/pkg/controller/pipeline/pipeline_controller.go
+++ b/components/concourse-operator/pkg/controller/pipeline/pipeline_controller.go
@@ -23,7 +23,6 @@ import (
 
 	concoursev1beta1 "github.com/alphagov/gsp/components/concourse-operator/pkg/apis/concourse/v1beta1"
 	"github.com/concourse/concourse/go-concourse/concourse"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -129,7 +129,7 @@ func (r *ReconcilePipeline) update(teamName string, instance *concoursev1beta1.P
 	var pipelineYAML []byte
 	var err error
 
-	if len(instance.Spec.Config.Jobs) > 0 {
+	if len(instance.Spec.Config.Config.Jobs) > 0 {
 		pipelineYAML, err = yaml.Marshal(instance.Spec.Config)
 		if err != nil {
 			return err

--- a/components/concourse-operator/pkg/controller/pipeline/pipeline_controller_test.go
+++ b/components/concourse-operator/pkg/controller/pipeline/pipeline_controller_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/concourse/concourse/go-concourse/concourse"
 	fakes "github.com/concourse/concourse/go-concourse/concourse/concoursefakes"
 	"github.com/onsi/gomega"
-	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
 )
 
 const timeout = time.Second * 5
@@ -74,7 +74,9 @@ jobs:
 			Namespace: "xxxx-myteam",
 		},
 		Spec: concoursev1beta1.PipelineSpec{
-			Config: config,
+			Config: concoursev1beta1.PipelineConfig{
+				Config: config,
+			},
 		},
 	}
 

--- a/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
+++ b/components/concourse-operator/pkg/webhook/default_server/pipeline/validating/pipeline_create_update_handler_test.go
@@ -1,80 +1,107 @@
 package validating
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/concourse/concourse/atc"
+	concoursev1beta1 "github.com/alphagov/gsp/components/concourse-operator/pkg/apis/concourse/v1beta1"
+	"sigs.k8s.io/yaml"
 )
 
 type ValidationTestCase struct {
-	Name                      string
-	Pipeline                  string
-	Valid                     bool
-	ValidationMessageContains string
-	HandlerErrorContains      string
+	Name                 string
+	Pipeline             string
+	Allowed              bool
+	Reason               string
+	HandlerErrorContains string
 }
 
 var validationCases = []ValidationTestCase{
 	{
-		Name:  "valid-pipeline-task",
-		Valid: true,
+		Name:    "valid-pipeline-task",
+		Allowed: true,
+		Reason:  "ok",
 		Pipeline: `
-jobs:
-- name: hello
-  plan:
-  - task: say
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source: {repository: busybox}
-      run:
-        path: echo
-        args: [hello world]
+apiVersion: concourse.govsvc.uk/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: pipeline-sample
+spec:
+  config:
+    jobs:
+    - name: hello
+      plan:
+      - task: say
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: busybox}
+          run:
+            path: echo
+            args: [hello world]
 `,
 	},
 
 	{
-		Name:  "using-in_parallel-step",
-		Valid: true,
+		Name:    "using-in_parallel-step",
+		Allowed: true,
+		Reason:  "ok",
 		Pipeline: `
-resources:
-- name: thing1
-  type: docker-image
-- name: thing2
-  type: docker-image
-
-jobs:
-- name: job-with-parallel
-  plan:
-  - in_parallel:
-      limit: 2
-      steps:
-      - get: thing1
-      - get: thing2
+apiVersion: concourse.govsvc.uk/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: pipeline-sample
+spec:
+  config:
+    resources:
+    - name: thing1
+      type: docker-image
+    - name: thing2
+      type: docker-image
+    jobs:
+    - name: job-with-parallel
+      plan:
+      - in_parallel:
+          limit: 2
+          steps:
+          - get: thing1
+          - get: thing2
 `,
 	},
 
 	{
-		Name:                      "non-existant-resource",
-		Valid:                     false,
-		ValidationMessageContains: "jobs.bad-job.plan.do[0].get(non-existant-resource): unknown resource",
+		Name:    "non-existant-resource",
+		Allowed: false,
+		Reason:  "get(non-existant-resource): unknown resource",
 		Pipeline: `
-jobs:
-- name: bad-job
-  plan:
-  - get: non-existant-resource
-  - task: say
-    config:
-      platform: linux
-      image_resource:
-        type: docker-image
-        source: {repository: busybox}
-      run:
-        path: echo
-        args: [hello world]
+apiVersion: concourse.govsvc.uk/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: pipeline-sample
+spec:
+  config:
+    jobs:
+    - name: bad-job
+      plan:
+      - get: non-existant-resource
+      - task: say
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: busybox}
+          run:
+            path: echo
+            args: [hello world]
 `,
 	},
 }
@@ -90,32 +117,20 @@ func TestPipelineValidation(t *testing.T) {
 
 func testPipelineValidation(tc ValidationTestCase) error {
 	h := &PipelineCreateUpdateHandler{}
-	var config atc.Config
-	unmarshalError := atc.UnmarshalConfig([]byte(tc.Pipeline), &config)
+	var pipeline concoursev1beta1.Pipeline
+	unmarshalError := yaml.Unmarshal([]byte(tc.Pipeline), &pipeline)
 	if unmarshalError != nil {
 		return fmt.Errorf("did not expect unmarshalError but got: %v", unmarshalError)
 	}
 
-	valid, validationMessage, handlerError := h.Validate(&config)
-	if handlerError != nil {
-		if tc.HandlerErrorContains == "" {
-			return fmt.Errorf("did not expect handlerError but got: %v", handlerError)
-		}
-		if !strings.Contains(handlerError.Error(), tc.HandlerErrorContains) {
-			return fmt.Errorf("expected handlerError to contain '%v' but got: %v", tc.HandlerErrorContains, handlerError)
-		}
-		return nil
+	res := h.handle(context.Background(), &pipeline)
+	if res.Response.Allowed != tc.Allowed {
+		return fmt.Errorf("expected handler to be allowed='%v' but got allowed='%v' with resaon='%v'", tc.Allowed, res.Response.Allowed, res.Response.Result.Reason)
 	}
-	if validationMessage != "ok" {
-		if tc.ValidationMessageContains == "" {
-			return fmt.Errorf("did not expect validationMessage but got: %v", validationMessage)
+	if !res.Response.Allowed {
+		if !strings.Contains(string(res.Response.Result.Reason), tc.Reason) {
+			return fmt.Errorf("expected failure reason to contain '%v' but got '%v'", tc.Reason, res.Response.Result.Reason)
 		}
-		if !strings.Contains(validationMessage, tc.ValidationMessageContains) {
-			return fmt.Errorf("expected validationMessage to contain '%v' but got: %v", tc.ValidationMessageContains, validationMessage)
-		}
-	}
-	if tc.Valid != valid {
-		return fmt.Errorf("expected valid=%v got: %v", tc.Valid, valid)
 	}
 	return nil
 }


### PR DESCRIPTION
Recent changes in the concourse atc.Config type have caused an
incompatibility between how the k8s apimachinry wants to unmashal the
resource spec into the type and how concourse expects atc.Config to be
unmarshaled.

Essentially previously a simple json.Unmarshal would have populated an
atc.Config correctly, whereas now the dedicated atc.UnmarshalConfig is
the only way to get a reliable decode.

To solve this, I have wrapped the Pipeline.Spec.Config in a type of our
own that implements the json.Unmarshaler interface to catch the decoding
and populate the Config as expected ... this is a bit ugly, but it was
simpler than attempting to catch the decode on the Spec and have to pick
the fields apart.

I may raise a PR upstream to implement Unmarshaler on atc.Config
directly as this seems like the sensible thing to do.

While attempting to reproduce the issue locally I re-jigged the tests a
little so that they work at the Resource level, making it clearer whats
going on.

And to avoid confusion with the different yaml encoding/decoding going
on I have dropped the use of yaml.v2 lib and used the k8s.io/yaml lib
(same one used in the apimachinery)