### PR TITLE
Use a timestamp for the kiam server nodes

### DIFF
--- a/modules/k8s-cluster/main.tf
+++ b/modules/k8s-cluster/main.tf
@@ -183,6 +183,7 @@ resource "aws_cloudformation_stack" "kiam-server-nodes" {
     NodeInstanceType                    = "t3.medium"
     NodeVolumeSize                      = "40"
     BootstrapArguments                  = "--kubelet-extra-args \"--node-labels=node.kubernetes.io/cluster-management --register-with-taints=node.kubernetes.io/cluster-management=:NoSchedule --event-qps=0\""
+    NodeGroupGenerationTimestamp        = var.worker_generation_timestamp
     VpcId                               = var.vpc_id
     Subnets                             = join(",", var.private_subnet_ids)
   }


### PR DESCRIPTION
Like is done for the worker nodes, to facilitate having them replaced
with new machines by updating the timestamp.