### PR TITLE
Provide DockerHub credentials to tenants and various system components

### DIFF
--- a/charts/gsp-cluster/charts/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/charts/gsp-cluster/charts/fluentd-cloudwatch/templates/daemonset.yaml
@@ -40,6 +40,8 @@ spec:
               mountPath: /config-volume
             - name: config
               mountPath: /etc/fluentd
+      imagePullSecrets:
+      - name: dockerhubpull
       containers:
       - name: {{ template "fluentd-cloudwatch.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/gsp-cluster/templates/00-aws-auth/gsp-system-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/gsp-system-namespace.yaml
@@ -11,3 +11,12 @@ metadata:
 {{ if .Values.global.cloudHsm.public }}
     talksToHsm: "true"
 {{ end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerhubpull
+  namespace: gsp-system
+data:
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+type: kubernetes.io/dockerconfigjson

--- a/charts/gsp-cluster/templates/00-aws-auth/gsp-system-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/gsp-system-namespace.yaml
@@ -18,5 +18,5 @@ metadata:
   name: dockerhubpull
   namespace: gsp-system
 data:
-  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials }}
 type: kubernetes.io/dockerconfigjson

--- a/charts/gsp-cluster/templates/00-aws-auth/istio-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/istio-namespace.yaml
@@ -7,3 +7,12 @@ metadata:
     namespace: istio-system
     istio-injection: disabled
     istio: system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerhubpull
+  namespace: istio-system
+data:
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+type: kubernetes.io/dockerconfigjson

--- a/charts/gsp-cluster/templates/00-aws-auth/istio-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/istio-namespace.yaml
@@ -14,5 +14,5 @@ metadata:
   name: dockerhubpull
   namespace: istio-system
 data:
-  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials }}
 type: kubernetes.io/dockerconfigjson

--- a/charts/gsp-cluster/templates/00-aws-auth/kube-system-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-system-namespace.yaml
@@ -8,3 +8,12 @@ metadata:
     istio-injection: disabled
     kube-system: "true"
     control-plane: "true"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerhubpull
+  namespace: kube-system
+data:
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+type: kubernetes.io/dockerconfigjson

--- a/charts/gsp-cluster/templates/00-aws-auth/kube-system-namespace.yaml
+++ b/charts/gsp-cluster/templates/00-aws-auth/kube-system-namespace.yaml
@@ -15,5 +15,5 @@ metadata:
   name: dockerhubpull
   namespace: kube-system
 data:
-  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials }}
 type: kubernetes.io/dockerconfigjson

--- a/charts/gsp-cluster/templates/01-aws-system/aws-ssm-agent-daemonset.yaml
+++ b/charts/gsp-cluster/templates/01-aws-system/aws-ssm-agent-daemonset.yaml
@@ -16,6 +16,8 @@ spec:
         name: ssm-agent
     spec:
       hostNetwork: true
+      imagePullSecrets:
+      - name: dockerhubpull
       containers:
       - image: {{ .Values.AWSSSMAgent.image.repository }}:{{ .Values.AWSSSMAgent.image.tag }}
         name: ssm-agent

--- a/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/pipeline-operator.yaml
@@ -26,6 +26,8 @@ spec:
         control-plane: concourse-operator
         controller-tools.k8s.io: "1.0"
     spec:
+      imagePullSecrets:
+      - name: dockerhubpull
       containers:
       - command:
         - /manager

--- a/charts/gsp-cluster/templates/02-gsp-system/service-operator/deployment.yaml
+++ b/charts/gsp-cluster/templates/02-gsp-system/service-operator/deployment.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         control-plane: {{ .Release.Name }}-service-operator
     spec:
+      imagePullSecrets:
+      - name: dockerhubpull
       containers:
       - command:
         - /manager

--- a/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/external-dns.yaml
@@ -82,6 +82,8 @@ spec:
         runAsUser: 1001
         runAsNonRoot: true
       serviceAccountName: {{ $.Release.Name }}-external-dns
+      imagePullSecrets:
+      - name: dockerhubpull
       containers:
       - name: external-dns
         image: "docker.io/bitnami/external-dns:0.5.18-debian-9-r4"

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -339,3 +339,21 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
     name: system:authenticated
 {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerhubpull
+  namespace: {{ .name }}
+data:
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dockerhubpull-concourse
+  namespace: {{ .name }}
+data:
+  username: {{ .Values.global.dockerHubUsername | b64enc }}
+  password: {{ .Values.global.dockerHubPassword | b64enc }}

--- a/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
+++ b/charts/gsp-cluster/templates/03-namespaces/namespace.yaml
@@ -346,7 +346,7 @@ metadata:
   name: dockerhubpull
   namespace: {{ .name }}
 data:
-  .dockerconfigjson: {{ .Values.global.dockerHubCredentials | b64enc }}
+  .dockerconfigjson: {{ .Values.global.dockerHubCredentials }}
 type: kubernetes.io/dockerconfigjson
 ---
 apiVersion: v1

--- a/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
+++ b/charts/gsp-cluster/templates/04-main-team-pipelines/cd-smoke-test-pipeline.yaml
@@ -15,6 +15,8 @@ spec:
       source:
         repository: ((concourse.task-toolbox-image))
         tag: ((concourse.task-toolbox-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     resource_types:
     - name: github
@@ -22,6 +24,8 @@ spec:
       source:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
+        username: ((dockerhubpull-concourse.username))
+        password: ((dockerhubpull-concourse.password))
 
     resources:
     - name: timer

--- a/charts/gsp-cluster/values.yaml
+++ b/charts/gsp-cluster/values.yaml
@@ -779,6 +779,8 @@ concourse:
   postgresql:
     persistence:
       size: 64Gi
+  imagePullSecrets:
+  - dockerhubpull
 
 pipelineOperator:
   service:

--- a/charts/gsp-istio/values.yaml
+++ b/charts/gsp-istio/values.yaml
@@ -13,6 +13,8 @@ global:
   # disappear. unfortunately the istio helm chart only lets you set
   # priorityClassName for all services at once
   priorityClassName: gsp-critical
+  imagePullSecrets:
+  - dockerhubpull
 
 istio-cni:
   excludeNamespaces:

--- a/hack/lint-terraform-values-output.sh
+++ b/hack/lint-terraform-values-output.sh
@@ -121,6 +121,7 @@ $helm template \
 		| sed 's/${egress_ip_addresses}/[]/' \
 		| sed 's/${eks_version}/1.16/' \
 		| sed 's/${external_dns_map}/externalDns: []/' \
+		| sed 's/${dockerhub_credentials}/DEADBEEF/' \
 	) \
 	--values output/values.yaml \
 	--set 'global.cloudHsm.enabled=true' \

--- a/modules/gsp-cluster/data/values.yaml
+++ b/modules/gsp-cluster/data/values.yaml
@@ -17,6 +17,9 @@ global:
   # move these to gsp-namespace terraform output
   canary:
     verificationKeys: []
+  dockerHubCredentials: ${dockerhub_credentials}
+  dockerHubUsername: ${dockerhub_username}
+  dockerHubPassword: ${dockerhub_password}
 
 adminRoleARNs: ${admin_role_arns}
 devRoleARNs: []

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -41,12 +41,12 @@ data "template_file" "values" {
     cert_manager_role_arn                          = aws_iam_role.cert_manager.arn
     dockerhub_username                             = var.dockerhub_username
     dockerhub_password                             = var.dockerhub_password
-    dockerhub_credentials                          = jsonencode({
+    dockerhub_credentials                          = base64encode(jsonencode({
         "auths" = {
             "https://index.docker.io/v1/" = {
                 "auth" = base64encode(format("%s:%s", var.dockerhub_username, var.dockerhub_password))
             }
         }
-    })
+    }))
   }
 }

--- a/modules/gsp-cluster/values.tf
+++ b/modules/gsp-cluster/values.tf
@@ -39,5 +39,14 @@ data "template_file" "values" {
     grafana_default_admin_password                 = jsonencode(random_password.grafana_default_admin_password.result)
     eks_version                                    = var.eks_version
     cert_manager_role_arn                          = aws_iam_role.cert_manager.arn
+    dockerhub_username                             = var.dockerhub_username
+    dockerhub_password                             = var.dockerhub_password
+    dockerhub_credentials                          = jsonencode({
+        "auths" = {
+            "https://index.docker.io/v1/" = {
+                "auth" = base64encode(format("%s:%s", var.dockerhub_username, var.dockerhub_password))
+            }
+        }
+    })
   }
 }

--- a/modules/gsp-cluster/variables.tf
+++ b/modules/gsp-cluster/variables.tf
@@ -194,3 +194,13 @@ variable "cluster_zone_ids" {
   default     = []
   description = "List of DNS zone IDs associated with the cluster"
 }
+
+variable "dockerhub_username" {
+  default     = ""
+  description = "The username to use when pulling from DockerHub"
+}
+
+variable "dockerhub_password" {
+  default     = ""
+  description = "The password to use when pulling from DockerHub"
+}

--- a/pipelines/deployer/deployer.tf
+++ b/pipelines/deployer/deployer.tf
@@ -98,6 +98,14 @@ variable "cls_destination_arn" {
   type = string
 }
 
+variable "dockerhub_username" {
+  type = string
+}
+
+variable "dockerhub_password" {
+  type = string
+}
+
 data "aws_caller_identity" "current" {
 }
 
@@ -186,6 +194,9 @@ module "gsp-cluster" {
 
   managed_namespaces_zones = local.external-dns-namespace-zones
   cluster_zone_ids         = local.cluster_zone_ids
+
+  dockerhub_username = var.dockerhub_username
+  dockerhub_password = var.dockerhub_password
 }
 
 output "kubeconfig" {

--- a/pipelines/deployer/deployer.yaml
+++ b/pipelines/deployer/deployer.yaml
@@ -636,6 +636,8 @@ resources:
       enable_nlb: ((enable-nlb))
       cls_destination_enabled: ((cls-destination-enabled))
       cls_destination_arn: ((cls-destination-arn))
+      dockerhub_username: ((dockerhub-tenants-username))
+      dockerhub_password: ((dockerhub-tenants-password))
 - name: user-state
   type: terraform
   source:


### PR DESCRIPTION
To avoid rate limiting problems.

These will be different credentials to those used in the release pipeline -
these will be shared with tenants and therefore will not be given any special
push permissions, they will be used for pulling things like Istio containers,
and other public images from DockerHub.

Provide it in the Docker config format for Kubernetes, and a secret with
username and password for use in Concourse.